### PR TITLE
Document start instructions for CreateProcessInstanceRequest gRPC message

### DIFF
--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -174,7 +174,7 @@ Only processes with none start events can be started through this command.
 message CreateProcessInstanceRequest {
   // the unique key identifying the process definition (e.g. returned from a process
   // in the DeployProcessResponse message)
-  int64 processKey = 1;
+  int64 processDefinitionKey = 1;
   // the BPMN process ID of the process definition
   string bpmnProcessId = 2;
   // the version of the process; set to -1 to use the latest version

--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -185,6 +185,23 @@ message CreateProcessInstanceRequest {
   // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
   // valid argument, as the root of the JSON document is an array and not an object.
   string variables = 4;
+  // List of start instructions. If empty (default) the process instance
+  // will start at the start event. If non-empty the process instance will apply start
+  // instructions after it has been created
+  repeated ProcessInstanceCreationStartInstruction startInstructions = 5;
+}
+
+message ProcessInstanceCreationStartInstruction {
+
+  // future extensions might include
+  // - different types of start instructions
+  // - ability to set local variables for different flow scopes
+
+  // for now, however, the start instruction is implicitly a
+  // "startBeforeElement" instruction
+
+  // element ID
+  string elementId = 1;
 }
 ```
 


### PR DESCRIPTION
The gRPC message `CreateProcessInstanceRequest` now supports start instructions which allow a user to switch from starting at the default none start event and instead, start 1 or multiple tokens at specific elements in the process. See https://github.com/camunda/zeebe/issues/9366 for more details on the feature.

This updates the Zeebe API (gRPC) documentation with the new start instructions definition. It also rectifies a previous change that wasn't pulled into the docs.

Note that no new errors are introduced for this feature. This may change in the future as command rejection reasons will be expanded.

This feature will be part of the upcoming 8.1 release, and so this PR targets the corresponding `release_8_1` branch.

closes #943 