### PR TITLE
Add a link to the proto file

### DIFF
--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -9,7 +9,7 @@ keywords: ["backpressure", "back-pressure", "back pressure"]
 
 ## Gateway service
 
-The Zeebe client gRPC API is exposed through a single gateway service.
+The Zeebe client gRPC API is exposed through a single gateway service. The current version of the proto file can be found here: [https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto) 
 
 ### `ActivateJobs` RPC
 

--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -9,7 +9,8 @@ keywords: ["backpressure", "back-pressure", "back pressure"]
 
 ## Gateway service
 
-The Zeebe client gRPC API is exposed through a single gateway service. The current version of the proto file can be found here: [https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto) 
+The Zeebe client gRPC API is exposed through a single gateway service. The current version of the proto buffer file can be found 
+in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto) 
 
 ### `ActivateJobs` RPC
 

--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -9,8 +9,7 @@ keywords: ["backpressure", "back-pressure", "back pressure"]
 
 ## Gateway service
 
-The Zeebe client gRPC API is exposed through a single gateway service. The current version of the proto buffer file can be found 
-in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto) 
+The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file can be found in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto).
 
 ### `ActivateJobs` RPC
 


### PR DESCRIPTION
As mentioned in https://forum.camunda.io/t/zeebe-git-examples-unaccessible/38459/5, users may be interested to use the api in other clients as well.