### PR TITLE
docs: improve setup and local development instructions

### DIFF
--- a/howtos/publish-documentation.md
+++ b/howtos/publish-documentation.md
@@ -2,11 +2,11 @@
 
 ## General
 
-Putting the documentation online happens automatically. The source is always `Master`.
+Putting the documentation online happens automatically. The source is always `main`.
 
 ## Staging
 
-Every push to the `master` branch will update the stage environment at https://stage.docs.camunda.io
+Every push to the `main` branch will update the stage environment at https://stage.docs.camunda.io
 
 Technically [this Github Workflow](/.github/workflows/publish-stage.yaml) will be triggered by the Release to build and deploy the docs.
 
@@ -16,7 +16,7 @@ You can observe the progress of the Build under [https://github.com/camunda-clou
 
 ### Steps
 
-1. Make sure that all changes are in the `master` branch
+1. Make sure that all changes are in the `main` branch
 2. Switch to the Releases view: [https://github.com/camunda-cloud/camunda-cloud-documentation/releases](https://github.com/camunda-cloud/camunda-cloud-documentation/releases)
 3. Create a new release using the button _Draft a new release_.
 4. Fill out the form: Tag version (semver: 'x.y.z'), Release title, Description

--- a/howtos/setup.md
+++ b/howtos/setup.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-npm i
+npm install
 ```
 
 ## Local Development
@@ -14,7 +14,16 @@ npm run start
 
 This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
 
+### Troubleshooting checklist
+
+- Have you pulled latest from `main`?
+- Have you run `npm install`? When we update dependencies in the project, they don't automatically update in your environment. You'll need to run `npm install` occasionally to acquire dependency updates locally.
+
 ## Build
+
+It's rare to build the docs locally -- running the dev server with `npm run start` meets most development needs.
+
+Sometimes it can be helpful to see what docusaurus is generating, though:
 
 ```bash
 npm run build
@@ -24,10 +33,4 @@ This command generates static content into the `build` directory and can be serv
 
 ## Deployment
 
-This is just for the record. All deployments have to be done via a new Release.
-
-```bash
-$ GIT_USER=<Your GitHub username> USE_SSH=true npm run deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+Deployments are handled by creating a new Release. See [publish-documentation.md](./publish-documentation.md) for details.


### PR DESCRIPTION
As discussed in person with @akeller, our setup docs for this project are a little vague. This PR expands them with more information about _why_ and _when_ you'll want to do certain things.

It also brings a couple details up to date -- (1) master is now main, and (2) we don't deploy to github pages anymore.