### PR TITLE
[DO NOT MERGE] POC - use docusaurus's recommended "next/latest" versioning practice

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,12 +39,6 @@ module.exports = {
         path: "optimize",
         routeBasePath: "optimize",
         sidebarPath: require.resolve("./optimize_sidebars.js"),
-        lastVersion: "current",
-        versions: {
-          current: {
-            label: `latest`,
-          },
-        },
         // ... other options
       },
     ],
@@ -260,16 +254,10 @@ module.exports = {
           editUrl:
             "https://github.com/camunda-cloud/camunda-cloud-documentation/edit/master/",
           // disableVersioning: isVersioningDisabled,
-          lastVersion: "current",
           // onlyIncludeVersions:
           //   !isVersioningDisabled && (isDev || isDeployPreview)
           //     ? ["current", ...versions.slice(0, 2)]
           //     : undefined,
-          versions: {
-            current: {
-              label: `latest`,
-            },
-          },
         },
         blog: false,
         theme: {


### PR DESCRIPTION
This PR will not be merged.

This is a proof of concept on abandoning our current versioning practice of presenting the "latest" version as default and un-numbered, in favor of docusaurus's [recommendation](https://docusaurus.io/docs/versioning#configuring-versioning-behavior) of presenting the last numbered version as default, and the "next" version as unstable. 

## Why?

In relation to #906, this versioning approach would allow us to iteratively work toward moving an entire section of the docs (or multiple sections) into a second docs instance. 

With our current versioning approach, we can't make any changes without affecting a "live" version -- either an older numbered version, or the "latest" version. This means we'd need a very-large-and-long-lived PR to move sections around, to avoid incomplete work prematurely surfacing to users. 

With the approach in this PR, we can make changes against the "next" version iteratively. When a user browses the "current" version, it'll be the most recent numbered version. If they want to poke around the "next" version, they can, but they will see a message that they're not viewing docs for the current version.

## Demo

https://www.loom.com/share/f790432e6d7842cf8859c1552a4769a1

## Some screenshots

When I view the main docs without specifying a version, Docusaurus treats it as if I'm viewing the last tagged version: 

![image](https://user-images.githubusercontent.com/1627089/168851768-4f4af26f-2ebf-4af0-80ab-5a038e3a5e91.png)

In the dropdown, I have an option for "Next":

<img width="195" alt="image" src="https://user-images.githubusercontent.com/1627089/168852127-f42272ea-4c4f-4938-bc4b-18461b6613c7.png">

And after I pick it, I'm viewing the "next" version of the docs, including a message that it's not the current versionhttps://www.loom.com/share/f790432e6d7842cf8859c1552a4769a1:

![image](https://user-images.githubusercontent.com/1627089/168852460-67d15f0d-f700-49a4-89a2-b956c69db3ca.png)
