### PR TITLE
Deprecate the contact point property

### DIFF
--- a/docs/guides/update-guide/800-to-810.md
+++ b/docs/guides/update-guide/800-to-810.md
@@ -1,0 +1,26 @@
+---
+id: 800-to-810
+title: Update 8.0 to 8.1
+description: "Review which adjustments must be made to migrate from Camunda Platform 8.0.x to Camunda Platform 8.1.0"
+---
+
+<span class="badge badge--primary">Intermediate</span>
+
+The following sections explain which adjustments must be made to migrate from Camunda Platform 8.0.x to 8.1.0 for each component of the system.
+
+## Server
+
+### Zeebe
+
+No changes are required to update Zeebe 8.0 to 8.1.
+But there are deprecated properties that you should be aware of.
+:::note
+Even if these parameters are deprecated you can still use them because of the backward compatibility of the Zeebe versioning system.
+:::
+Deprecated properties:
+
+- Zeebe Gateway's property `contactPoint`
+  - Remove the usage of `zeebe.gateway.cluster.contactPoint` property.
+  - Use the `zeebe.gateway.cluster.initialContactPoints` property. Note: you can set the list of broker addresses here, to make the start process of the Zeebe Gateway more resilient. Please, refer to [the Zeebe Gateway's configuration](../../../self-managed/zeebe-gateway-deployment/zeebe-gateway/#cluster-configuration) guide for detail.
+  - Remove the usage of `ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT` environment variable.
+  - Use the `ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS` environment variable. Note: you can set the list of broker addresses here, to make the start process of the Zeebe Gateway more resilient. Please, refer to [the Zeebe Gateway's configuration](../../../self-managed/zeebe-gateway-deployment/zeebe-gateway/#cluster-configuration) guide for detail.

--- a/docs/guides/update-guide/800-to-810.md
+++ b/docs/guides/update-guide/800-to-810.md
@@ -20,7 +20,5 @@ Even if these parameters are deprecated you can still use them because of the ba
 Deprecated properties:
 
 - Zeebe Gateway's property `contactPoint`
-  - Remove the usage of `zeebe.gateway.cluster.contactPoint` property.
-  - Use the `zeebe.gateway.cluster.initialContactPoints` property. Note: you can set the list of broker addresses here, to make the start process of the Zeebe Gateway more resilient. Please, refer to [the Zeebe Gateway's configuration](../../../self-managed/zeebe-gateway-deployment/zeebe-gateway/#cluster-configuration) guide for detail.
-  - Remove the usage of `ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT` environment variable.
-  - Use the `ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS` environment variable. Note: you can set the list of broker addresses here, to make the start process of the Zeebe Gateway more resilient. Please, refer to [the Zeebe Gateway's configuration](../../../self-managed/zeebe-gateway-deployment/zeebe-gateway/#cluster-configuration) guide for detail.
+  - Remove the usage of `zeebe.gateway.cluster.contactPoint` property or the `ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT` environment variable.
+  - Use the `zeebe.gateway.cluster.initialContactPoints` property or the `ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS` environment variable. Note: you can set the list of broker addresses here, to make the start process of the Zeebe Gateway more resilient. Please, refer to [the Zeebe Gateway's configuration](../../../self-managed/zeebe-gateway-deployment/zeebe-gateway/#cluster-configuration) guide for detail.

--- a/docs/guides/update-guide/introduction.md
+++ b/docs/guides/update-guide/introduction.md
@@ -12,6 +12,13 @@ Versions prior to Camunda Platform 8 are listed below and identified as Camunda 
 
 There is a dedicated update guide for each version:
 
+### [Camunda Platform 8.0 to Camunda Platform 8.1](../800-to-810)
+
+Update from 8.0.x to 8.1.0
+
+[//]: # "TODO: As soon as the release will be created[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.0)"
+[//]: # "TODO: As soon as the release will be created[Release blog](https://camunda.com/blog/)"
+
 ### [Camunda Cloud 1.3 to Camunda Platform 8.0](../130-to-800)
 
 Update from 1.3.x to 8.0.0

--- a/docs/self-managed/zeebe-deployment/operations/network-ports.md
+++ b/docs/self-managed/zeebe-deployment/operations/network-ports.md
@@ -7,7 +7,11 @@ The broker cluster sits behind the gRPC Gateway, which handles all requests from
 
 ## Gateway
 
-The gateway needs to receive communication via `zeebe.gateway.network.port: 26500` from clients/workers, and `zeebe.gateway.cluster.contactPoint: 127.0.0.1:26502` from brokers.
+The gateway needs to receive communication via `zeebe.gateway.network.port: 26500` from clients/workers, and `zeebe.gateway.cluster.initialContactPoints: [127.0.0.1:26502]` from brokers.
+
+:::note
+You can use all broker connections instead of one to make the startup process of the Zeebe Gateway more resilient.
+:::
 
 The relevant [configuration](../configuration/configuration.md) settings are:
 
@@ -18,12 +22,12 @@ Config file
         network:
           port: 26500
         cluster:
-          contactPoint: 127.0.0.1:26502
+          initialContactPoints: [127.0.0.1:26502]
 
 
 Environment Variables
   ZEEBE_GATEWAY_CLUSTER_NETWORK_PORT = 26500
-  ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT = 127.0.0.1:26502
+  ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS = 127.0.0.1:26502
 ```
 
 ## Broker

--- a/docs/self-managed/zeebe-gateway-deployment/the-zeebe-gateway.md
+++ b/docs/self-managed/zeebe-gateway-deployment/the-zeebe-gateway.md
@@ -75,20 +75,20 @@ The network configuration allows configuration of the host and port details for 
 
 As mentioned, the gateway needs to connect to the Zeebe brokers.
 
-It is important to configure the cluster contact point to one of the Zeebe brokers. Be aware that the gateway currently doesn’t support a list of contact points. The contact point needs to be available to the gateway. With the help of the SWIM protocol, the gateway will find the other broker nodes (if there are any). The corresponding environment variable is called `ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT`.
+It is important to configure the cluster's initial contact point to the Zeebe brokers. You may set only one of the Zeebe brokers, but keep in mind that resiliency will be lower than using all the Zeebe brokers available. The corresponding environment variable is called `ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS`.
 
 It is necessary to use the same cluster name for the broker and gateway. Otherwise, a connection will not be possible. The related configuration property is `zeebe.gateway.cluster.clusterName` and as an environment variable, it is called `ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME`.
 
 If you use the Helm charts, both properties are configured for you already.
 
-| Environment variable                   | Application.yaml property              | Description                                                                                                           | Default value     |
-| -------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT`   | `zeebe.gateway.cluster.contactPoint`   | Sets the broker the gateway should initial contact.                                                                   | `127.0.0.1:26502` |
-| `ZEEBE_GATEWAY_CLUSTER_REQUESTTIMEOUT` | `zeebe.gateway.cluster.requestTimeout` | Sets the timeout of requests sent to the broker cluster.                                                              | `15s`             |
-| `ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME`    | `zeebe.gateway.cluster.clusterName`    | Sets the name of the Zeebe cluster to connect to. This must be the same as the clustername configured in the brokers. | `zeebe-cluster`   |
-| `ZEEBE_GATEWAY_CLUSTER_MEMBERID`       | `zeebe.gateway.cluster.memberId`       | Sets the member id of the gateway in the cluster. This can be any unique string.                                      | `gateway`         |
-| `ZEEBE_GATEWAY_CLUSTER_HOST`           | `zeebe.gateway.cluster.host`           | Sets the host the gateway node binds to for internal cluster communicatio.                                            | `0.0.0.0`         |
-| `ZEEBE_GATEWAY_CLUSTER_PORT`           | `zeebe.gateway.cluster.port`           | Sets the port the gateway node binds to for internal cluster communication.                                           | `26502`           |
+| Environment variable                         | Application.yaml property                    | Description                                                                                                           | Default value       |
+| -------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS` | `zeebe.gateway.cluster.initialContactPoints` | Sets brokers the gateway should initial contact.                                                                      | `[127.0.0.1:26502]` |
+| `ZEEBE_GATEWAY_CLUSTER_REQUESTTIMEOUT`       | `zeebe.gateway.cluster.requestTimeout`       | Sets the timeout of requests sent to the broker cluster.                                                              | `15s`               |
+| `ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME`          | `zeebe.gateway.cluster.clusterName`          | Sets the name of the Zeebe cluster to connect to. This must be the same as the clustername configured in the brokers. | `zeebe-cluster`     |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERID`             | `zeebe.gateway.cluster.memberId`             | Sets the member id of the gateway in the cluster. This can be any unique string.                                      | `gateway`           |
+| `ZEEBE_GATEWAY_CLUSTER_HOST`                 | `zeebe.gateway.cluster.host`                 | Sets the host the gateway node binds to for internal cluster communicatio.                                            | `0.0.0.0`           |
+| `ZEEBE_GATEWAY_CLUSTER_PORT`                 | `zeebe.gateway.cluster.port`                 | Sets the port the gateway node binds to for internal cluster communication.                                           | `26502`             |
 
 ### Membership configuration
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -25,6 +25,7 @@ module.exports = {
     {
       "Update guide": [
         "guides/update-guide/introduction",
+        "guides/update-guide/800-to-810",
         "guides/update-guide/130-to-800",
         "guides/update-guide/120-to-130",
         "guides/update-guide/110-to-120",


### PR DESCRIPTION
In this PR I made description about deprecating the `contactPoint` property and how to migrate to the new `initialContactPoints` property.

Closes #958.