### PR TITLE
Document how to upgrade the old monitoring config

### DIFF
--- a/docs/guides/update-guide/120-to-130.md
+++ b/docs/guides/update-guide/120-to-130.md
@@ -17,6 +17,35 @@ A critical [issue](https://github.com/camunda-cloud/zeebe/issues/8611) which may
 Please refer to the [release notes](https://github.com/camunda-cloud/zeebe/releases/tag/1.3.2) for more.
 :::
 
+With Zeebe 1.3.0, we removed the monitoring specific configuration from the broker and the gateway. Instead, the monitoring configuration is now completely handled via the Spring Boot management server. You can read [this page](https://docs.spring.io/spring-boot/docs/2.6.x/reference/htmlsingle/#actuator) to find out more how to configure the server.
+
+For the broker, this replaces the following configuration settings:
+
+```yaml
+zeebe:
+  broker:
+    network:
+      monitoringApi: # everything in this section
+```
+
+For the gateway, the following was removed:
+
+```yaml
+zeebe:
+  gateway:
+    monitoring: # everything in this section
+```
+
+To configure the monitoring URL for the broker and gateway, you can instead use the `server.port` and `server.host` properties. Unfortunately due to how Spring loads its configuration, it's not possible to configure this directly in the YAML configuration. But you can use environment variables - respectively `SERVER_PORT` and `SERVER_HOST` - or system properties - respectively `-Dserver.port=` or `-Dserver.host=` - to configure them.
+
+To disable monitoring the monitoring server, you can configure the broker or gateway with:
+
+```yaml
+spring:
+  main:
+    web-application-type: none
+```
+
 ### Operate
 
 :::caution

--- a/docs/guides/update-guide/120-to-130.md
+++ b/docs/guides/update-guide/120-to-130.md
@@ -17,7 +17,7 @@ A critical [issue](https://github.com/camunda-cloud/zeebe/issues/8611) which may
 Please refer to the [release notes](https://github.com/camunda-cloud/zeebe/releases/tag/1.3.2) for more.
 :::
 
-With Zeebe 1.3.0, we removed the monitoring specific configuration from the broker and the gateway. Instead, the monitoring configuration is now completely handled via the Spring Boot management server. You can read [this page](https://docs.spring.io/spring-boot/docs/2.6.x/reference/htmlsingle/#actuator) to find out more how to configure the server.
+With Zeebe 1.3.0, we removed the monitoring specific configuration from the broker and the gateway. Instead, the monitoring configuration is now completely handled via the Spring Boot management server. Read [this Spring Boot documentation](https://docs.spring.io/spring-boot/docs/2.6.x/reference/htmlsingle/#actuator) for more information on how to configure the server.
 
 For the broker, this replaces the following configuration settings:
 
@@ -41,9 +41,9 @@ zeebe:
       port: 9600
 ```
 
-To configure the monitoring URL for the broker and gateway, you can instead use the `server.port` and `server.host` properties. Unfortunately due to how Spring loads its configuration, it's not possible to configure this directly in the YAML configuration. But you can use environment variables - respectively `SERVER_PORT` and `SERVER_HOST` - or system properties - respectively `-Dserver.port=` or `-Dserver.host=` - to configure them.
+To configure the monitoring URL for the broker and gateway, you can instead use the `server.port` and `server.host` properties. Given how Spring loads its configuration, it's not possible to configure this directly in the YAML configuration. However, you can use environment variables - respectively `SERVER_PORT` and `SERVER_HOST` - or system properties - respectively `-Dserver.port=` or `-Dserver.host=` - to configure them.
 
-To disable monitoring the monitoring server, you can configure the broker or gateway with:
+To disable monitoring the monitoring server, configure the broker or gateway with the following:
 
 ```yaml
 spring:

--- a/docs/guides/update-guide/120-to-130.md
+++ b/docs/guides/update-guide/120-to-130.md
@@ -25,7 +25,9 @@ For the broker, this replaces the following configuration settings:
 zeebe:
   broker:
     network:
-      monitoringApi: # everything in this section
+      monitoringApi:
+        host: 0.0.0.0
+        port: 9600
 ```
 
 For the gateway, the following was removed:
@@ -33,7 +35,10 @@ For the gateway, the following was removed:
 ```yaml
 zeebe:
   gateway:
-    monitoring: # everything in this section
+    monitoring:
+      enabled: true
+      host: 0.0.0.0
+      port: 9600
 ```
 
 To configure the monitoring URL for the broker and gateway, you can instead use the `server.port` and `server.host` properties. Unfortunately due to how Spring loads its configuration, it's not possible to configure this directly in the YAML configuration. But you can use environment variables - respectively `SERVER_PORT` and `SERVER_HOST` - or system properties - respectively `-Dserver.port=` or `-Dserver.host=` - to configure them.


### PR DESCRIPTION
This PR documents how to upgrade the monitoring configuration from 1.2.x to 1.3.x. It doesn't go in depth into how to configure the Spring server, but instead mostly focuses on what was previously feasible and how to configure it similarly.

closes #861 