### PR TITLE
chore: rename branch master to main

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "**"
-      - "!master"
+      - "!main"
     tags-ignore:
       - "*"
 

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -3,7 +3,7 @@ name: publish-stage
 on:
   push:
     branches:
-      - "master"
+      - "main"
     tags-ignore:
       - "*"
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -241,7 +241,7 @@ module.exports = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           editUrl:
-            "https://github.com/camunda-cloud/camunda-cloud-documentation/edit/master/",
+            "https://github.com/camunda/camunda-platform-docs/edit/main/",
           // disableVersioning: isVersioningDisabled,
           lastVersion: "current",
           // onlyIncludeVersions:


### PR DESCRIPTION
Partially addresses #634

The default branch in GitHub has changed from `master` to `main`. This PR updates the few places we have specified the `master` branch. 

(Bonus: the editUrl for docusaurus was incorrect since we moved the docs from the camunda-cloud to camunda org! So I fixed that here, too.)