### PR TITLE
chore(ci): verify prettier formatting in build-docs workflow

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -18,6 +18,8 @@ jobs:
           node-version: 16
       - name: Install Dependencies
         run: npm ci
+      - name: Verify format
+        run: npm run format:check
       - name: Build
         run: npm run build
       - name: Remove https redirect

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -51,6 +51,8 @@ By contributing to this repository, you are also expected to adhere to our commu
 Before submitting your pull request for code review, please ensure your code has met the requirements listed below:
 
 - Is your code formatted according to our [code style guidelines]?
+  - Code format is validated by prettier during the pull-request build workflow.
+  - You can auto-format your code locally by running `npm run format`.
 - Does your writing follow our [Technical Writing Style Guide]?
 - Is your code covered by unit tests?
   - It is the responsibility of contributors to ensure that their contributed code passes automated testing.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@auth0/auth0-react": "^1.9.0",


### PR DESCRIPTION
Adds a step to the build-docs workflow to check prettier formatting. This is a follow-up to #815.

## What it looks like when format is valid (as seen in [this workflow run](https://github.com/camunda/camunda-platform-docs/runs/6231159619))

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/1627089/165980207-62d67bb2-8312-4eed-ab0d-4e443f9e64e2.png">

## What it looks like when format is invalid (as seen in [this workflow run](https://github.com/camunda/camunda-platform-docs/runs/6231238715))

<img width="1128" alt="image" src="https://user-images.githubusercontent.com/1627089/165980960-6c2b26aa-1080-4cb2-8d73-2cb549328fff.png">

### Follow-up work, not included in this PR

- add a git pre-commit hook to auto-format changes (coming soon)
- format remaining folders in the docs (coming later, de-prioritized for now)

