### PR TITLE
improvement(ci): run build-docs CI check for external pull requests

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -11,6 +11,10 @@ on:
 
 jobs:
   build-docs:
+    # For internal PRs, this will run on `push` events;
+    #   for external/forked PRs, it will run on `pull_request` events.
+    #   Ideally we'd have checked this condition when defining the triggers,
+    #   but that's not supported by GitHub actions.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -7,9 +7,11 @@ on:
       - "!main"
     tags-ignore:
       - "*"
+  pull_request:
 
 jobs:
   build-docs:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Addresses [this comment](https://github.com/camunda/camunda-platform-docs/pull/903#issuecomment-1145987703).

PRs from forks were not running our build-docs CI check, because it was triggered only by `push` events. 

This PR...

1. Triggers build-docs for `pull_request` events, too
2. But only if the pull request is coming from a fork, so that we don't run duplicate checks for internal PRs. 

## Does it really matter that we run duplicate checks?

Maybe not -- they'd run concurrently, so it wouldn't slow us down in that regard. But unnecessary compute cycles are unnecessary compute cycles, and it's nice when CI runs exactly when/how we want it to.

## Follow-up work

After this PR is merged, I'll reach out on #903 and ask Tobias to rebase that PR on main. We should then see the build-docs check run on that PR!

## Proof

1. Check this PR itself. It's running a check for `push`, but skipping it for `pull_request`:

![image](https://user-images.githubusercontent.com/1627089/172228728-0cc4b34b-de83-4c60-aef7-25d7ddd53b17.png)

2. Check [this **unforked** PR](https://github.com/camunda/camunda-platform-docs/pull/959), intended to merge into this branch. You can see several things in this screenshot, enumerated below it:

![image](https://user-images.githubusercontent.com/1627089/172229303-89a8d566-f5d5-43f0-8c75-e96c49bdfe6a.png)

* it's a PR from this repo, not a fork
* checks are running each time I push a commit to it (the first one was skipped because I did a rebase for the first two commits together)
* The `push` trigger is running, but the `pull_request` trigger is not.

3. And finally, [this **forked** PR](https://github.com/camunda/camunda-platform-docs/pull/960), also intended to merge into this branch. You can see several things in this screenshot, enumerated below it: 

![image](https://user-images.githubusercontent.com/1627089/172229830-94d1c2a6-0fae-4a19-bfe5-e8f39c182d8c.png)

* it's a PR from a fork (the `pepopowitz:` on the branch name indicates this)
* checks are running each time I push a commit to it
* The `pull_request` trigger is running, but the `push` event doesn't even fire

