### PR TITLE
Added content from blog post to migration guide

### DIFF
--- a/docs/guides/migrating-from-camunda-platform-7.md
+++ b/docs/guides/migrating-from-camunda-platform-7.md
@@ -485,18 +485,207 @@ Furthermore, there are changes that might interesting, but legacy behavior can s
 
 ## Prepare for smooth migrations
 
-Whenever you build a process solution using Camunda Platform 7, you can follow these recommendations to create a process solution that will be easier to migrate later on:
+Sometimes you might not be able to use Camunda 8 right away as described in [What to do When You Can’t Quickly Migrate to Camunda 8](https://camunda.com/blog/2022/05/what-to-do-when-you-cant-quickly-migrate-to-camunda-8/). In this case you will keep developing Camunda Platform 7 process solutions, but you should make sure to establish some practices as quickly as possible that will ease migration projects later on.
 
-- Use Java, Maven, and Spring Boot.
-- Separate your business logic from Camunda API.
-- Use external tasks.
-- Stick to basic usage of public API (no engine plugins or extensions).
-- Don't expose Camunda Platform 7 APIs (REST or Java) to front-end applications.
-- Use primitive variable types or JSON payloads only (no XML or serialized Java objects).
-- Use JSONPath on JSON payloads (translates easier to FEEL).
-- Stick to [BPMN elements supported in Camunda Platform 8](/components/modeler/bpmn/bpmn-coverage.md).
-- Use [FEEL as script language in BPMN](https://camunda.github.io/feel-scala/docs/reference/developer-guide/bootstrapping#use-as-script-engine), e.g. on Gateways.
-- Use Camunda Forms.
+In order to implement Camunda Platform 7 process solutions that can be easily migrated, you should stick to the following rules (that are good development practices you should follow anyway):
+
+1.  Implement what we call **Clean Delegates** - concentrate on reading and writing process variables, plus business logic delegation. Data transformations will be mostly done as part of your delegate (and especially not as listeners, as mentioned below). Separate your actual business logic from the delegates and all Camunda APIs. Avoid accessing the BPMN model and invoking Camunda APIs within your delegates.
+2.  Don’t use listeners or Spring beans in expressions to do data transformations via Java code.
+3.  Don’t rely on an ACID transaction manager spanning multiple steps or resources.
+4.  Don’t expose Camunda API (REST or Java) to other services or front-end applications.
+5.  Use primitive variable types or JSON payloads only (no XML or serialized Java objects).
+6.  Use simple expressions or plug-in FEEL. FEEL is the only supported expression language in Camunda 8. JSONPath is also relatively easy to translate to FEEL. Avoid using special variables in expressions, e.g., `execution` or `task`.
+7.  Use your own user interface or Camunda Forms; the other form mechanisms are not supported out-of-the-box in Camunda 8.
+8.  Avoid using any implementation classes from Camunda; generally, those with \*.impl.\* in their package name.
+9.  Avoid using engine plugins.
+
+For the moment, it might also be good to check the [BPMN elements supported in Camunda 8](/docs/components/modeler/bpmn/bpmn-coverage/), but any feature gap will most likely be closed soon.
+
+[Execution Listeners](https://docs.camunda.org/manual/latest/user-guide/process-engine/delegation-code/#execution-listener) and [Task Listeners](https://docs.camunda.org/manual/latest/user-guide/process-engine/delegation-code/#task-listener) are areas in Camunda Platform 8 that are still under discussion. Currently, those use cases need to be solved slightly differently. Depending on your use case, the following Camunda Platform 8 features can be used:
+
+- Input and output mappings using FEEL
+- Tasklist API
+- History API
+- Exporters
+- Client interceptors
+- Gateway interceptors
+- Job workers on user tasks
+
+Expect to soon have a solution in Camunda Platform 8 for most of the problems that listeners solve. Still, it might be good practice to use as few listeners as possible, and especially don’t use them for data mapping as described below.
+
+### Clean Delegates
+
+With Java Delegates and the workflow engine being embedded as a library, projects can do dirty hacks in their code. Casting to implementation classes? No problem. Using a ThreadLocal or trusting a specific transaction manager implementation? Yeah, possible. Calling complex Spring beans hidden behind a simple JUEL (Java unified expression language) expression? Well, you guessed it — doable!
+
+Those hacks are the real show stoppers for migration, as they simply cannot be migrated to Camunda Platform 8. Actually, [Camunda 8 increased isolation intentionally](https://blog.bernd-ruecker.com/moving-from-embedded-to-remote-workflow-engines-8472992cc371).
+
+So you should concentrate on what a Java Delegate is intended to do:
+
+1.  Read variables from the process and potentially manipulate or transform that data to be used by your business logic.
+2.  Delegate to business logic — this is where Java Delegates got their name from. In a perfect world, you would simply issue a call to your business code in another Spring bean or remote service.
+3.  Transform the results of that business logic into variables you write into the process.
+
+Here's an example of a good Java Delegate:
+
+```java
+@Component
+public class CreateCustomerInCrmJavaDelegate implements JavaDelegate {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CrmFacade crmFacade;
+
+    public void execute(DelegateExecution execution) throws Exception {
+        // Data Input Mapping
+        String customerDataJson = (String) execution.getVariable("customerData");
+        CustomerData customerData = objectMapper.readValue(customerDataJson, CustomerData.class);
+
+        // Delegate to business logic
+        String customerId = crmFacade.createCustomer(customerData);
+
+        // Data Output Mapping
+        execution.setVariable("customerId", customerId);
+    }
+}
+```
+
+You should never cast to Camunda implementation classes, use any ThreadLocal object, or influence the transaction manager in any way. Java Delegates should further always be stateless and not store any data in their fields.
+
+The resulting delegate can be easily migrated to a Camunda Platform 8 API, or simply be reused by the [adapter provided in this migration community extension](https://github.com/camunda-community-hub/camunda-7-to-8-migration/).
+
+### No transaction managers
+
+You should not trust ACID [transaction managers](https://blog.bernd-ruecker.com/achieving-consistency-without-transaction-managers-7cb480bd08c) to glue together the workflow engine with your business code. Instead, you need to embrace eventual consistency and make every service task its own transactional step. If you are familiar with Camunda Platform 7 lingo, this means that all BPMN elements will be `async=true`. A process solution that relies on five service tasks to be executed within one ACID transaction, probably rolling back in case of an error, will make migration challenging.
+
+### Don’t expose Camunda API
+
+You should apply the [information hiding principle](https://en.wikipedia.org/wiki/Information_hiding) and not expose too much of the Camunda API to other parts of your application.
+
+In the above example, you should not hand over an execution context to your CrmFacade, which is hopefully intuitive anyway:
+
+```java
+// DO NOT DO THIS!
+crmFacade.createCustomer(execution);
+```
+
+The same holds true for when a new order is placed, and your order fulfillment process should be started. Instead of the front-end calling the Camunda API to start a process instance, you are better off providing your own endpoint to translate between the inbound REST call and Camunda, like for example:
+
+```java
+@RestController
+public class OrderFulfillmentRestController {
+
+  @Autowired
+  private ProcessEngine camunda;
+
+  @RequestMapping(path = "/order", method = PUT)
+  public String placeOrder(String orderPayload, HttpServletResponse response) throws Exception {
+    // TODO: Somehow extract data from orderPayload
+    String orderData = "todo";
+
+    ProcessInstance pi = camunda.getRuntimeService() //
+        .startProcessInstanceByKey("orderFulfillment", //
+            Variables.putValue("order", orderData));
+
+    response.setStatus(HttpServletResponse.SC_ACCEPTED);
+    return "{\"status\":\"pending\"}";
+  }
+}
+```
+
+### Use primitive variable types or JSON
+
+Camunda Platform 7 provides quite flexible ways to add data to your process. For example, you could add Java objects that would be serialized as byte code. Java byte code is brittle and also tied to the Java runtime environment. Another possibility is magically transforming those objects on the fly to XML using Camunda Spin. It turned out this was black magic and led to regular problems, which is why Camunda Platform 8 does not offer this anymore. Instead, you should do any transformation within your code before talking to Camunda API. Camunda Platform 8 only takes JSON as a payload, which automatically includes primitive values.
+
+In the above Java Delegate example, you can see that Jackson was used in the delegate for JSON to Java mapping:
+
+```java
+@Component
+public class CreateCustomerInCrmJavaDelegate implements JavaDelegate {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    //...
+
+    public void execute(DelegateExecution execution) throws Exception {
+        // Data Input Mapping
+        String customerDataJson = (String) execution.getVariable("customerData");
+        CustomerData customerData = objectMapper.readValue(customerDataJson, CustomerData.class);
+        // ...
+    }
+}
+```
+
+This way, you have full control over what is happening, and such code is also easily migratable. And the overall complexity is even lower, as Jackson is quite known to Java people — a kind of de-facto standard with a lot of best practices and recipes available.
+
+### Simple expressions and FEEL
+
+[Camunda 8 uses FEEL as its expression language](https://docs.camunda.io/docs/components/modeler/feel/what-is-feel/). There are big advantages to this decision. Not only are the expression languages between BPMN and DMN harmonized, but also the language is really powerful for typical expressions. One of my favorite examples is the following onboarding demo we regularly show. A decision table will hand back a list of possible risks, whereas every risk has a severity indicator (yellow, red) and a description.
+
+![](https://camunda.com/wp-content/uploads/2022/05/Migrating-to-Camunda-Platform-8-image-1-1024x367.png)
+
+The result of this decision shall be used in the process to make a routing decision:
+
+![](https://camunda.com/wp-content/uploads/2022/05/Migrate-to-Camunda-Platform-8-25052022-image-2-1024x481.png)
+
+To unwrap the DMN result in Camunda Platform 7, you could write some Java code and attach that to a listener when leaving the DMN task (this is already an anti-pattern for migration as you will read next). The code is not super readable:
+
+```java
+@Component
+public class MapDmnResult implements ExecutionListener {
+
+  @Override
+  public void notify(DelegateExecution execution) throws Exception {
+    List<String> risks = new ArrayList<String>();
+    Set<String> riskLevels = new HashSet<String>();
+
+    Object oDMNresult = execution.getVariable("riskDMNresult");
+    for (Object oResult : (List<?>) oDMNresult) {
+      Map<?, ?> result = (Map<?, ?>) oResult;
+      risks.add(result.containsKey("risk") ? (String) result.get("risk") : "");
+      if (result.get("riskLevel") != null) {
+        riskLevels.add(((String) result.get("riskLevel")).toLowerCase());
+      }
+    }
+
+    String accumulatedRiskLevel = "green";
+    if (riskLevels.contains("rot") || riskLevels.contains("red")) {
+      accumulatedRiskLevel = "red";
+    } else if (riskLevels.contains("gelb") || riskLevels.contains("yellow")) {
+      accumulatedRiskLevel = "yellow";
+    }
+
+    execution.setVariable("risks", Variables.objectValue(risks).serializationDataFormat(SerializationDataFormats.JSON).create());
+    execution.setVariable("riskLevel", accumulatedRiskLevel);
+  }
+}
+```
+
+With FEEL, you can evaluate that data structure directly and have an expression on the "red" path:
+
+```
+= some risk in riskLevels satisfies risk = "red"
+```
+
+Isn’t this a great expression? If you think, yes, and you have such use cases, you can even hook in FEEL as the scripting language in Camunda Platform 7 today (as explained by [Scripting with DMN inside BPMN](https://camunda.com/blog/2018/07/dmn-scripting/) or [User Task Assignment based on a DMN Decision Table](https://camunda.com/blog/2020/05/camunda-bpm-user-task-assignment-based-on-a-dmn-decision-table/)).  
+But the more common situation is that you will keep using JUEL in Camunda Platform 7. If you write simple expressions, they can be easily migrated automatically, as you can see in [the test case](https://github.com/camunda-community-hub/camunda-7-to-8-migration/blob/main/modeler-plugin-7-to-8-converter/client/JuelToFeelConverter.test.js) of the [migration community extension](https://github.com/camunda-community-hub/camunda-7-to-8-migration). You should avoid more complex expressions if possible.
+
+Very often, a good workaround to achieve this is to adjust the output mapping of your Java Delegate to prepare data in a form that allows for easy expressions.
+
+You should definitely avoid hooking in Java code during an expression evaluation. The above listener to process the DMN result was one example of this. But a more diabolic example could be the following expression in Camunda Platform 7:
+
+```java
+// DON'T DO THIS:
+#{ dmnResultChecker.check( riskDMNresult ) }
+```
+
+Now, the dmnResultChecker is a Spring bean that can contain arbitrary Java logic, possibly even querying some remote service to query whether we currently accept yellow risks or not (sorry, this is not a good example). Such code can not be executed within Camunda 8 FEEL expressions, and the logic needs to be moved elsewhere.
+
+### Camunda Forms
+
+Finally, while Camunda Platform 7 supports [different types of task forms](https://docs.camunda.org/manual/latest/user-guide/task-forms/), Camunda 8 only supports [Camunda Forms](/docs/guides/utilizing-forms/#configuration) (and will actually be extended over time). If you rely on other form types, you either need to make Camunda Forms out of them or use a bespoke tasklist where you still support those forms.
 
 ## Open issues
 
@@ -523,5 +712,6 @@ In this guide, you hopefully gained a better understanding of what migration fro
 - You need to adjust code that uses the workflow engine API
 - How you might be able to reuse glue code
 - Community extensions that can help with migration
+- The Clean Delegate approach, that will help you writing Camunda Platform 7 solutions that are easier to migrate
 
 We are watching all customer migration projects closely and will update this guide in the future.

--- a/docs/guides/migrating-from-camunda-platform-7.md
+++ b/docs/guides/migrating-from-camunda-platform-7.md
@@ -685,7 +685,7 @@ Now, the dmnResultChecker is a Spring bean that can contain arbitrary Java logic
 
 ### Camunda Forms
 
-Finally, while Camunda Platform 7 supports [different types of task forms](https://docs.camunda.org/manual/latest/user-guide/task-forms/), Camunda 8 only supports [Camunda Forms](/docs/guides/utilizing-forms/#configuration) (and will actually be extended over time). If you rely on other form types, you either need to make Camunda Forms out of them or use a bespoke tasklist where you still support those forms.
+Finally, while Camunda Platform 7 supports [different types of task forms](https://docs.camunda.org/manual/latest/user-guide/task-forms/), Camunda 8 only supports [Camunda Forms](/docs/guides/utilizing-forms/) (and will actually be extended over time). If you rely on other form types, you either need to make Camunda Forms out of them or use a bespoke tasklist where you still support those forms.
 
 ## Open issues
 

--- a/docs/guides/migrating-from-camunda-platform-7.md
+++ b/docs/guides/migrating-from-camunda-platform-7.md
@@ -671,7 +671,7 @@ With FEEL, you can evaluate that data structure directly and have an expression 
 = some risk in riskLevels satisfies risk = "red"
 ```
 
-Additionally, you can even hook in FEEL as the scripting language in Camunda Platform 7 today (as explained by [Scripting with DMN inside BPMN](https://camunda.com/blog/2018/07/dmn-scripting/) or [User Task Assignment based on a DMN Decision Table](https://camunda.com/blog/2020/05/camunda-bpm-user-task-assignment-based-on-a-dmn-decision-table/)).  
+Additionally, you can even hook in FEEL as the scripting language in Camunda Platform 7 today (as explained by [Scripting with DMN inside BPMN](https://camunda.com/blog/2018/07/dmn-scripting/) or [User Task Assignment based on a DMN Decision Table](https://camunda.com/blog/2020/05/camunda-bpm-user-task-assignment-based-on-a-dmn-decision-table/)).
 
 However, more commonly you will keep using JUEL in Camunda Platform 7. If you write simple expressions, they can be easily migrated automatically, as you can see in [the test case](https://github.com/camunda-community-hub/camunda-7-to-8-migration/blob/main/modeler-plugin-7-to-8-converter/client/JuelToFeelConverter.test.js) of the [migration community extension](https://github.com/camunda-community-hub/camunda-7-to-8-migration). You should avoid more complex expressions if possible.
 

--- a/docs/guides/migrating-from-camunda-platform-7.md
+++ b/docs/guides/migrating-from-camunda-platform-7.md
@@ -485,21 +485,21 @@ Furthermore, there are changes that might interesting, but legacy behavior can s
 
 ## Prepare for smooth migrations
 
-Sometimes you might not be able to use Camunda 8 right away as described in [What to do When You Can’t Quickly Migrate to Camunda 8](https://camunda.com/blog/2022/05/what-to-do-when-you-cant-quickly-migrate-to-camunda-8/). In this case you will keep developing Camunda Platform 7 process solutions, but you should make sure to establish some practices as quickly as possible that will ease migration projects later on.
+Sometimes you might not be able to use Camunda 8 right away as described in [What to do When You Can’t Quickly Migrate to Camunda 8](https://camunda.com/blog/2022/05/what-to-do-when-you-cant-quickly-migrate-to-camunda-8/). In this case, you will keep developing Camunda Platform 7 process solutions, but you should establish some practices as quickly as possible to ease migration projects later on.
 
-In order to implement Camunda Platform 7 process solutions that can be easily migrated, you should stick to the following rules (that are good development practices you should follow anyway):
+To implement Camunda Platform 7 process solutions that can be easily migrated, stick to the following rules and development practices:
 
-1.  Implement what we call **Clean Delegates** - concentrate on reading and writing process variables, plus business logic delegation. Data transformations will be mostly done as part of your delegate (and especially not as listeners, as mentioned below). Separate your actual business logic from the delegates and all Camunda APIs. Avoid accessing the BPMN model and invoking Camunda APIs within your delegates.
-2.  Don’t use listeners or Spring beans in expressions to do data transformations via Java code.
-3.  Don’t rely on an ACID transaction manager spanning multiple steps or resources.
-4.  Don’t expose Camunda API (REST or Java) to other services or front-end applications.
-5.  Use primitive variable types or JSON payloads only (no XML or serialized Java objects).
-6.  Use simple expressions or plug-in FEEL. FEEL is the only supported expression language in Camunda 8. JSONPath is also relatively easy to translate to FEEL. Avoid using special variables in expressions, e.g., `execution` or `task`.
-7.  Use your own user interface or Camunda Forms; the other form mechanisms are not supported out-of-the-box in Camunda 8.
-8.  Avoid using any implementation classes from Camunda; generally, those with \*.impl.\* in their package name.
-9.  Avoid using engine plugins.
+1. Implement what we call **Clean Delegates** - concentrate on reading and writing process variables, plus business logic delegation. Data transformations will be mostly done as part of your delegate (and especially not as listeners, as mentioned below). Separate your actual business logic from the delegates and all Camunda APIs. Avoid accessing the BPMN model and invoking Camunda APIs within your delegates.
+2. Don’t use listeners or Spring beans in expressions to do data transformations via Java code.
+3. Don’t rely on an ACID transaction manager spanning multiple steps or resources.
+4. Don’t expose Camunda API (REST or Java) to other services or front-end applications.
+5. Use primitive variable types or JSON payloads only (no XML or serialized Java objects).
+6. Use simple expressions or plug-in FEEL. FEEL is the only supported expression language in Camunda 8. JSONPath is also relatively easy to translate to FEEL. Avoid using special variables in expressions, e.g. `execution` or `task`.
+7. Use your own user interface or Camunda Forms; the other form mechanisms are not supported out-of-the-box in Camunda 8.
+8. Avoid using any implementation classes from Camunda; generally, those with \*.impl.\* in their package name.
+9. Avoid using engine plugins.
 
-For the moment, it might also be good to check the [BPMN elements supported in Camunda 8](/docs/components/modeler/bpmn/bpmn-coverage/), but any feature gap will most likely be closed soon.
+We also recommend reviewing [BPMN elements supported in Camunda 8](/docs/components/modeler/bpmn/bpmn-coverage/), though any feature gap will likely be closed soon.
 
 [Execution Listeners](https://docs.camunda.org/manual/latest/user-guide/process-engine/delegation-code/#execution-listener) and [Task Listeners](https://docs.camunda.org/manual/latest/user-guide/process-engine/delegation-code/#task-listener) are areas in Camunda Platform 8 that are still under discussion. Currently, those use cases need to be solved slightly differently. Depending on your use case, the following Camunda Platform 8 features can be used:
 
@@ -515,15 +515,15 @@ Expect to soon have a solution in Camunda Platform 8 for most of the problems th
 
 ### Clean Delegates
 
-With Java Delegates and the workflow engine being embedded as a library, projects can do dirty hacks in their code. Casting to implementation classes? No problem. Using a ThreadLocal or trusting a specific transaction manager implementation? Yeah, possible. Calling complex Spring beans hidden behind a simple JUEL (Java unified expression language) expression? Well, you guessed it — doable!
+Given Java Delegates and the workflow engine are embedded as a library, projects can do dirty hacks in their code. Casting to implementation classes? No problem. Using a ThreadLocal or trusting a specific transaction manager implementation? Yeah, possible. Calling complex Spring beans hidden behind a simple JUEL (Java Unified Expression Language) expression? Well, you guessed it — doable!
 
-Those hacks are the real show stoppers for migration, as they simply cannot be migrated to Camunda Platform 8. Actually, [Camunda 8 increased isolation intentionally](https://blog.bernd-ruecker.com/moving-from-embedded-to-remote-workflow-engines-8472992cc371).
+Those hacks are the real showstoppers for migration, as they simply cannot be migrated to Camunda Platform 8. In fact, [Camunda 8 increased isolation intentionally](https://blog.bernd-ruecker.com/moving-from-embedded-to-remote-workflow-engines-8472992cc371).
 
-So you should concentrate on what a Java Delegate is intended to do:
+Concentrate on what a Java Delegate is intended to do:
 
-1.  Read variables from the process and potentially manipulate or transform that data to be used by your business logic.
-2.  Delegate to business logic — this is where Java Delegates got their name from. In a perfect world, you would simply issue a call to your business code in another Spring bean or remote service.
-3.  Transform the results of that business logic into variables you write into the process.
+1. Read variables from the process and potentially manipulate or transform that data to be used by your business logic.
+2. Delegate to business logic — this is where Java Delegates got their name from. In a perfect world, you would simply issue a call to your business code in another Spring bean or remote service.
+3. Transform the results of that business logic into variables you write into the process.
 
 Here's an example of a good Java Delegate:
 
@@ -551,7 +551,7 @@ public class CreateCustomerInCrmJavaDelegate implements JavaDelegate {
 }
 ```
 
-You should never cast to Camunda implementation classes, use any ThreadLocal object, or influence the transaction manager in any way. Java Delegates should further always be stateless and not store any data in their fields.
+Never cast to Camunda implementation classes, use any ThreadLocal object, or influence the transaction manager in any way. Java Delegates should further always be stateless and not store any data in their fields.
 
 The resulting delegate can be easily migrated to a Camunda Platform 8 API, or simply be reused by the [adapter provided in this migration community extension](https://github.com/camunda-community-hub/camunda-7-to-8-migration/).
 
@@ -563,14 +563,14 @@ You should not trust ACID [transaction managers](https://blog.bernd-ruecker.com/
 
 You should apply the [information hiding principle](https://en.wikipedia.org/wiki/Information_hiding) and not expose too much of the Camunda API to other parts of your application.
 
-In the above example, you should not hand over an execution context to your CrmFacade, which is hopefully intuitive anyway:
+In the above example, you should not hand over an execution context to your CrmFacade:
 
 ```java
 // DO NOT DO THIS!
 crmFacade.createCustomer(execution);
 ```
 
-The same holds true for when a new order is placed, and your order fulfillment process should be started. Instead of the front-end calling the Camunda API to start a process instance, you are better off providing your own endpoint to translate between the inbound REST call and Camunda, like for example:
+The same holds true when a new order is placed, and your order fulfillment process should be started. Instead of the frontend calling the Camunda API to start a process instance, you are better off providing your own endpoint to translate between the inbound REST call and Camunda, for example:
 
 ```java
 @RestController
@@ -596,7 +596,9 @@ public class OrderFulfillmentRestController {
 
 ### Use primitive variable types or JSON
 
-Camunda Platform 7 provides quite flexible ways to add data to your process. For example, you could add Java objects that would be serialized as byte code. Java byte code is brittle and also tied to the Java runtime environment. Another possibility is magically transforming those objects on the fly to XML using Camunda Spin. It turned out this was black magic and led to regular problems, which is why Camunda Platform 8 does not offer this anymore. Instead, you should do any transformation within your code before talking to Camunda API. Camunda Platform 8 only takes JSON as a payload, which automatically includes primitive values.
+Camunda Platform 7 provides flexible ways to add data to your process. For example, you could add Java objects that would be serialized as byte code. Java byte code is brittle and also tied to the Java runtime environment.
+
+Another possibility is transforming those objects on the fly to XML using Camunda Spin. It turned out this was black magic and led to regular problems, which is why Camunda Platform 8 does not offer this anymore. Instead, you should do any transformation within your code before talking to Camunda API. Camunda Platform 8 only takes JSON as a payload, which automatically includes primitive values.
 
 In the above Java Delegate example, you can see that Jackson was used in the delegate for JSON to Java mapping:
 
@@ -618,17 +620,17 @@ public class CreateCustomerInCrmJavaDelegate implements JavaDelegate {
 }
 ```
 
-This way, you have full control over what is happening, and such code is also easily migratable. And the overall complexity is even lower, as Jackson is quite known to Java people — a kind of de-facto standard with a lot of best practices and recipes available.
+This way, you have full control over what is happening, and such code is also easily migratable. The overall complexity is even lower, as Jackson is quite known to Java people — a kind of de-facto standard with a lot of best practices and recipes available.
 
 ### Simple expressions and FEEL
 
 [Camunda 8 uses FEEL as its expression language](https://docs.camunda.io/docs/components/modeler/feel/what-is-feel/). There are big advantages to this decision. Not only are the expression languages between BPMN and DMN harmonized, but also the language is really powerful for typical expressions. One of my favorite examples is the following onboarding demo we regularly show. A decision table will hand back a list of possible risks, whereas every risk has a severity indicator (yellow, red) and a description.
 
-![](https://camunda.com/wp-content/uploads/2022/05/Migrating-to-Camunda-Platform-8-image-1-1024x367.png)
+![onboarding demo](https://camunda.com/wp-content/uploads/2022/05/Migrating-to-Camunda-Platform-8-image-1-1024x367.png)
 
 The result of this decision shall be used in the process to make a routing decision:
 
-![](https://camunda.com/wp-content/uploads/2022/05/Migrate-to-Camunda-Platform-8-25052022-image-2-1024x481.png)
+![routing decision](https://camunda.com/wp-content/uploads/2022/05/Migrate-to-Camunda-Platform-8-25052022-image-2-1024x481.png)
 
 To unwrap the DMN result in Camunda Platform 7, you could write some Java code and attach that to a listener when leaving the DMN task (this is already an anti-pattern for migration as you will read next). The code is not super readable:
 
@@ -669,19 +671,20 @@ With FEEL, you can evaluate that data structure directly and have an expression 
 = some risk in riskLevels satisfies risk = "red"
 ```
 
-Isn’t this a great expression? If you think, yes, and you have such use cases, you can even hook in FEEL as the scripting language in Camunda Platform 7 today (as explained by [Scripting with DMN inside BPMN](https://camunda.com/blog/2018/07/dmn-scripting/) or [User Task Assignment based on a DMN Decision Table](https://camunda.com/blog/2020/05/camunda-bpm-user-task-assignment-based-on-a-dmn-decision-table/)).  
-But the more common situation is that you will keep using JUEL in Camunda Platform 7. If you write simple expressions, they can be easily migrated automatically, as you can see in [the test case](https://github.com/camunda-community-hub/camunda-7-to-8-migration/blob/main/modeler-plugin-7-to-8-converter/client/JuelToFeelConverter.test.js) of the [migration community extension](https://github.com/camunda-community-hub/camunda-7-to-8-migration). You should avoid more complex expressions if possible.
+Additionally, you can even hook in FEEL as the scripting language in Camunda Platform 7 today (as explained by [Scripting with DMN inside BPMN](https://camunda.com/blog/2018/07/dmn-scripting/) or [User Task Assignment based on a DMN Decision Table](https://camunda.com/blog/2020/05/camunda-bpm-user-task-assignment-based-on-a-dmn-decision-table/)).  
+
+However, more commonly you will keep using JUEL in Camunda Platform 7. If you write simple expressions, they can be easily migrated automatically, as you can see in [the test case](https://github.com/camunda-community-hub/camunda-7-to-8-migration/blob/main/modeler-plugin-7-to-8-converter/client/JuelToFeelConverter.test.js) of the [migration community extension](https://github.com/camunda-community-hub/camunda-7-to-8-migration). You should avoid more complex expressions if possible.
 
 Very often, a good workaround to achieve this is to adjust the output mapping of your Java Delegate to prepare data in a form that allows for easy expressions.
 
-You should definitely avoid hooking in Java code during an expression evaluation. The above listener to process the DMN result was one example of this. But a more diabolic example could be the following expression in Camunda Platform 7:
+Avoid hooking in Java code during an expression evaluation. The above listener to process the DMN result was one example of this, but a more diabolic example could be the following expression in Camunda Platform 7:
 
 ```java
 // DON'T DO THIS:
 #{ dmnResultChecker.check( riskDMNresult ) }
 ```
 
-Now, the dmnResultChecker is a Spring bean that can contain arbitrary Java logic, possibly even querying some remote service to query whether we currently accept yellow risks or not (sorry, this is not a good example). Such code can not be executed within Camunda 8 FEEL expressions, and the logic needs to be moved elsewhere.
+Now, the dmnResultChecker is a Spring bean that can contain arbitrary Java logic, possibly even querying some remote service to query whether we currently accept yellow risks or not. Such code can not be executed within Camunda 8 FEEL expressions, and the logic needs to be moved elsewhere.
 
 ### Camunda Forms
 
@@ -712,6 +715,6 @@ In this guide, you hopefully gained a better understanding of what migration fro
 - You need to adjust code that uses the workflow engine API
 - How you might be able to reuse glue code
 - Community extensions that can help with migration
-- The Clean Delegate approach, that will help you writing Camunda Platform 7 solutions that are easier to migrate
+- The Clean Delegate approach, which helps you write Camunda Platform 7 solutions that are easier to migrate
 
 We are watching all customer migration projects closely and will update this guide in the future.


### PR DESCRIPTION
Added content from https://camunda.com/blog/2022/05/what-to-do-when-you-cant-quickly-migrate-to-camunda-8/ to the migration guide.

Not sure if we need to copy over the images - at the moment I just referred to the one existing on the Camunda blog. Let me know what you think!.