### PR TITLE
chore(deps): remove unused 'color' dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@docusaurus/preset-classic": "2.0.0-beta.15",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
-        "color": "^3.2.1",
         "docusaurus-gtm-plugin": "0.0.2",
         "mixpanel-browser": "^2.43.0",
         "react": "^17.0.2",
@@ -4602,15 +4601,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -4623,15 +4613,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "node_modules/color-string": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/colord": {
       "version": "2.9.2",
@@ -7216,11 +7197,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -11158,14 +11134,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
     },
     "node_modules/sirv": {
       "version": "1.0.19",
@@ -16310,15 +16278,6 @@
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
       "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
     },
-    "color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "requires": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -16331,15 +16290,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "color-string": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "colord": {
       "version": "2.9.2",
@@ -18218,11 +18168,6 @@
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
       }
-    },
-    "is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -21057,14 +21002,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      }
     },
     "sirv": {
       "version": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@docusaurus/preset-classic": "2.0.0-beta.15",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
-    "color": "^3.2.1",
     "docusaurus-gtm-plugin": "0.0.2",
     "mixpanel-browser": "^2.43.0",
     "react": "^17.0.2",


### PR DESCRIPTION
Removes the `color` dependency, which I don't think we are using. 

Causes no obvious regressions when I run the docs locally.

I'm tagging reviewers that might have more context about why it was pulled in, based on my spelunking described below.

## Why did I spend time on this?

I was going through dependabot PRs and saw #768, a major-version bump for the `color` package. I wanted to update it, but I like to know where things are used so I can smoke test them before I merge dependency updates. I didn't find anywhere that `color` was used.

## Why don't I think it is used anywhere?

I searched for `"color"`, `'color'`, `color(`, and `color.`, and saw no significant results. I attempted to search for the whole word `color` but there were too many results to meaningfully identify its usage.

These first two tell me that we never import or require this dependency (as in `import color from "color"`): 
<img width="297" alt="image" src="https://user-images.githubusercontent.com/1627089/167501699-6e945de6-a41f-49c7-8512-db3301264f2d.png">
<img width="294" alt="image" src="https://user-images.githubusercontent.com/1627089/167501712-0ae6c766-3601-41fd-a82e-1fab8469a934.png">

These last two tell me that we never _use_ [the `color` API](https://github.com/Qix-/color/tree/e752c390d4ab3f3659b22ef6cf91333c544cf7b8): 
<img width="383" alt="image" src="https://user-images.githubusercontent.com/1627089/167501736-dfdb6c3b-3127-4cfb-b6a7-b2f94a8a83db.png">
<img width="380" alt="image" src="https://user-images.githubusercontent.com/1627089/167501753-82222009-e84c-48d1-9980-63adf1060a84.png">

I am not sure if there's any other way for docusaurus to magically make use of this dependency, but it appears to me it's not used.

## When did it get pulled in? 

As part of #99 - be warned that that is a very large release, and the github UI slows considerably while trying to navigate it. 

More specifically, in [this commit](https://github.com/camunda/camunda-platform-docs/pull/99/commits/8d4146d48497b210fe0c19d6079f06b79f238317#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), titled "add version 0.25". Be warned that this _also_ is a very large commit, and the github UI slows considerably while trying to navigate it. 

I can't glean any information from that commit about _why_ it was added. I'm tagging @urbanisierung and @akeller for a review because they might have been involved in that work, but I fully expect neither of them to remember a dependency added a year and a half ago.  