### PR TITLE
removing regions detail from guides content

### DIFF
--- a/docs/guides/assets/react-components/create-cluster.md
+++ b/docs/guides/assets/react-components/create-cluster.md
@@ -4,8 +4,8 @@
 You must create a cluster if you have a new Camunda Platform 8 account.
 
 1. To create a cluster, click the **Clusters** tab, and click **Create New Cluster**.
-2. Name your cluster. For the purpose of this guide, we recommend using the **Stable** channel, the latest generation, and the region closest to you. Click **Create**.
-3. Your cluster will take a few moments to create. Check the satus on the **Clusters** page or by clicking into the cluster itself and looking at the **Applications Overview**.
+2. Name your cluster. For the purpose of this guide, we recommend using the **Stable** channel and the latest generation. Click **Create**.
+3. Your cluster will take a few moments to create. Check the status on the **Clusters** page or by clicking into the cluster itself and looking at the **Applications Overview**.
 
 Even while the cluster shows a status **Creating**, you can still proceed to begin modeling.
 


### PR DESCRIPTION
According to consulting feedback and given selecting a region is not available in trial plans, removing from guides content.