### PR TITLE
chore: remove unused mdx-js/react dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@auth0/auth0-react": "^1.10.1",
         "@docusaurus/core": "2.0.0-beta.15",
         "@docusaurus/preset-classic": "2.0.0-beta.15",
-        "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
         "docusaurus-gtm-plugin": "0.0.2",
         "mixpanel-browser": "^2.45.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@auth0/auth0-react": "^1.10.1",
     "@docusaurus/core": "2.0.0-beta.15",
     "@docusaurus/preset-classic": "2.0.0-beta.15",
-    "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
     "docusaurus-gtm-plugin": "0.0.2",
     "mixpanel-browser": "^2.45.0",


### PR DESCRIPTION
While investigating the build failure in #919, I got curious about whether this dependency is even needed. 

I don't think it is, so this PR removes it. 

MDX support [is built into docusaurus](https://6220d0362c028b000827f851--docusaurus-2.netlify.app/docs/2.0.0-beta.15/markdown-features/react), even in the version we're using. I suspect that maybe it initially wasn't, and that's why the dependency [was added early on](https://github.com/camunda/camunda-platform-docs/blame/c13600365b206bf4d5de6e779e249f56063730dc/package.json).

I've tested the site locally, and found that docs that are using MDX render fine without this dependency. For example, the tabs we have throughout the site: 

<img width="1554" alt="image" src="https://user-images.githubusercontent.com/1627089/172253764-c27999b2-424d-4479-b2a3-4844211a93c1.png">


