### PR TITLE
Fix for the service task implementation guide

### DIFF
--- a/docs/guides/getting-started/bpmn/gettingstarted_quickstart.bpmn
+++ b/docs/guides/getting-started/bpmn/gettingstarted_quickstart.bpmn
@@ -1,25 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0o87biy" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
-  <bpmn:process id="camunda-cloud-quick-start" name="Camunda Cloud Quick start" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0o87biy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="camunda-8-quick-start" name="Camunda 8 Quick start" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start Event">
       <bpmn:outgoing>SequenceFlow_1jbw0ni</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="SequenceFlow_1jbw0ni" sourceRef="StartEvent_1" targetRef="Event_0yx0mkt" />
-    <bpmn:endEvent id="Event_0yx0mkt">
+    <bpmn:endEvent id="Event_0yx0mkt" name="End Event">
       <bpmn:incoming>SequenceFlow_1jbw0ni</bpmn:incoming>
     </bpmn:endEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="camunda-cloud-quick-start">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="camunda-8-quick-start">
       <bpmndi:BPMNEdge id="SequenceFlow_1jbw0ni_di" bpmnElement="SequenceFlow_1jbw0ni">
         <di:waypoint x="215" y="121" />
         <di:waypoint x="452" y="121" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="170" y="146" width="55" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0yx0mkt_di" bpmnElement="Event_0yx0mkt">
         <dc:Bounds x="452" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="445" y="146" width="51" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/docs/guides/getting-started/bpmn/gettingstarted_quickstart_advanced.bpmn
+++ b/docs/guides/getting-started/bpmn/gettingstarted_quickstart_advanced.bpmn
@@ -1,12 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?><bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0o87biy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="b72d66c" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0" camunda:diagramRelationId="565f5fc0-a7f4-43ad-9fe5-0a1213312401" xmlns:camunda="http://camunda.org/schema/1.0/bpmn">
-  <bpmn:process id="camunda-cloud-quick-start-advanced" name="Camunda Cloud Quick start" isExecutable="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0o87biy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0" camunda:diagramRelationId="565f5fc0-a7f4-43ad-9fe5-0a1213312401">
+  <bpmn:process id="camunda-8-quick-start-advanced" name="Camunda 8 Quick start" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Start">
       <bpmn:outgoing>Flow_15yg3k5</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_15yg3k5" sourceRef="StartEvent_1" targetRef="Activity_1ihlcws"/>
+    <bpmn:sequenceFlow id="Flow_15yg3k5" sourceRef="StartEvent_1" targetRef="Activity_1ihlcws" />
     <bpmn:serviceTask id="Activity_1ihlcws" name="Ping">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="test-worker" retries="1"/>
+        <zeebe:taskDefinition type="test-worker" retries="1" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_15yg3k5</bpmn:incoming>
       <bpmn:outgoing>Flow_13k1knz</bpmn:outgoing>
@@ -16,7 +17,7 @@
       <bpmn:outgoing>Flow_0qhnfdq</bpmn:outgoing>
       <bpmn:outgoing>Flow_1vlnqoi</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_13k1knz" sourceRef="Activity_1ihlcws" targetRef="Gateway_0lgrw8b"/>
+    <bpmn:sequenceFlow id="Flow_13k1knz" sourceRef="Activity_1ihlcws" targetRef="Gateway_0lgrw8b" />
     <bpmn:endEvent id="Event_0xyif30" name="Pong received">
       <bpmn:incoming>Flow_0qhnfdq</bpmn:incoming>
     </bpmn:endEvent>
@@ -31,56 +32,56 @@
     </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="camunda-cloud-quick-start-advanced">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="camunda-8-quick-start-advanced">
       <bpmndi:BPMNEdge id="Flow_1vlnqoi_di" bpmnElement="Flow_1vlnqoi">
-        <di:waypoint x="490" y="206"/>
-        <di:waypoint x="490" y="270"/>
-        <di:waypoint x="632" y="270"/>
+        <di:waypoint x="490" y="206" />
+        <di:waypoint x="490" y="270" />
+        <di:waypoint x="632" y="270" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="509" y="243" width="22" height="14"/>
+          <dc:Bounds x="509" y="243" width="22" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0qhnfdq_di" bpmnElement="Flow_0qhnfdq">
-        <di:waypoint x="490" y="156"/>
-        <di:waypoint x="490" y="100"/>
-        <di:waypoint x="632" y="100"/>
+        <di:waypoint x="490" y="156" />
+        <di:waypoint x="490" y="100" />
+        <di:waypoint x="632" y="100" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="507" y="113" width="26" height="14"/>
+          <dc:Bounds x="507" y="113" width="26" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_13k1knz_di" bpmnElement="Flow_13k1knz">
-        <di:waypoint x="400" y="181"/>
-        <di:waypoint x="465" y="181"/>
+        <di:waypoint x="400" y="181" />
+        <di:waypoint x="465" y="181" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_15yg3k5_di" bpmnElement="Flow_15yg3k5">
-        <di:waypoint x="215" y="181"/>
-        <di:waypoint x="300" y="181"/>
+        <di:waypoint x="215" y="181" />
+        <di:waypoint x="300" y="181" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="163" width="36" height="36"/>
+        <dc:Bounds x="179" y="163" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="185" y="206" width="24" height="14"/>
+          <dc:Bounds x="185" y="206" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0p5x4dp_di" bpmnElement="Activity_1ihlcws">
-        <dc:Bounds x="300" y="141" width="100" height="80"/>
+        <dc:Bounds x="300" y="141" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0lgrw8b_di" bpmnElement="Gateway_0lgrw8b" isMarkerVisible="true">
-        <dc:Bounds x="465" y="156" width="50" height="50"/>
+        <dc:Bounds x="465" y="156" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="523" y="174" width="34" height="14"/>
+          <dc:Bounds x="523" y="174" width="34" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0xyif30_di" bpmnElement="Event_0xyif30">
-        <dc:Bounds x="632" y="82" width="36" height="36"/>
+        <dc:Bounds x="632" y="82" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="615" y="125" width="71" height="14"/>
+          <dc:Bounds x="615" y="125" width="71" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1gkdyo0_di" bpmnElement="Event_1gkdyo0">
-        <dc:Bounds x="632" y="252" width="36" height="36"/>
+        <dc:Bounds x="632" y="252" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="612" y="295" width="76" height="27"/>
+          <dc:Bounds x="612" y="295" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/docs/guides/getting-started/bpmn/gettingstarted_quickstart_advanced.bpmn
+++ b/docs/guides/getting-started/bpmn/gettingstarted_quickstart_advanced.bpmn
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0o87biy" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+<?xml version="1.0" encoding="UTF-8"?><bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0o87biy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="b72d66c" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0" camunda:diagramRelationId="565f5fc0-a7f4-43ad-9fe5-0a1213312401" xmlns:camunda="http://camunda.org/schema/1.0/bpmn">
   <bpmn:process id="camunda-cloud-quick-start-advanced" name="Camunda Cloud Quick start" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
       <bpmn:outgoing>Flow_15yg3k5</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_15yg3k5" sourceRef="StartEvent_1" targetRef="Activity_1ihlcws" />
+    <bpmn:sequenceFlow id="Flow_15yg3k5" sourceRef="StartEvent_1" targetRef="Activity_1ihlcws"/>
     <bpmn:serviceTask id="Activity_1ihlcws" name="Ping">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="test-worker" retries="1" />
+        <zeebe:taskDefinition type="test-worker" retries="1"/>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_15yg3k5</bpmn:incoming>
       <bpmn:outgoing>Flow_13k1knz</bpmn:outgoing>
@@ -17,63 +16,72 @@
       <bpmn:outgoing>Flow_0qhnfdq</bpmn:outgoing>
       <bpmn:outgoing>Flow_1vlnqoi</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_13k1knz" sourceRef="Activity_1ihlcws" targetRef="Gateway_0lgrw8b" />
-    <bpmn:endEvent id="Event_0xyif30">
+    <bpmn:sequenceFlow id="Flow_13k1knz" sourceRef="Activity_1ihlcws" targetRef="Gateway_0lgrw8b"/>
+    <bpmn:endEvent id="Event_0xyif30" name="Pong received">
       <bpmn:incoming>Flow_0qhnfdq</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0qhnfdq" name="Pong" sourceRef="Gateway_0lgrw8b" targetRef="Event_0xyif30">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=return="Pong"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=variable="Pong"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:endEvent id="Event_1gkdyo0">
+    <bpmn:endEvent id="Event_1gkdyo0" name="Something else received">
       <bpmn:incoming>Flow_1vlnqoi</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1vlnqoi" name="Else" sourceRef="Gateway_0lgrw8b" targetRef="Event_1gkdyo0">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=return!="Pong"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=variable!="Pong"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="camunda-cloud-quick-start-advanced">
-      <bpmndi:BPMNEdge id="Flow_15yg3k5_di" bpmnElement="Flow_15yg3k5">
-        <di:waypoint x="215" y="181" />
-        <di:waypoint x="300" y="181" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_13k1knz_di" bpmnElement="Flow_13k1knz">
-        <di:waypoint x="400" y="181" />
-        <di:waypoint x="465" y="181" />
+      <bpmndi:BPMNEdge id="Flow_1vlnqoi_di" bpmnElement="Flow_1vlnqoi">
+        <di:waypoint x="490" y="206"/>
+        <di:waypoint x="490" y="270"/>
+        <di:waypoint x="632" y="270"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="509" y="243" width="22" height="14"/>
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0qhnfdq_di" bpmnElement="Flow_0qhnfdq">
-        <di:waypoint x="490" y="156" />
-        <di:waypoint x="490" y="100" />
-        <di:waypoint x="632" y="100" />
+        <di:waypoint x="490" y="156"/>
+        <di:waypoint x="490" y="100"/>
+        <di:waypoint x="632" y="100"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="507" y="113" width="26" height="14" />
+          <dc:Bounds x="507" y="113" width="26" height="14"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1vlnqoi_di" bpmnElement="Flow_1vlnqoi">
-        <di:waypoint x="490" y="206" />
-        <di:waypoint x="490" y="270" />
-        <di:waypoint x="632" y="270" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="509" y="243" width="22" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNEdge id="Flow_13k1knz_di" bpmnElement="Flow_13k1knz">
+        <di:waypoint x="400" y="181"/>
+        <di:waypoint x="465" y="181"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15yg3k5_di" bpmnElement="Flow_15yg3k5">
+        <di:waypoint x="215" y="181"/>
+        <di:waypoint x="300" y="181"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="163" width="36" height="36" />
+        <dc:Bounds x="179" y="163" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="206" width="24" height="14"/>
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0p5x4dp_di" bpmnElement="Activity_1ihlcws">
-        <dc:Bounds x="300" y="141" width="100" height="80" />
+        <dc:Bounds x="300" y="141" width="100" height="80"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0lgrw8b_di" bpmnElement="Gateway_0lgrw8b" isMarkerVisible="true">
-        <dc:Bounds x="465" y="156" width="50" height="50" />
+        <dc:Bounds x="465" y="156" width="50" height="50"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="523" y="174" width="34" height="14" />
+          <dc:Bounds x="523" y="174" width="34" height="14"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0xyif30_di" bpmnElement="Event_0xyif30">
-        <dc:Bounds x="632" y="82" width="36" height="36" />
+        <dc:Bounds x="632" y="82" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="615" y="125" width="71" height="14"/>
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1gkdyo0_di" bpmnElement="Event_1gkdyo0">
-        <dc:Bounds x="632" y="252" width="36" height="36" />
+        <dc:Bounds x="632" y="252" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="612" y="295" width="76" height="27"/>
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/docs/guides/getting-started/implement-service-task.md
+++ b/docs/guides/getting-started/implement-service-task.md
@@ -66,7 +66,7 @@ This process includes a service task and an XOR gateway.
 Now, you can connect a worker for the configured service task:
 
 ```bash
-zbctl create worker test-worker --handler "echo {\"return\":\"Pong\"}"
+zbctl create worker test-worker --handler "echo {\"variable\":\"Pong\"}"
 ```
 
 ## Next steps


### PR DESCRIPTION
A user reported a problem in the forum about using the guide in order to implement a service task. It seemed that the expressions of the outgoing sequence flows were broken. 
(See: https://forum.camunda.io/t/platform-8-gettering-started-failed-to-parse-expression-return-pong/37106/2) 

Deployment errors:
`Flow_1vlnqoi > conditionExpressionfailed to parse expression ' return != "Pong"': Expected (ifOp | forOp | quantifiedOp | disjunction):1:2, found "return != "`
and
`Flow_0qhnfdq > conditionExpressionfailed to parse expression ' return = "Pong"': Expected (ifOp | forOp | quantifiedOp | disjunction):1:2, found "return = \""`

I fixed it easily by using another variable name than `return`. I also update the `zbctl` call accordingly and added labels for the start and end events according to our best practices. 

Lmk if something is missing. 
-Thomas 