### PR TITLE
Feedback on backpressure pages

### DIFF
--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -2,6 +2,7 @@
 id: grpc
 title: "Zeebe API (gRPC)"
 description: "Zeebe clients use gRPC to communicate with the cluster."
+keywords: ["backpressure", "back-pressure", "back pressure"]
 ---
 
 [Zeebe](../components/zeebe/zeebe-overview.md) clients use [gRPC](https://grpc.io/) to communicate with the cluster.
@@ -691,12 +692,12 @@ communicate with nodes in the cluster. The nodes in the cluster are called broke
 Technical errors which occur between gateway and brokers (e.g. the gateway cannot deserialize the broker response,
 the broker is unavailable, etc.) are reported to the client using the following error codes:
 
-- `GRPC_STATUS_RESOURCE_EXHAUSTED`: When a broker receives more requests than it can handle, it signals back-pressure and rejects requests with this error code.
+- `GRPC_STATUS_RESOURCE_EXHAUSTED`: When a broker receives more requests than it can handle, it signals backpressure and rejects requests with this error code.
   - In this case, it is possible to retry the requests with an appropriate retry strategy.
   - If you receive many such errors within a short time period, it indicates the broker is constantly under high load.
   - It is recommended to reduce the rate of requests.
-    When back-pressure is active, the broker may reject any request except _CompleteJob_ RPC and _FailJob_ RPC.
-  - These requests are white-listed for back-pressure and are always accepted by the broker even if it is receiving requests above its limits.
+    When backpressure is active, the broker may reject any request except _CompleteJob_ RPC and _FailJob_ RPC.
+  - These requests are white-listed for backpressure and are always accepted by the broker even if it is receiving requests above its limits.
 - `GRPC_STATUS_UNAVAILABLE`: If the gateway itself is in an invalid state (e.g. out of memory).
 - `GRPC_STATUS_INTERNAL`: For any other internal errors that occurred between the gateway and the broker.
 

--- a/docs/apis-clients/java-client/job-worker.md
+++ b/docs/apis-clients/java-client/job-worker.md
@@ -2,6 +2,7 @@
 id: job-worker
 title: "Job worker"
 description: "Let's take a deeper look at job workers to handle jobs."
+keywords: ["backpressure", "back-pressure", "back pressure"]
 ---
 
 ## Related resources

--- a/docs/components/zeebe/technical-concepts/internal-processing.md
+++ b/docs/components/zeebe/technical-concepts/internal-processing.md
@@ -2,6 +2,7 @@
 id: internal-processing
 title: "Internal processing"
 description: "This document analyzes the state machines, events and commands, stateful stream processing, driving the engine, and handling backpressure within Zeebe."
+keywords: [ back-pressure, backpressure ]
 ---
 
 Internally, Zeebe is implemented as a collection of **stream processors** working on record streams \(partitions\). The stream processing model is used since it is a unified approach to provide:
@@ -58,7 +59,7 @@ This command can in turn be processed, completing the service task and driving t
 
 When a broker receives a client request, it is written to the **event stream** first, and processed later by the stream processor. If the processing is slow or if there are many client requests in the stream, it might take too long for the processor to start processing the command. If the broker keeps accepting new requests from the client, the back log increases and the processing latency can grow beyond an acceptable time.
 
-To avoid such problems, Zeebe employs a back-pressure mechanism.
+To avoid such problems, Zeebe employs a [back-pressure](/self-managed/zeebe-deployment/operations/backpressure.md) mechanism.
 When the broker receives more requests than it can process with an acceptable latency, it rejects some requests.
 
 The maximum rate of requests that can be processed by a broker depends on the processing capacity of the machine, the network latency, current load of the system, etc.
@@ -69,3 +70,4 @@ The inflight request count is incremented when a request is accepted, and decrem
 
 When the broker rejects requests due to back-pressure, the clients can retry them with an appropriate retry strategy. If the rejection rate is high, it indicates that the broker is constantly under high load.
 In that case, it is recommended to reduce the request rate.
+

--- a/docs/components/zeebe/technical-concepts/internal-processing.md
+++ b/docs/components/zeebe/technical-concepts/internal-processing.md
@@ -2,7 +2,7 @@
 id: internal-processing
 title: "Internal processing"
 description: "This document analyzes the state machines, events and commands, stateful stream processing, driving the engine, and handling backpressure within Zeebe."
-keywords: [ back-pressure, backpressure ]
+keywords: [ back-pressure, backpressure, back pressure ]
 ---
 
 Internally, Zeebe is implemented as a collection of **stream processors** working on record streams \(partitions\). The stream processing model is used since it is a unified approach to provide:
@@ -55,11 +55,11 @@ As a workflow engine, Zeebe must continuously drive the execution of its process
 For example, when the **Complete Job** command is processed, it does not just complete the job; it also writes the **Complete Activity** command for the corresponding service task.
 This command can in turn be processed, completing the service task and driving the execution of the process instance to the next step.
 
-## Handling back-pressure
+## Handling backpressure
 
 When a broker receives a client request, it is written to the **event stream** first, and processed later by the stream processor. If the processing is slow or if there are many client requests in the stream, it might take too long for the processor to start processing the command. If the broker keeps accepting new requests from the client, the back log increases and the processing latency can grow beyond an acceptable time.
 
-To avoid such problems, Zeebe employs a [back-pressure](/self-managed/zeebe-deployment/operations/backpressure.md) mechanism.
+To avoid such problems, Zeebe employs a [backpressure](/self-managed/zeebe-deployment/operations/backpressure.md) mechanism.
 When the broker receives more requests than it can process with an acceptable latency, it rejects some requests.
 
 The maximum rate of requests that can be processed by a broker depends on the processing capacity of the machine, the network latency, current load of the system, etc.
@@ -68,6 +68,5 @@ Hence, there is no fixed limit configured in Zeebe for the maximum rate of reque
 
 The inflight request count is incremented when a request is accepted, and decremented when a response is sent back to the client. The broker rejects requests when the inflight request count reaches the limit.
 
-When the broker rejects requests due to back-pressure, the clients can retry them with an appropriate retry strategy. If the rejection rate is high, it indicates that the broker is constantly under high load.
+When the broker rejects requests due to backpressure, the clients can retry them with an appropriate retry strategy. If the rejection rate is high, it indicates that the broker is constantly under high load.
 In that case, it is recommended to reduce the request rate.
-

--- a/docs/self-managed/zeebe-deployment/operations/backpressure.md
+++ b/docs/self-managed/zeebe-deployment/operations/backpressure.md
@@ -2,6 +2,7 @@
 id: backpressure
 title: "Backpressure"
 description: "This document outlines an overview of backpressure and its accompanying assets."
+keywords: [ back-pressure, backpressure ]
 ---
 
 When a broker receives a client request, it is written to the **event stream** first (see section [internal processing](/components/zeebe/technical-concepts/internal-processing.md) for details), and processed later by the stream processor.
@@ -100,3 +101,7 @@ If this is the expected workload, you might consider a different configuration f
 ## Potential issues
 
 The rate limiter used by Zeebe to implement backpressure may use `System.nanoTime()` to measure the RTT of requests. In some systems, we've observed consecutive calls to this method can return equal or even decreasing values. [Low clock resolution](https://shipilev.net/blog/2014/nanotrusting-nanotime) and [monotonicity](https://bugs.openjdk.java.net/browse/JDK-6458294) [issues](https://stackoverflow.com/questions/3657289/linux-clock-gettimeclock-monotonic-strange-non-monotonic-behavior) are some of the most likely culprits of this. If this happens, it's recommended to configure the backpressure to use the **fixed** algorithm. Without a clock with sufficient resolution, adaptive backpressure algorithms are not useful.
+
+## Next steps
+
+Looking for more information on backpressure? Check out [this section](/components/zeebe/technical-concepts/internal-processing.md#handling-back-pressure) on internal processing and backpressure.

--- a/docs/self-managed/zeebe-deployment/operations/backpressure.md
+++ b/docs/self-managed/zeebe-deployment/operations/backpressure.md
@@ -2,7 +2,7 @@
 id: backpressure
 title: "Backpressure"
 description: "This document outlines an overview of backpressure and its accompanying assets."
-keywords: [ back-pressure, backpressure ]
+keywords: [ back-pressure, backpressure, back pressure ]
 ---
 
 When a broker receives a client request, it is written to the **event stream** first (see section [internal processing](/components/zeebe/technical-concepts/internal-processing.md) for details), and processed later by the stream processor.

--- a/docs/self-managed/zeebe-deployment/operations/backpressure.md
+++ b/docs/self-managed/zeebe-deployment/operations/backpressure.md
@@ -104,4 +104,4 @@ The rate limiter used by Zeebe to implement backpressure may use `System.nanoTim
 
 ## Next steps
 
-Looking for more information on backpressure? Check out [this section](/components/zeebe/technical-concepts/internal-processing.md#handling-back-pressure) on internal processing and backpressure.
+Looking for more information on backpressure? Check out [this section](/components/zeebe/technical-concepts/internal-processing.md#handling-backpressure) on internal processing and backpressure.

--- a/docs/self-managed/zeebe-deployment/operations/backups.md
+++ b/docs/self-managed/zeebe-deployment/operations/backups.md
@@ -2,6 +2,7 @@
 id: backups
 title: "Backups"
 description: "A guide to creating and installing Zeebe backups."
+keywords: ["backpressure", "back-pressure", "back pressure"]
 ---
 
 As Zeebe fully manages the state of your process instances, consider taking backups of Zeebe data; this is crucial to prevent data loss, roll back application-level errors, and more.

--- a/docs/self-managed/zeebe-deployment/operations/index.md
+++ b/docs/self-managed/zeebe-deployment/operations/index.md
@@ -2,6 +2,7 @@
 id: index
 title: "Operating Zeebe in Production"
 sidebar_label: "Overview"
+keywords: ["backpressure", "back-pressure", "back pressure"]
 ---
 
 This chapter covers topics relevant to anyone who wants to operate Zeebe in production.

--- a/docs/self-managed/zeebe-deployment/operations/metrics.md
+++ b/docs/self-managed/zeebe-deployment/operations/metrics.md
@@ -1,6 +1,7 @@
 ---
 id: metrics
 title: "Metrics"
+keywords: ["backpressure", "back-pressure", "back pressure"]
 ---
 
 When operating a distributed system like Zeebe, it is important to put proper monitoring in place.

--- a/docs/self-managed/zeebe-deployment/operations/resource-planning.md
+++ b/docs/self-managed/zeebe-deployment/operations/resource-planning.md
@@ -1,6 +1,7 @@
 ---
 id: resource-planning
 title: "Resource planning"
+keywords: ["backpressure", "back-pressure", "back pressure"]
 ---
 
 The short answer to “_what resources and configuration will I need to take Zeebe to production?_” is: it depends.
@@ -108,7 +109,7 @@ The following conditions inhibit the automatic deletion of event log segments:
 - The max number of snapshots has not been written. Log segment deletion begin as soon as the max number of snapshots is reached.
 - An exporter does not advance its read position in the event log. In this case, the event log grows ad infinitum.
 
-An event log segment is not deleted until all the events in it are exported by all configured exporters. This means exporters that rely on side effects, perform intensive computation, or experience back pressure from external storage will cause disk usage to grow, as they delay the deletion of event log segments.
+An event log segment is not deleted until all the events in it are exported by all configured exporters. This means exporters that rely on side effects, perform intensive computation, or experience backpressure from external storage will cause disk usage to grow, as they delay the deletion of event log segments.
 
 Exporting is only performed on the partition leader, but the followers of the partition do not delete segments in their replica of the partition until the leader marks all events in it as unneeded by exporters.
 

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -8,6 +8,9 @@ Options -Indexes -MultiViews
 
 # Redirect pages - https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule
 
+RewriteRule ^docs/components/zeebe/technical-concepts/internal-processing/#handling-back-pressure(.*)$ /docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure [R=301,L]
+RewriteRule ^docs/components/zeebe/technical-concepts/internal-processing/#handling-back-pressure$ /docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure [R=301,L]
+
 RewriteRule ^docs/self-managed/optimize-deployment/setup/secure-elasticsearch(.*)$ /docs/self-managed/optimize-deployment/configuration/security-instructions [R=301,L]
 RewriteRule ^docs/self-managed/optimize-deployment/setup/secure-elasticsearch$ /docs/self-managed/optimize-deployment/configuration/security-instructions [R=301,L]
 


### PR DESCRIPTION
Thanks @falko for your feedback! I've added you as a reviewer for this PR. If you have a chance to review that would be great. 

@christinaausley in our docs we use both backpressure and back-pressure. I didn't correct this and instead added keywords to the frontmatter on both pages to handle this spelling. Can you check if this is something that is standardized in the software engineering space to use (or not use!) the hyphen? We should standardize on something, but whatever we decide we should keep the keywords as-is to assist with search.