### PR TITLE
Document new multi-instance properties for completion condition

### DIFF
--- a/docs/components/modeler/bpmn/multi-instance/multi-instance.md
+++ b/docs/components/modeler/bpmn/multi-instance/multi-instance.md
@@ -99,9 +99,9 @@ The BPMN 2.0 specification defines the following properties of a multi-instance 
 - `numberOfInstances`: The number of instances created.
 - `numberOfActiveInstances`: The number of instances currently active.
 - `numberOfCompletedInstances`: The number of instances already completed.
-- `numberOfTerminatedInstances`: The number of instances already terminated, this will always be `0`.
+- `numberOfTerminatedInstances`: The number of instances already terminated.
 
-These properties are available for use in the `completionCondition` expression (eg. when 50% of the instances have completed, the multi-instance body is completed). Although they are available in this expression, they do not exist as process variables. These properties take precedence over process variables with the same name.
+These properties are available for use in the `completionCondition` expression. For example, using these properties you can express "complete the multi-instance body when 50% or more of the instances already completed" as `= numberOfCompletedInstances / numberOfInstances >= 0.5`. Although these properties are available in this expression, they do not exist as process variables. These properties take precedence over process variables with the same name.
 
 Multiple boolean values or comparisons can be combined as disjunction (`and`) or conjunction (`or`).
 
@@ -118,7 +118,7 @@ For example:
 
 = numberOfCompletedInstances = 2
 
-= numberOfCompletedInstances/numberOfInstances >= 0.5
+= numberOfCompletedInstances / numberOfInstances >= 0.5
 ```
 
 

--- a/docs/components/modeler/bpmn/multi-instance/multi-instance.md
+++ b/docs/components/modeler/bpmn/multi-instance/multi-instance.md
@@ -94,6 +94,14 @@ target: output
 
 A `completionCondition` defines whether the multi-instance body can be completed immediately when the condition is satisfied. It is a [boolean expression](/components/concepts/expressions.md#boolean-expressions) that will be evaluated each time the instance of the multi-instance body completes. Any instances that are still active are terminated and the multi-instance body is completed when the expression evaluates to `true`.
 
+The BPMN 2.0 specification defined the following properties of a multi-instance body instance:
+
+- `numberOfInstances`: the total number of instances created.
+- `numberOfActiveInstances`: the number of currently active instances.
+- `numberOfCompletedInstances`: the number of already completed instances.
+
+These properties are available for use in the `completionCondition` expression. Although they are available in that expression, they do not exist as process variables. These properties take precedence over process variables with the same name.
+
 Multiple boolean values or comparisons can be combined as disjunction (`and`) or conjunction (`or`).
 
 For example:
@@ -108,6 +116,10 @@ For example:
 = orderCount > 15 or totalPrice > 50
 
 = list contains([6,7], today().weekday)
+
+= numberOfCompletedInstances = 2
+
+= numberOfCompletedInstances/numberOfInstances >= 0.5
 ```
 
 

--- a/docs/components/modeler/bpmn/multi-instance/multi-instance.md
+++ b/docs/components/modeler/bpmn/multi-instance/multi-instance.md
@@ -94,13 +94,13 @@ target: output
 
 A `completionCondition` defines whether the multi-instance body can be completed immediately when the condition is satisfied. It is a [boolean expression](/components/concepts/expressions.md#boolean-expressions) that will be evaluated each time the instance of the multi-instance body completes. Any instances that are still active are terminated and the multi-instance body is completed when the expression evaluates to `true`.
 
-The BPMN 2.0 specification defined the following properties of a multi-instance body instance:
+The BPMN 2.0 specification defines the following properties of a multi-instance body instance:
 
-- `numberOfInstances`: the total number of instances created.
-- `numberOfActiveInstances`: the number of currently active instances.
-- `numberOfCompletedInstances`: the number of already completed instances.
+- `numberOfInstances`: The number of instances created.
+- `numberOfActiveInstances`: The number of instances currently active.
+- `numberOfCompletedInstances`: The number of instances already completed.
 
-These properties are available for use in the `completionCondition` expression. Although they are available in that expression, they do not exist as process variables. These properties take precedence over process variables with the same name.
+These properties are available for use in the `completionCondition` expression. Although they are available in this expression, they do not exist as process variables. These properties take precedence over process variables with the same name.
 
 Multiple boolean values or comparisons can be combined as disjunction (`and`) or conjunction (`or`).
 

--- a/docs/components/modeler/bpmn/multi-instance/multi-instance.md
+++ b/docs/components/modeler/bpmn/multi-instance/multi-instance.md
@@ -94,13 +94,14 @@ target: output
 
 A `completionCondition` defines whether the multi-instance body can be completed immediately when the condition is satisfied. It is a [boolean expression](/components/concepts/expressions.md#boolean-expressions) that will be evaluated each time the instance of the multi-instance body completes. Any instances that are still active are terminated and the multi-instance body is completed when the expression evaluates to `true`.
 
-The BPMN 2.0 specification defines the following properties of a multi-instance body instance:
+The BPMN 2.0 specification defines the following properties of a multi-instance body:
 
 - `numberOfInstances`: The number of instances created.
 - `numberOfActiveInstances`: The number of instances currently active.
 - `numberOfCompletedInstances`: The number of instances already completed.
+- `numberOfTerminatedInstances`: The number of instances already terminated, this will always be `0`.
 
-These properties are available for use in the `completionCondition` expression. Although they are available in this expression, they do not exist as process variables. These properties take precedence over process variables with the same name.
+These properties are available for use in the `completionCondition` expression (eg. when 50% of the instances have completed, the multi-instance body is completed). Although they are available in this expression, they do not exist as process variables. These properties take precedence over process variables with the same name.
 
 Multiple boolean values or comparisons can be combined as disjunction (`and`) or conjunction (`or`).
 
@@ -112,8 +113,6 @@ For example:
 = count(["a", "b", "c", "d"]) > 3
 
 = orderCount >= 5 and orderCount < 15
-
-= orderCount > 15 or totalPrice > 50
 
 = list contains([6,7], today().weekday)
 


### PR DESCRIPTION
The BPMN 2.0 specification defines the following properties of a multi-instance body instance:

- `numberOfInstances`: The total number of instances created.
- `numberOfActiveInstances`: The number of instances currently active.
- `numberOfCompletedInstances`: The number of instances already completed.

These properties are available for use in the `completionCondition` expression. 

closes #884 
