### PR TITLE
Add dynamic variable section to Sendgrid

### DIFF
--- a/docs/components/modeler/web-modeler/connectors/available-connectors/sendgrid.md
+++ b/docs/components/modeler/web-modeler/connectors/available-connectors/sendgrid.md
@@ -142,6 +142,18 @@ To make the **SendGrid Email Template Connector** executable, fill out all the m
 
 ![sendgrid email template connector complete properties](../img/connectors-sendgrid-email-template-complete-properties.png)
 
+If you want to provide dynamic content in the email via process variables, you can set them in the **Template Data** field as well:
+
+```text
+= {
+  name: nameVariable,
+  location: locationVariable,
+  weather: weatherVariable,
+  actual-temp: temerature,
+  feel-temp: windChill
+}
+```
+
 :::note
 Now you can simply [deploy and start a new instance](../../save-and-deploy.md) of your process. As with all connectors the run-time is available out of the box in Camunda 8 SaaS.
 :::


### PR DESCRIPTION
The example given only showed using static values for the dynamic template in sendgrid.  With this example users will see how to use process variables as well. Addresses issue #882 