### PR TITLE
chore(deps): Update docusaurus from beta-15 to beta-16, including configuring new Algolia instance

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -191,10 +191,10 @@ module.exports = {
       copyright: `Copyright © ${new Date().getFullYear()} Camunda`,
     },
     algolia: {
-      apiKey: "f1b2a46296ae374b7f5a5c627341c354",
+      // These keys are for our new standalone algolia instance!
+      apiKey: "d701d38126d1a43866047d3ab97680d1",
+      appId: "6KYF3VMCXZ",
       indexName: "camunda",
-      contextualSearch: true, // useful for versioned docs (https://docusaurus.io/docs/search#contextual-search)
-      searchParameters: {}, // Optional (if provided by Algolia)
     },
     // Disabling Dark Mode
     // https://github.com/camunda-cloud/camunda-cloud-documentation/issues/125

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@auth0/auth0-react": "^1.10.2",
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/preset-classic": "2.0.0-beta.15",
+        "@docusaurus/core": "^2.0.0-beta.16",
+        "@docusaurus/preset-classic": "^2.0.0-beta.16",
         "clsx": "^1.1.1",
         "docusaurus-gtm-plugin": "0.0.2",
         "mixpanel-browser": "^2.45.0",
@@ -25,19 +25,19 @@
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.5.2.tgz",
-      "integrity": "sha512-DY0bhyczFSS1b/CqJlTE/nQRtnTAHl6IemIkBy0nEWnhDzRDdtdx4p5Uuk3vwAFxwEEgi1WqKwgSSMx6DpNL4A==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
+      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.5.2"
+        "@algolia/autocomplete-shared": "1.7.1"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.5.2.tgz",
-      "integrity": "sha512-3MRYnYQFJyovANzSX2CToS6/5cfVjbLLqFsZTKcvF3abhQzxbqwwaMBlJtt620uBUOeMzhdfasKhCc40+RHiZw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
+      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.5.2"
+        "@algolia/autocomplete-shared": "1.7.1"
       },
       "peerDependencies": {
         "@algolia/client-search": "^4.9.1",
@@ -45,79 +45,79 @@
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.5.2.tgz",
-      "integrity": "sha512-ylQAYv5H0YKMfHgVWX0j0NmL8XBcAeeeVQUmppnnMtzDbDnca6CzhKj3Q8eF9cHCgcdTDdb5K+3aKyGWA0obug=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
+      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.13.0.tgz",
-      "integrity": "sha512-nj1vHRZauTqP/bluwkRIgEADEimqojJgoTRCel5f6q8WCa9Y8QeI4bpDQP28FoeKnDRYa3J5CauDlN466jqRhg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.13.1.tgz",
+      "integrity": "sha512-UAUVG2PEfwd/FfudsZtYnidJ9eSCpS+LW9cQiesePQLz41NAcddKxBak6eP2GErqyFagSlnVXe/w2E9h2m2ttg==",
       "dependencies": {
-        "@algolia/cache-common": "4.13.0"
+        "@algolia/cache-common": "4.13.1"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.13.0.tgz",
-      "integrity": "sha512-f9mdZjskCui/dA/fA/5a+6hZ7xnHaaZI5tM/Rw9X8rRB39SUlF/+o3P47onZ33n/AwkpSbi5QOyhs16wHd55kA=="
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.13.1.tgz",
+      "integrity": "sha512-7Vaf6IM4L0Jkl3sYXbwK+2beQOgVJ0mKFbz/4qSxKd1iy2Sp77uTAazcX+Dlexekg1fqGUOSO7HS4Sx47ZJmjA=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.13.0.tgz",
-      "integrity": "sha512-hHdc+ahPiMM92CQMljmObE75laYzNFYLrNOu0Q3/eyvubZZRtY2SUsEEgyUEyzXruNdzrkcDxFYa7YpWBJYHAg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.13.1.tgz",
+      "integrity": "sha512-pZzybCDGApfA/nutsFK1P0Sbsq6fYJU3DwIvyKg4pURerlJM4qZbB9bfLRef0FkzfQu7W11E4cVLCIOWmyZeuQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.13.0"
+        "@algolia/cache-common": "4.13.1"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.13.0.tgz",
-      "integrity": "sha512-FzFqFt9b0g/LKszBDoEsW+dVBuUe1K3scp2Yf7q6pgHWM1WqyqUlARwVpLxqyc+LoyJkTxQftOKjyFUqddnPKA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.13.1.tgz",
+      "integrity": "sha512-TFLiZ1KqMiir3FNHU+h3b0MArmyaHG+eT8Iojio6TdpeFcAQ1Aiy+2gb3SZk3+pgRJa/BxGmDkRUwE5E/lv3QQ==",
       "dependencies": {
-        "@algolia/client-common": "4.13.0",
-        "@algolia/client-search": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/client-common": "4.13.1",
+        "@algolia/client-search": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.13.0.tgz",
-      "integrity": "sha512-klmnoq2FIiiMHImkzOm+cGxqRLLu9CMHqFhbgSy9wtXZrqb8BBUIUE2VyBe7azzv1wKcxZV2RUyNOMpFqmnRZA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.13.1.tgz",
+      "integrity": "sha512-iOS1JBqh7xaL5x00M5zyluZ9+9Uy9GqtYHv/2SMuzNW1qP7/0doz1lbcsP3S7KBbZANJTFHUOfuqyRLPk91iFA==",
       "dependencies": {
-        "@algolia/client-common": "4.13.0",
-        "@algolia/client-search": "4.13.0",
-        "@algolia/requester-common": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/client-common": "4.13.1",
+        "@algolia/client-search": "4.13.1",
+        "@algolia/requester-common": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.13.0.tgz",
-      "integrity": "sha512-GoXfTp0kVcbgfSXOjfrxx+slSipMqGO9WnNWgeMmru5Ra09MDjrcdunsiiuzF0wua6INbIpBQFTC2Mi5lUNqGA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.13.1.tgz",
+      "integrity": "sha512-LcDoUE0Zz3YwfXJL6lJ2OMY2soClbjrrAKB6auYVMNJcoKZZ2cbhQoFR24AYoxnGUYBER/8B+9sTBj5bj/Gqbg==",
       "dependencies": {
-        "@algolia/requester-common": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/requester-common": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.13.0.tgz",
-      "integrity": "sha512-KneLz2WaehJmNfdr5yt2HQETpLaCYagRdWwIwkTqRVFCv4DxRQ2ChPVW9jeTj4YfAAhfzE6F8hn7wkQ/Jfj6ZA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.13.1.tgz",
+      "integrity": "sha512-1CqrOW1ypVrB4Lssh02hP//YxluoIYXAQCpg03L+/RiXJlCs+uIqlzC0ctpQPmxSlTK6h07kr50JQoYH/TIM9w==",
       "dependencies": {
-        "@algolia/client-common": "4.13.0",
-        "@algolia/requester-common": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/client-common": "4.13.1",
+        "@algolia/requester-common": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.13.0.tgz",
-      "integrity": "sha512-blgCKYbZh1NgJWzeGf+caKE32mo3j54NprOf0LZVCubQb3Kx37tk1Hc8SDs9bCAE8hUvf3cazMPIg7wscSxspA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.13.1.tgz",
+      "integrity": "sha512-YQKYA83MNRz3FgTNM+4eRYbSmHi0WWpo019s5SeYcL3HUan/i5R09VO9dk3evELDFJYciiydSjbsmhBzbpPP2A==",
       "dependencies": {
-        "@algolia/client-common": "4.13.0",
-        "@algolia/requester-common": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/client-common": "4.13.1",
+        "@algolia/requester-common": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "node_modules/@algolia/events": {
@@ -126,47 +126,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.13.0.tgz",
-      "integrity": "sha512-8yqXk7rMtmQJ9wZiHOt/6d4/JDEg5VCk83gJ39I+X/pwUPzIsbKy9QiK4uJ3aJELKyoIiDT1hpYVt+5ia+94IA=="
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.13.1.tgz",
+      "integrity": "sha512-L6slbL/OyZaAXNtS/1A8SAbOJeEXD5JcZeDCPYDqSTYScfHu+2ePRTDMgUTY4gQ7HsYZ39N1LujOd8WBTmM2Aw=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.13.0.tgz",
-      "integrity": "sha512-YepRg7w2/87L0vSXRfMND6VJ5d6699sFJBRWzZPOlek2p5fLxxK7O0VncYuc/IbVHEgeApvgXx0WgCEa38GVuQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.13.1.tgz",
+      "integrity": "sha512-7jQOTftfeeLlnb3YqF8bNgA2GZht7rdKkJ31OCeSH2/61haO0tWPoNRjZq9XLlgMQZH276pPo0NdiArcYPHjCA==",
       "dependencies": {
-        "@algolia/logger-common": "4.13.0"
+        "@algolia/logger-common": "4.13.1"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.13.0.tgz",
-      "integrity": "sha512-Dj+bnoWR5MotrnjblzGKZ2kCdQi2cK/VzPURPnE616NU/il7Ypy6U6DLGZ/ZYz+tnwPa0yypNf21uqt84fOgrg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.13.1.tgz",
+      "integrity": "sha512-oa0CKr1iH6Nc7CmU6RE7TnXMjHnlyp7S80pP/LvZVABeJHX3p/BcSCKovNYWWltgTxUg0U1o+2uuy8BpMKljwA==",
       "dependencies": {
-        "@algolia/requester-common": "4.13.0"
+        "@algolia/requester-common": "4.13.1"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.13.0.tgz",
-      "integrity": "sha512-BRTDj53ecK+gn7ugukDWOOcBRul59C4NblCHqj4Zm5msd5UnHFjd/sGX+RLOEoFMhetILAnmg6wMrRrQVac9vw=="
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.13.1.tgz",
+      "integrity": "sha512-eGVf0ID84apfFEuXsaoSgIxbU3oFsIbz4XiotU3VS8qGCJAaLVUC5BUJEkiFENZIhon7hIB4d0RI13HY4RSA+w=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.13.0.tgz",
-      "integrity": "sha512-9b+3O4QFU4azLhGMrZAr/uZPydvzOR4aEZfSL8ZrpLZ7fbbqTO0S/5EVko+QIgglRAtVwxvf8UJ1wzTD2jvKxQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.13.1.tgz",
+      "integrity": "sha512-7C0skwtLdCz5heKTVe/vjvrqgL/eJxmiEjHqXdtypcE5GCQCYI15cb+wC4ytYioZDMiuDGeVYmCYImPoEgUGPw==",
       "dependencies": {
-        "@algolia/requester-common": "4.13.0"
+        "@algolia/requester-common": "4.13.1"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.13.0.tgz",
-      "integrity": "sha512-8tSQYE+ykQENAdeZdofvtkOr5uJ9VcQSWgRhQ9h01AehtBIPAczk/b2CLrMsw5yQZziLs5cZ3pJ3478yI+urhA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.13.1.tgz",
+      "integrity": "sha512-pICnNQN7TtrcYJqqPEXByV8rJ8ZRU2hCiIKLTLRyNpghtQG3VAFk6fVtdzlNfdUGZcehSKGarPIZEHlQXnKjgw==",
       "dependencies": {
-        "@algolia/cache-common": "4.13.0",
-        "@algolia/logger-common": "4.13.0",
-        "@algolia/requester-common": "4.13.0"
+        "@algolia/cache-common": "4.13.1",
+        "@algolia/logger-common": "4.13.1",
+        "@algolia/requester-common": "4.13.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1899,83 +1899,94 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@docsearch/css": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0.tgz",
-      "integrity": "sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.1.1.tgz",
+      "integrity": "sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0.tgz",
-      "integrity": "sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.5.2",
-        "@algolia/autocomplete-preset-algolia": "1.5.2",
-        "@docsearch/css": "3.0.0",
+        "@algolia/autocomplete-core": "1.7.1",
+        "@algolia/autocomplete-preset-algolia": "1.7.1",
+        "@docsearch/css": "3.1.1",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
-        "@types/react": ">= 16.8.0 < 18.0.0",
-        "react": ">= 16.8.0 < 18.0.0",
-        "react-dom": ">= 16.8.0 < 18.0.0"
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0"
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.15.tgz",
-      "integrity": "sha512-zXhhD0fApMSvq/9Pkm9DQxa//hGOXVCq9yMHiXOkI5D1tLec7PxtnaC5cLfGHljkN9cKIfRDYUVcG1gHymVfpA==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.16.tgz",
+      "integrity": "sha512-0AbNSpTKapz+tctg7PHvuGQRtW7nd3Tm3axNqnFowO3SV2VvFCaBji2s1H3XCGXVRGveQ04g20vl2ZqG5GheUA==",
       "dependencies": {
-        "@babel/core": "^7.16.0",
-        "@babel/generator": "^7.16.0",
+        "@babel/core": "^7.17.5",
+        "@babel/generator": "^7.17.3",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.16.0",
-        "@babel/preset-env": "^7.16.4",
-        "@babel/preset-react": "^7.16.0",
-        "@babel/preset-typescript": "^7.16.0",
-        "@babel/runtime": "^7.16.3",
-        "@babel/runtime-corejs3": "^7.16.3",
-        "@babel/traverse": "^7.16.3",
-        "@docusaurus/cssnano-preset": "2.0.0-beta.15",
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/mdx-loader": "2.0.0-beta.15",
+        "@babel/plugin-transform-runtime": "^7.17.0",
+        "@babel/preset-env": "^7.16.11",
+        "@babel/preset-react": "^7.16.7",
+        "@babel/preset-typescript": "^7.16.7",
+        "@babel/runtime": "^7.17.2",
+        "@babel/runtime-corejs3": "^7.17.2",
+        "@babel/traverse": "^7.17.3",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/mdx-loader": "2.0.0-beta.16",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-common": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.0",
-        "@svgr/webpack": "^6.0.0",
-        "autoprefixer": "^10.3.5",
-        "babel-loader": "^8.2.2",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-common": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@slorber/static-site-generator-webpack-plugin": "^4.0.1",
+        "@svgr/webpack": "^6.2.1",
+        "autoprefixer": "^10.4.2",
+        "babel-loader": "^8.2.3",
         "babel-plugin-dynamic-import-node": "2.3.0",
-        "boxen": "^5.0.1",
-        "chokidar": "^3.5.2",
-        "clean-css": "^5.1.5",
+        "boxen": "^6.2.1",
+        "chokidar": "^3.5.3",
+        "clean-css": "^5.2.4",
+        "cli-table3": "^0.6.1",
+        "combine-promises": "^1.1.0",
         "commander": "^5.1.0",
-        "copy-webpack-plugin": "^10.2.0",
-        "core-js": "^3.18.0",
-        "css-loader": "^6.5.1",
-        "css-minimizer-webpack-plugin": "^3.3.1",
-        "cssnano": "^5.0.8",
+        "copy-webpack-plugin": "^10.2.4",
+        "core-js": "^3.21.1",
+        "css-loader": "^6.6.0",
+        "css-minimizer-webpack-plugin": "^3.4.1",
+        "cssnano": "^5.0.17",
         "del": "^6.0.0",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
         "eta": "^1.12.3",
         "file-loader": "^6.2.0",
-        "fs-extra": "^10.0.0",
-        "html-minifier-terser": "^6.0.2",
+        "fs-extra": "^10.0.1",
+        "html-minifier-terser": "^6.1.0",
         "html-tags": "^3.1.0",
-        "html-webpack-plugin": "^5.4.0",
+        "html-webpack-plugin": "^5.5.0",
         "import-fresh": "^3.3.0",
         "is-root": "^2.1.0",
         "leven": "^3.1.0",
-        "lodash": "^4.17.20",
-        "mini-css-extract-plugin": "^1.6.0",
+        "lodash": "^4.17.21",
+        "mini-css-extract-plugin": "^2.5.3",
         "nprogress": "^0.2.0",
-        "postcss": "^8.3.7",
-        "postcss-loader": "^6.1.1",
-        "prompts": "^2.4.1",
+        "postcss": "^8.4.6",
+        "postcss-loader": "^6.2.1",
+        "prompts": "^2.4.2",
         "react-dev-utils": "^12.0.0",
-        "react-helmet": "^6.1.0",
+        "react-helmet-async": "^1.2.3",
         "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
         "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
         "react-router": "^5.2.0",
@@ -1985,21 +1996,20 @@
         "rtl-detect": "^1.0.4",
         "semver": "^7.3.4",
         "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.4",
-        "strip-ansi": "^6.0.0",
-        "terser-webpack-plugin": "^5.2.4",
+        "shelljs": "^0.8.5",
+        "terser-webpack-plugin": "^5.3.1",
         "tslib": "^2.3.1",
         "update-notifier": "^5.1.0",
         "url-loader": "^4.1.1",
-        "wait-on": "^6.0.0",
-        "webpack": "^5.61.0",
-        "webpack-bundle-analyzer": "^4.4.2",
-        "webpack-dev-server": "^4.7.1",
+        "wait-on": "^6.0.1",
+        "webpack": "^5.69.1",
+        "webpack-bundle-analyzer": "^4.5.0",
+        "webpack-dev-server": "^4.7.4",
         "webpack-merge": "^5.8.0",
         "webpackbar": "^5.0.2"
       },
       "bin": {
-        "docusaurus": "bin/docusaurus.js"
+        "docusaurus": "bin/docusaurus.mjs"
       },
       "engines": {
         "node": ">=14"
@@ -2009,20 +2019,214 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.15.tgz",
-      "integrity": "sha512-55aYURbB5dqrx64lStNcZxDx5R6bKkAawlCB7mDKx3r+Qnp3ofGW7UExLQSCbTu3axT1vJCF5D7H6ljTRYJLtA==",
+    "node_modules/@docusaurus/core/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
-        "cssnano-preset-advanced": "^5.1.4",
-        "postcss": "^8.3.7",
-        "postcss-sort-media-queries": "^4.1.0"
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/boxen": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-6.2.1.tgz",
+      "integrity": "sha512-H4PEsJXfFI/Pt8sjDWbHlQPx4zL/bvSQjcilJmaulGt5mLDorHOHpmdXAJcBcmru7PhYSp/cDMWRko4ZUMFkSw==",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.2",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.0.1",
+        "type-fest": "^2.5.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@docusaurus/core/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/@docusaurus/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/type-fest": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.15.1.tgz",
+      "integrity": "sha512-LYSjcIz3NmoQksXq/3/B7Nfad+T8mkaI628agAAnHCpXPTBRMK2ygt3eABpzII8CbZZM8dLdVQ4Gr8ousjFjMw==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/wrap-ansi": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
+      "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.0.tgz",
+      "integrity": "sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/cssnano-preset": {
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.16.tgz",
+      "integrity": "sha512-dkGpb+xoFNmcp5m5EpwGcFlMT4C7kOTzgZ73QoNoU930NL6OXuqcJdMd4XI6yYuGz+t8Bo8UzzCryEjHTiObOg==",
+      "dependencies": {
+        "cssnano-preset-advanced": "^5.1.12",
+        "postcss": "^8.4.6",
+        "postcss-sort-media-queries": "^4.2.1"
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.15.tgz",
-      "integrity": "sha512-5bDSHCyLfMtz6QnFfICdL5mgxbGfC7DW1V+/Q17nRdpZSPZgsNKK/Esp0zdDi1oxAyEpXMXx64nLaHL7joJxIg==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.16.tgz",
+      "integrity": "sha512-/fta5gCXHMLip+8WxYoi+hlB1pwJEeVpFc7Z4iIMwAxn8SrcmCJ0K3wPNjZpDdz0EHrpLHEJ/vEkCuL+7Su4ZQ==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.3.1"
@@ -2096,18 +2300,18 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.15.tgz",
-      "integrity": "sha512-MVpytjDDao7hmPF1QSs9B5zoTgevZjiqjnX3FM1yjqdCv+chyUo0gnmYHjeG/4Gqu7jucp+dDdp6yQpzs4g09A==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.16.tgz",
+      "integrity": "sha512-NR0Cptz4UGlzgu08AITffRL4rj+SU8HYq2yNFxbY8FSuj/GWI3SrSsBi7grB6fKql0s4SGUKEEzSweewzW1Rgg==",
       "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@babel/traverse": "^7.16.3",
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@mdx-js/mdx": "^1.6.21",
+        "@babel/parser": "^7.17.3",
+        "@babel/traverse": "^7.17.3",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^10.0.1",
         "image-size": "^1.0.1",
         "mdast-util-to-string": "^2.0.0",
         "remark-emoji": "^2.1.0",
@@ -2115,7 +2319,7 @@
         "tslib": "^2.3.1",
         "unist-util-visit": "^2.0.2",
         "url-loader": "^4.1.1",
-        "webpack": "^5.61.0"
+        "webpack": "^5.69.1"
       },
       "engines": {
         "node": ">=14"
@@ -2125,26 +2329,42 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.15.tgz",
-      "integrity": "sha512-VtEwkgkoNIS8JFPe+huBeBuJ8HG8Lq1JNYM/ItwQg/cwGAgP8EgwbEuKDn428oZKEI2PpgAuf5Gv4AzJWIes9A==",
+    "node_modules/@docusaurus/module-type-aliases": {
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.16.tgz",
+      "integrity": "sha512-x6/JlbrSfhGuDc6dWybt/E1T6xh/jjEJemlizAGArHpKB0mTuxRm5FRCmksX7z7IM8HZs43tpftGS8gXNL5gug==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/mdx-loader": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-common": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
+        "@docusaurus/types": "2.0.0-beta.16",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-blog": {
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.16.tgz",
+      "integrity": "sha512-JSRzNKpuMPAndIDIZKbA4G2rA0sC3jPHO+TOmBliO8SBUkw1DL58MZTp98y+5EeUg+KjNIYoz7wRMj3YhFIhJA==",
+      "dependencies": {
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/mdx-loader": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-common": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
         "cheerio": "^1.0.0-rc.10",
         "feed": "^4.2.2",
-        "fs-extra": "^10.0.0",
-        "lodash": "^4.17.20",
+        "fs-extra": "^10.0.1",
+        "lodash": "^4.17.21",
         "reading-time": "^1.5.0",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.61.0"
+        "webpack": "^5.69.1"
       },
       "engines": {
         "node": ">=14"
@@ -2155,25 +2375,24 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.15.tgz",
-      "integrity": "sha512-HSwNZdUKz4rpJiGbFjl/OFhSleeZUSZ6E6lk98i4iL1A5u6fIm4CHsT53yp4UUOse+lFrePTFZsyqwMA4nZZYA==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.16.tgz",
+      "integrity": "sha512-IiNEud1WYj9a0rkNHjX1JNLfim8f6pyB5w17arRDK6HiY3w51zCQsZJo0popRp1KQQf/g66I+5Y3qP5rHGeU6Q==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/mdx-loader": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/mdx-loader": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
         "combine-promises": "^1.1.0",
-        "fs-extra": "^10.0.0",
-        "import-fresh": "^3.2.2",
-        "js-yaml": "^4.0.0",
-        "lodash": "^4.17.20",
+        "fs-extra": "^10.0.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "remark-admonitions": "^1.2.1",
-        "shelljs": "^0.8.4",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.61.0"
+        "webpack": "^5.69.1"
       },
       "engines": {
         "node": ">=14"
@@ -2184,19 +2403,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.15.tgz",
-      "integrity": "sha512-N7YhW5RiOY6J228z4lOoP//qX0Q48cRtxDONZ/Ohd9C5OI2vS6TD8iQuDqOIYHxH+BshjNSsKvbJ+SMIQDwysg==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.16.tgz",
+      "integrity": "sha512-XH/dNfDhnad7qA+RUdyJW94Yf8LzALz0bJRwp8GbtjXeAmfP/DWGvVPT/egd9Pz99uO5UgiO9vR1i7UlktQSwA==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/mdx-loader": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
-        "fs-extra": "^10.0.0",
-        "globby": "^11.0.2",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/mdx-loader": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "fs-extra": "^10.0.1",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
-        "webpack": "^5.61.0"
+        "webpack": "^5.69.1"
       },
       "engines": {
         "node": ">=14"
@@ -2207,13 +2425,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.15.tgz",
-      "integrity": "sha512-Jth11jB/rVqPwCGdkVKSUWeXZPAr/NyPn+yeknTBk2LgQKBJ3YU5dNG0uyt0Ay+UYT01TkousPJkXhLuy4Qrsw==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.16.tgz",
+      "integrity": "sha512-uzp4hrL/PozgDNEWF/Y+DH+nH0GoC+dOyNLqsyFqQLlzykFHTJYLMK1tfwKHUJ3WqhQFbRwLTR4rzFC89Kaf7g==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "fs-extra": "^10.0.0",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "fs-extra": "^10.0.1",
         "react-json-view": "^1.21.3",
         "tslib": "^2.3.1"
       },
@@ -2226,12 +2444,12 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.15.tgz",
-      "integrity": "sha512-ELAnxNYiC2i7gfu/ViurNIdm1/DdnbEfVDmpffS9niQhOREM1U3jpxkz/ff1GIC6heOLyHTtini/CZBDoroVGw==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.16.tgz",
+      "integrity": "sha512-UKd1RWYHeSm/RLjJ2ZflLTT6hbiWQWFAxVzYRBiyOnDbBP+un8qmP692QZCIP+rrm+KkxsV1FGte0NtrcsFUEw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2243,12 +2461,12 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.15.tgz",
-      "integrity": "sha512-E5Rm3+dN7i3A9V5uq5sl9xTNA3aXsLwTZEA2SpOkY571dCpd+sfVvz1lR+KRY9Fy6ZHk8PqrNImgCWfIerRuZQ==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.16.tgz",
+      "integrity": "sha512-WUD1Kh5y/9VaV/ubg8c6a43gE2+N+yeLUL/qfrUZuLHheaBaozGjioHRbndmfN6W7l2EhuxO1QRN3SlBqc7kjA==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2260,16 +2478,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.15.tgz",
-      "integrity": "sha512-PBjeQb2Qpe4uPdRefWL/eXCeYjrgNB/UArExYeUuP4wiY1dpw2unGNCvFUxv4hzJGmARoTLsnRkeYkUim809LQ==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.16.tgz",
+      "integrity": "sha512-B8fa2qvScNSiuCos6vZjPERikRTbbebzy33s5zV+VTZsqLtrjs4//Y0HlJ0tuz5qHWCzavb6nFX/mgFAJoyqFQ==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-common": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
-        "fs-extra": "^10.0.0",
-        "sitemap": "^7.0.0",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-common": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "fs-extra": "^10.0.1",
+        "sitemap": "^7.1.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2281,21 +2499,21 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.15.tgz",
-      "integrity": "sha512-3NZIXWTAzk+kOgiB8uAbD+FZv3VFR1qkU6+TW24DRenjRnXof3CkRuldhI1QI0hILm1fuJ319QRkakV8FFtXyA==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.16.tgz",
+      "integrity": "sha512-HLY2dC412Lexe2ZupUEUJpY44yz6uqtvibKTXvXH392hFB43Thp7MKr5zACRTwacjbddIoqPVbdzRWtvugSU2g==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.15",
-        "@docusaurus/plugin-debug": "2.0.0-beta.15",
-        "@docusaurus/plugin-google-analytics": "2.0.0-beta.15",
-        "@docusaurus/plugin-google-gtag": "2.0.0-beta.15",
-        "@docusaurus/plugin-sitemap": "2.0.0-beta.15",
-        "@docusaurus/theme-classic": "2.0.0-beta.15",
-        "@docusaurus/theme-common": "2.0.0-beta.15",
-        "@docusaurus/theme-search-algolia": "2.0.0-beta.15"
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
+        "@docusaurus/plugin-debug": "2.0.0-beta.16",
+        "@docusaurus/plugin-google-analytics": "2.0.0-beta.16",
+        "@docusaurus/plugin-google-gtag": "2.0.0-beta.16",
+        "@docusaurus/plugin-sitemap": "2.0.0-beta.16",
+        "@docusaurus/theme-classic": "2.0.0-beta.16",
+        "@docusaurus/theme-common": "2.0.0-beta.16",
+        "@docusaurus/theme-search-algolia": "2.0.0-beta.16"
       },
       "engines": {
         "node": ">=14"
@@ -2318,27 +2536,27 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.15.tgz",
-      "integrity": "sha512-WwNRcQvMtQ7KDhOEHFKFHxXCdoZwLg66hT3vhqNIFMfGQuPzOP91MX5LUSo1QWHhlrD3H3Og+r7Ik/fy2bf5lQ==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.16.tgz",
+      "integrity": "sha512-7cylhb2hwAUSM+ZD2ClQwS/Ag8tnt5gTDrma9WzWA+sB7Zd/b5Dc9WHFowzUjieC++UZ+KxYktCfKE/1RWF77w==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.15",
-        "@docusaurus/theme-common": "2.0.0-beta.15",
-        "@docusaurus/theme-translations": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-common": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
-        "@mdx-js/react": "^1.6.21",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
+        "@docusaurus/theme-common": "2.0.0-beta.16",
+        "@docusaurus/theme-translations": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-common": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
         "copy-text-to-clipboard": "^3.0.1",
         "infima": "0.2.0-alpha.37",
-        "lodash": "^4.17.20",
-        "postcss": "^8.3.7",
+        "lodash": "^4.17.21",
+        "postcss": "^8.4.6",
         "prism-react-renderer": "^1.2.1",
-        "prismjs": "^1.23.0",
+        "prismjs": "^1.27.0",
         "react-router-dom": "^5.2.0",
         "rtlcss": "^3.3.0"
       },
@@ -2351,15 +2569,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.15.tgz",
-      "integrity": "sha512-+pvarmzcyECE4nWxw+dCMKRIoes0NegrRuM9+nRsUrS/E5ywsF539kpupKIEqaMjq6AuM0CJtDoHxHHPNe0KaQ==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.16.tgz",
+      "integrity": "sha512-7jP+lVrNMlEXH9bUvjnRxyF1MQpIC0Z+FpBmahTwi1lNAVe1kbs3r7SVsXnBHwI4F+tIWaRMkpEfZfNhH1MjNA==",
       "dependencies": {
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.15",
+        "@docusaurus/module-type-aliases": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
         "clsx": "^1.1.1",
         "parse-numeric-range": "^1.3.0",
+        "prism-react-renderer": "^1.3.1",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0"
       },
@@ -2367,28 +2587,28 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "prism-react-renderer": "^1.2.1",
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.15.tgz",
-      "integrity": "sha512-XrrQKyjOPzmEuOcdsaAn1tzNJkNMA3PC86PwPZUaah0cYPpBGptcJYDlIW4VHIrCBfkQvhvmg/B3qKF6bMMi8g==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.16.tgz",
+      "integrity": "sha512-yNQ7nWWAzT+abQiiSgnPT3FDE07KDIt4UZgxEwo2WvynDD4O7G+6uUkBryAZXYvgc2GEMw7u0E/8+2EPbJ5yyg==",
       "dependencies": {
-        "@docsearch/react": "^3.0.0-alpha.39",
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/theme-common": "2.0.0-beta.15",
-        "@docusaurus/theme-translations": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
-        "algoliasearch": "^4.10.5",
-        "algoliasearch-helper": "^3.5.5",
+        "@docsearch/react": "^3.0.0",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/theme-common": "2.0.0-beta.16",
+        "@docusaurus/theme-translations": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "algoliasearch": "^4.12.1",
+        "algoliasearch-helper": "^3.7.0",
         "clsx": "^1.1.1",
         "eta": "^1.12.3",
-        "lodash": "^4.17.20",
+        "fs-extra": "^10.0.1",
+        "lodash": "^4.17.21",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0"
       },
@@ -2401,53 +2621,59 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.15.tgz",
-      "integrity": "sha512-Lu2JDsnZaB2BcJe8Hpq5nrbS7+7bd09jT08b9vztQyvzR8PgzsthnzlLN4ilOeamRIuYJKo1pUGm0EsQBOP6Nw==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.16.tgz",
+      "integrity": "sha512-OMYjraIbkQyPEdpPGe4zc9gDUm1FxruyBMcxW9pnqh8BoEogPpyFGTJwXiKzOWS6W+xiyctWJYIYmS5laDkriw==",
       "dependencies": {
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^10.0.1",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
-    "node_modules/@docusaurus/utils": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.15.tgz",
-      "integrity": "sha512-xkoPmFxCBkDqbZR4U3SE752OcXtWTGgZnc/pZWxItzb1IYRGNZHrzdIr7CnI7rppriuZzsyivDGiC4Ud9MWhkA==",
+    "node_modules/@docusaurus/types": {
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.16.tgz",
+      "integrity": "sha512-ttej9CFthe9+mDMGKMI1wRegXJHLXUZUhxsiYaGczW7PZXdbCQZvKVAoMtrEp/Oa/KOMtqwva60iEEot//KGnQ==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@mdx-js/runtime": "^1.6.22",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "querystring": "0.2.1",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.69.1",
+        "webpack-merge": "^5.8.0"
+      }
+    },
+    "node_modules/@docusaurus/utils": {
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.16.tgz",
+      "integrity": "sha512-ngOVqWlT+JvHsWDYH1i0oou9Dhhm6gKcTB3PR3nkIlDOdn+MViuhhKivTBD9et5JxAnf8A1hk/oaUO9tBU7WGA==",
+      "dependencies": {
+        "@docusaurus/logger": "2.0.0-beta.16",
         "@svgr/webpack": "^6.0.0",
         "file-loader": "^6.2.0",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^10.0.1",
         "github-slugger": "^1.4.0",
         "globby": "^11.0.4",
         "gray-matter": "^4.0.3",
-        "js-yaml": "^4.0.0",
-        "lodash": "^4.17.20",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "micromatch": "^4.0.4",
-        "remark-mdx-remove-exports": "^1.6.22",
-        "remark-mdx-remove-imports": "^1.6.22",
         "resolve-pathname": "^3.0.0",
+        "shelljs": "^0.8.5",
         "tslib": "^2.3.1",
-        "url-loader": "^4.1.1"
+        "url-loader": "^4.1.1",
+        "webpack": "^5.69.1"
       },
       "engines": {
         "node": ">=14"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "react": "*",
-        "react-dom": "*",
-        "webpack": "5.x"
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.15.tgz",
-      "integrity": "sha512-kIGlSIvbE/oniUpUjI8GOkSpH8o4NXbYqAh9dqPn+TJ0KbEFY3fc80gzZQU+9SunCwJMJbIxIGevX9Ry+nackw==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.16.tgz",
+      "integrity": "sha512-xAUBVX/BftMPAw9rvdeIKBKmmAX2xus+HbXciL+5VKNG9ePI5X+W739lCqJVm6C2fDRXENBbeaKnnMx9wTeEUg==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -2456,41 +2682,17 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.15.tgz",
-      "integrity": "sha512-1oOVBCkRrsTXSYrBTsMdnj3a/R56zrx11rjF4xo0+dmm8C01Xw4msFtc3uA7VLX0HQvgHsk8xPzU5GERNdsNpg==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.16.tgz",
+      "integrity": "sha512-gXAKMP1D5ERX3d5SF88Yp7G9ROYd2XOhyLSErPRaHs5b9SzYhI9lIiPUoXFk6VyRnUjXiUley2/MtdrEgt989A==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "joi": "^17.4.2",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "joi": "^17.6.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/@mdx-js/runtime": {
-      "version": "1.6.22",
-      "resolved": "https://registry.npmjs.org/@mdx-js/runtime/-/runtime-1.6.22.tgz",
-      "integrity": "sha512-p17spaO2+55VLCuxXA3LVHC4phRx60NR2XMdZ+qgVU1lKvEX4y88dmFNOzGDCPLJ03IZyKrJ/rPWWRiBrd9JrQ==",
-      "dependencies": {
-        "@mdx-js/mdx": "1.6.22",
-        "@mdx-js/react": "1.6.22",
-        "buble-jsx-only": "^0.19.8"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "react": "^16.13.1"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -3183,6 +3385,11 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -3252,6 +3459,35 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz",
+      "integrity": "sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-config": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-router-config/-/react-router-config-5.0.6.tgz",
+      "integrity": "sha512-db1mx37a1EJDf1XeX8jJN7R3PZABmJQXR8r28yUjVMFSjkmnQo6X6pOEEmNl+Tp2gYQOGPdYbFIipBtdElZ3Yg==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@types/retry": {
@@ -3487,14 +3723,6 @@
         "acorn": "^8"
       }
     },
-    "node_modules/acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
@@ -3583,35 +3811,35 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.13.0.tgz",
-      "integrity": "sha512-oHv4faI1Vl2s+YC0YquwkK/TsaJs79g2JFg5FDm2rKN12VItPTAeQ7hyJMHarOPPYuCnNC5kixbtcqvb21wchw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.13.1.tgz",
+      "integrity": "sha512-dtHUSE0caWTCE7liE1xaL+19AFf6kWEcyn76uhcitWpntqvicFHXKFoZe5JJcv9whQOTRM6+B8qJz6sFj+rDJA==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.13.0",
-        "@algolia/cache-common": "4.13.0",
-        "@algolia/cache-in-memory": "4.13.0",
-        "@algolia/client-account": "4.13.0",
-        "@algolia/client-analytics": "4.13.0",
-        "@algolia/client-common": "4.13.0",
-        "@algolia/client-personalization": "4.13.0",
-        "@algolia/client-search": "4.13.0",
-        "@algolia/logger-common": "4.13.0",
-        "@algolia/logger-console": "4.13.0",
-        "@algolia/requester-browser-xhr": "4.13.0",
-        "@algolia/requester-common": "4.13.0",
-        "@algolia/requester-node-http": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/cache-browser-local-storage": "4.13.1",
+        "@algolia/cache-common": "4.13.1",
+        "@algolia/cache-in-memory": "4.13.1",
+        "@algolia/client-account": "4.13.1",
+        "@algolia/client-analytics": "4.13.1",
+        "@algolia/client-common": "4.13.1",
+        "@algolia/client-personalization": "4.13.1",
+        "@algolia/client-search": "4.13.1",
+        "@algolia/logger-common": "4.13.1",
+        "@algolia/logger-console": "4.13.1",
+        "@algolia/requester-browser-xhr": "4.13.1",
+        "@algolia/requester-common": "4.13.1",
+        "@algolia/requester-node-http": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.8.2.tgz",
-      "integrity": "sha512-AXxiF0zT9oYwl8ZBgU/eRXvfYhz7cBA5YrLPlw9inZHdaYF0QEya/f1Zp1mPYMXc1v6VkHwBq4pk6/vayBLICg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.10.0.tgz",
+      "integrity": "sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
       "peerDependencies": {
-        "algoliasearch": ">= 3.1 < 5"
+        "algoliasearch": ">= 3.1 < 6"
       }
     },
     "node_modules/ansi-align": {
@@ -3692,9 +3920,9 @@
       }
     },
     "node_modules/arg": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3717,7 +3945,7 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -3745,9 +3973,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
-      "integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
+      "version": "10.4.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
+      "integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3759,8 +3987,8 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.20.2",
-        "caniuse-lite": "^1.0.30001317",
+        "browserslist": "^4.20.3",
+        "caniuse-lite": "^1.0.30001335",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -3926,7 +4154,7 @@
     "node_modules/base16": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
-      "integrity": "sha1-4pf2DX7BAUp6lxo568ipjAtoHnA="
+      "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -4126,9 +4354,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.1.tgz",
+      "integrity": "sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4140,53 +4368,16 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001359",
+        "electron-to-chromium": "^1.4.172",
+        "node-releases": "^2.0.5",
+        "update-browserslist-db": "^1.0.4"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buble-jsx-only": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/buble-jsx-only/-/buble-jsx-only-0.19.8.tgz",
-      "integrity": "sha512-7AW19pf7PrKFnGTEDzs6u9+JZqQwM1VnLS19OlqYDhXomtFFknnoQJAPHeg84RMFWAvOhYrG7harizJNwUKJsA==",
-      "dependencies": {
-        "acorn": "^6.1.1",
-        "acorn-dynamic-import": "^4.0.0",
-        "acorn-jsx": "^5.0.1",
-        "chalk": "^2.4.2",
-        "magic-string": "^0.25.3",
-        "minimist": "^1.2.0",
-        "regexpu-core": "^4.5.4"
-      },
-      "bin": {
-        "buble": "bin/buble"
-      }
-    },
-    "node_modules/buble-jsx-only/node_modules/acorn": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/buble-jsx-only/node_modules/acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "peerDependencies": {
-        "acorn": "^6.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -4309,9 +4500,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001361",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz",
+      "integrity": "sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4373,17 +4564,17 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
-      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
       "dependencies": {
-        "cheerio-select": "^1.5.0",
-        "dom-serializer": "^1.3.2",
-        "domhandler": "^4.2.0",
-        "htmlparser2": "^6.1.0",
-        "parse5": "^6.0.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.1",
-        "tslib": "^2.2.0"
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
       },
       "engines": {
         "node": ">= 6"
@@ -4393,18 +4584,165 @@
       }
     },
     "node_modules/cheerio-select": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
-      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "dependencies": {
-        "css-select": "^4.3.0",
-        "css-what": "^6.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0"
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/entities": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/entities": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/htmlparser2": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
+      }
+    },
+    "node_modules/cheerio/node_modules/parse5": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+      "dependencies": {
+        "entities": "^4.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -4494,6 +4832,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/cli-truncate": {
@@ -4991,9 +5343,9 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
-      "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.0.tgz",
+      "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==",
       "engines": {
         "node": "^10 || ^12 || >=14"
       },
@@ -5198,12 +5550,12 @@
       }
     },
     "node_modules/cssnano-preset-advanced": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.3.tgz",
-      "integrity": "sha512-AB9SmTSC2Gd8T7PpKUsXFJ3eNsg7dc4CTZ0+XAJ29MNxyJsrCEk7N1lw31bpHrsQH2PVJr21bbWgGAfA9j0dIA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.8.tgz",
+      "integrity": "sha512-xUlLLnEB1LjpEik+zgRNlk8Y/koBPPtONZjp7JKbXigeAmCrFvq9H0pXW5jJV45bQWAlmJ0sKy+IMr0XxLYQZg==",
       "dependencies": {
         "autoprefixer": "^10.3.7",
-        "cssnano-preset-default": "^5.2.7",
+        "cssnano-preset-default": "^5.2.12",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -5217,35 +5569,35 @@
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.7.tgz",
-      "integrity": "sha512-JiKP38ymZQK+zVKevphPzNSGHSlTI+AOwlasoSRtSVMUU285O7/6uZyd5NbW92ZHp41m0sSHe6JoZosakj63uA==",
+      "version": "5.2.12",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
+      "integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
       "dependencies": {
-        "css-declaration-sorter": "^6.2.2",
+        "css-declaration-sorter": "^6.3.0",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
         "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.0",
-        "postcss-discard-comments": "^5.1.1",
+        "postcss-convert-values": "^5.1.2",
+        "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.4",
-        "postcss-merge-rules": "^5.1.1",
+        "postcss-merge-longhand": "^5.1.6",
+        "postcss-merge-rules": "^5.1.2",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.2",
-        "postcss-minify-selectors": "^5.2.0",
+        "postcss-minify-params": "^5.1.3",
+        "postcss-minify-selectors": "^5.2.1",
         "postcss-normalize-charset": "^5.1.0",
         "postcss-normalize-display-values": "^5.1.0",
-        "postcss-normalize-positions": "^5.1.0",
-        "postcss-normalize-repeat-style": "^5.1.0",
+        "postcss-normalize-positions": "^5.1.1",
+        "postcss-normalize-repeat-style": "^5.1.1",
         "postcss-normalize-string": "^5.1.0",
         "postcss-normalize-timing-functions": "^5.1.0",
         "postcss-normalize-unicode": "^5.1.0",
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
-        "postcss-ordered-values": "^5.1.1",
+        "postcss-ordered-values": "^5.1.3",
         "postcss-reduce-initial": "^5.1.0",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
@@ -5497,9 +5849,9 @@
       }
     },
     "node_modules/domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "funding": [
         {
           "type": "github",
@@ -5575,8 +5927,7 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -5584,9 +5935,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.118",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.118.tgz",
-      "integrity": "sha512-maZIKjnYDvF7Fs35nvVcyr44UcKNwybr93Oba2n3HkKDFAtk0svERkLN/HyczJDS3Fo4wU9th9fUQd09ZLtj1w=="
+      "version": "1.4.176",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.176.tgz",
+      "integrity": "sha512-92JdgyRlcNDwuy75MjuFSb3clt6DGJ2IXSpg0MCjKd3JV9eSmuUAIyWiGAp/EtT0z2D4rqbYqThQLV90maH3Zw=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -7167,6 +7518,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -7975,7 +8334,7 @@
     "node_modules/lodash.curry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
+      "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -8000,7 +8359,7 @@
     "node_modules/lodash.flow": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
+      "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
     },
     "node_modules/lodash.foreach": {
       "version": "4.5.0",
@@ -8165,14 +8524,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/make-dir": {
@@ -8390,40 +8741,70 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
-      "integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz",
+      "integrity": "sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==",
       "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0",
-        "webpack-sources": "^1.1.0"
+        "schema-utils": "^4.0.0"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 12.13.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^4.4.0 || ^5.0.0"
+        "webpack": "^5.0.0"
       }
     },
-    "node_modules/mini-css-extract-plugin/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/webpack-sources": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.8.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -8557,9 +8938,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
+      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -8572,7 +8953,7 @@
     "node_modules/normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8881,11 +9262,51 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
       "dependencies": {
-        "parse5": "^6.0.1"
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+      "dependencies": {
+        "entities": "^4.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -9121,10 +9542,11 @@
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.0.tgz",
-      "integrity": "sha512-GkyPbZEYJiWtQB0KZ0X6qusqFHUepguBCNFi9t5JJc7I2OTXG7C0twbTLvCfaKOLl3rSXmpAwV7W5txd91V84g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
+      "integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
       "dependencies": {
+        "browserslist": "^4.20.3",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -9135,9 +9557,9 @@
       }
     },
     "node_modules/postcss-discard-comments": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
-      "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
       "engines": {
         "node": "^10 || ^12 || >=14.0"
       },
@@ -9229,9 +9651,9 @@
       }
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.4.tgz",
-      "integrity": "sha512-hbqRRqYfmXoGpzYKeW0/NCZhvNyQIlQeWVSao5iKWdyx7skLvCfQFGIUsP9NUs3dSbPac2IC4Go85/zG+7MlmA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
+      "integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
         "stylehacks": "^5.1.0"
@@ -9244,9 +9666,9 @@
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.1.tgz",
-      "integrity": "sha512-8wv8q2cXjEuCcgpIB1Xx1pIy8/rhMPIQqYKNzEdyx37m6gpq83mQQdCxgIkFgliyEnKvdwJf/C61vN4tQDq4Ww==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
+      "integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
       "dependencies": {
         "browserslist": "^4.16.6",
         "caniuse-api": "^3.0.0",
@@ -9291,9 +9713,9 @@
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.2.tgz",
-      "integrity": "sha512-aEP+p71S/urY48HWaRHasyx4WHQJyOYaKpQ6eXl8k0kxg66Wt/30VR6/woh8THgcpRbonJD5IeD+CzNhPi1L8g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
+      "integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
       "dependencies": {
         "browserslist": "^4.16.6",
         "cssnano-utils": "^3.1.0",
@@ -9307,9 +9729,9 @@
       }
     },
     "node_modules/postcss-minify-selectors": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.0.tgz",
-      "integrity": "sha512-vYxvHkW+iULstA+ctVNx0VoRAR4THQQRkG77o0oa4/mBS0OzGvvzLIvHDv/nNEM0crzN2WIyFU5X7wZhaUK3RA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
+      "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
       "dependencies": {
         "postcss-selector-parser": "^6.0.5"
       },
@@ -9401,9 +9823,9 @@
       }
     },
     "node_modules/postcss-normalize-positions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.0.tgz",
-      "integrity": "sha512-8gmItgA4H5xiUxgN/3TVvXRoJxkAWLW6f/KKhdsH03atg0cB8ilXnrB5PpSshwVu/dD2ZsRFQcR1OEmSBDAgcQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
+      "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -9415,9 +9837,9 @@
       }
     },
     "node_modules/postcss-normalize-repeat-style": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.0.tgz",
-      "integrity": "sha512-IR3uBjc+7mcWGL6CtniKNQ4Rr5fTxwkaDHwMBDGGs1x9IVRkYIT/M4NelZWkAOBdV6v3Z9S46zqaKGlyzHSchw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
+      "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -9501,9 +9923,9 @@
       }
     },
     "node_modules/postcss-ordered-values": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.1.tgz",
-      "integrity": "sha512-7lxgXF0NaoMIgyihL/2boNAEZKiW0+HkMhdKMTD93CjW8TdCy2hSdj8lsAo+uwm7EDG16Da2Jdmtqpedl0cMfw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
+      "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
       "dependencies": {
         "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
@@ -9670,9 +10092,9 @@
       }
     },
     "node_modules/prism-react-renderer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.1.tgz",
-      "integrity": "sha512-xUeDMEz074d0zc5y6rxiMp/dlC7C+5IDDlaEUlcBOFE2wddz7hz5PNupb087mPwTt7T9BrFmewObfCBuf/LKwQ==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
+      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
       "peerDependencies": {
         "react": ">=0.14.9"
       }
@@ -9788,7 +10210,7 @@
     "node_modules/pure-color": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
-      "integrity": "sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4="
+      "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
     },
     "node_modules/qs": {
       "version": "6.9.7",
@@ -9799,6 +10221,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/queue": {
@@ -9895,7 +10326,7 @@
     "node_modules/react-base16-styling": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
-      "integrity": "sha1-7yFW1mz0E5aVyKFniGy2nqZgeSw=",
+      "integrity": "sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==",
       "dependencies": {
         "base16": "^1.0.0",
         "lodash.curry": "^4.0.1",
@@ -10129,18 +10560,20 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
-    "node_modules/react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+    "node_modules/react-helmet-async": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
       "dependencies": {
-        "object-assign": "^4.1.1",
+        "@babel/runtime": "^7.12.5",
+        "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
+        "react-fast-compare": "^3.2.0",
+        "shallowequal": "^1.1.0"
       },
       "peerDependencies": {
-        "react": ">=16.3.0"
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {
@@ -10257,28 +10690,20 @@
         "react": ">=15"
       }
     },
-    "node_modules/react-side-effect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0"
-      }
-    },
     "node_modules/react-textarea-autosize": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
-      "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
+      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.2",
-        "use-composed-ref": "^1.0.0",
-        "use-latest": "^1.0.0"
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -10539,30 +10964,6 @@
         "is-alphabetical": "1.0.4",
         "remark-parse": "8.0.3",
         "unified": "9.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-mdx-remove-exports": {
-      "version": "1.6.22",
-      "resolved": "https://registry.npmjs.org/remark-mdx-remove-exports/-/remark-mdx-remove-exports-1.6.22.tgz",
-      "integrity": "sha512-7g2uiTmTGfz5QyVb+toeX25frbk1Y6yd03RXGPtqx0+DVh86Gb7MkNYbk7H2X27zdZ3CQv1W/JqlFO0Oo8IxVA==",
-      "dependencies": {
-        "unist-util-remove": "2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-mdx-remove-imports": {
-      "version": "1.6.22",
-      "resolved": "https://registry.npmjs.org/remark-mdx-remove-imports/-/remark-mdx-remove-imports-1.6.22.tgz",
-      "integrity": "sha512-lmjAXD8Ltw0TsvBzb45S+Dxx7LTJAtDaMneMAv8LAUIPEyYoKkmGbmVsiF0/pY6mhM1Q16swCmu1TN+ie/vn/A==",
-      "dependencies": {
-        "unist-util-remove": "2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11189,7 +11590,7 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -11206,6 +11607,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -11391,11 +11797,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "node_modules/space-separated-tokens": {
       "version": "1.1.5",
@@ -11799,7 +12200,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/trim": {
       "version": "0.0.1",
@@ -12088,6 +12489,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
+      "integrity": "sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/update-notifier": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
@@ -12246,14 +12672,14 @@
       }
     },
     "node_modules/use-latest": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.0.tgz",
-      "integrity": "sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
       "dependencies": {
-        "use-isomorphic-layout-effect": "^1.0.0"
+        "use-isomorphic-layout-effect": "^1.1.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -12395,7 +12821,7 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
       "version": "5.72.0",
@@ -12860,7 +13286,7 @@
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -13041,95 +13467,95 @@
   },
   "dependencies": {
     "@algolia/autocomplete-core": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.5.2.tgz",
-      "integrity": "sha512-DY0bhyczFSS1b/CqJlTE/nQRtnTAHl6IemIkBy0nEWnhDzRDdtdx4p5Uuk3vwAFxwEEgi1WqKwgSSMx6DpNL4A==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
+      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.5.2"
+        "@algolia/autocomplete-shared": "1.7.1"
       }
     },
     "@algolia/autocomplete-preset-algolia": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.5.2.tgz",
-      "integrity": "sha512-3MRYnYQFJyovANzSX2CToS6/5cfVjbLLqFsZTKcvF3abhQzxbqwwaMBlJtt620uBUOeMzhdfasKhCc40+RHiZw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
+      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.5.2"
+        "@algolia/autocomplete-shared": "1.7.1"
       }
     },
     "@algolia/autocomplete-shared": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.5.2.tgz",
-      "integrity": "sha512-ylQAYv5H0YKMfHgVWX0j0NmL8XBcAeeeVQUmppnnMtzDbDnca6CzhKj3Q8eF9cHCgcdTDdb5K+3aKyGWA0obug=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
+      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.13.0.tgz",
-      "integrity": "sha512-nj1vHRZauTqP/bluwkRIgEADEimqojJgoTRCel5f6q8WCa9Y8QeI4bpDQP28FoeKnDRYa3J5CauDlN466jqRhg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.13.1.tgz",
+      "integrity": "sha512-UAUVG2PEfwd/FfudsZtYnidJ9eSCpS+LW9cQiesePQLz41NAcddKxBak6eP2GErqyFagSlnVXe/w2E9h2m2ttg==",
       "requires": {
-        "@algolia/cache-common": "4.13.0"
+        "@algolia/cache-common": "4.13.1"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.13.0.tgz",
-      "integrity": "sha512-f9mdZjskCui/dA/fA/5a+6hZ7xnHaaZI5tM/Rw9X8rRB39SUlF/+o3P47onZ33n/AwkpSbi5QOyhs16wHd55kA=="
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.13.1.tgz",
+      "integrity": "sha512-7Vaf6IM4L0Jkl3sYXbwK+2beQOgVJ0mKFbz/4qSxKd1iy2Sp77uTAazcX+Dlexekg1fqGUOSO7HS4Sx47ZJmjA=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.13.0.tgz",
-      "integrity": "sha512-hHdc+ahPiMM92CQMljmObE75laYzNFYLrNOu0Q3/eyvubZZRtY2SUsEEgyUEyzXruNdzrkcDxFYa7YpWBJYHAg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.13.1.tgz",
+      "integrity": "sha512-pZzybCDGApfA/nutsFK1P0Sbsq6fYJU3DwIvyKg4pURerlJM4qZbB9bfLRef0FkzfQu7W11E4cVLCIOWmyZeuQ==",
       "requires": {
-        "@algolia/cache-common": "4.13.0"
+        "@algolia/cache-common": "4.13.1"
       }
     },
     "@algolia/client-account": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.13.0.tgz",
-      "integrity": "sha512-FzFqFt9b0g/LKszBDoEsW+dVBuUe1K3scp2Yf7q6pgHWM1WqyqUlARwVpLxqyc+LoyJkTxQftOKjyFUqddnPKA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.13.1.tgz",
+      "integrity": "sha512-TFLiZ1KqMiir3FNHU+h3b0MArmyaHG+eT8Iojio6TdpeFcAQ1Aiy+2gb3SZk3+pgRJa/BxGmDkRUwE5E/lv3QQ==",
       "requires": {
-        "@algolia/client-common": "4.13.0",
-        "@algolia/client-search": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/client-common": "4.13.1",
+        "@algolia/client-search": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.13.0.tgz",
-      "integrity": "sha512-klmnoq2FIiiMHImkzOm+cGxqRLLu9CMHqFhbgSy9wtXZrqb8BBUIUE2VyBe7azzv1wKcxZV2RUyNOMpFqmnRZA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.13.1.tgz",
+      "integrity": "sha512-iOS1JBqh7xaL5x00M5zyluZ9+9Uy9GqtYHv/2SMuzNW1qP7/0doz1lbcsP3S7KBbZANJTFHUOfuqyRLPk91iFA==",
       "requires": {
-        "@algolia/client-common": "4.13.0",
-        "@algolia/client-search": "4.13.0",
-        "@algolia/requester-common": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/client-common": "4.13.1",
+        "@algolia/client-search": "4.13.1",
+        "@algolia/requester-common": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "@algolia/client-common": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.13.0.tgz",
-      "integrity": "sha512-GoXfTp0kVcbgfSXOjfrxx+slSipMqGO9WnNWgeMmru5Ra09MDjrcdunsiiuzF0wua6INbIpBQFTC2Mi5lUNqGA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.13.1.tgz",
+      "integrity": "sha512-LcDoUE0Zz3YwfXJL6lJ2OMY2soClbjrrAKB6auYVMNJcoKZZ2cbhQoFR24AYoxnGUYBER/8B+9sTBj5bj/Gqbg==",
       "requires": {
-        "@algolia/requester-common": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/requester-common": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.13.0.tgz",
-      "integrity": "sha512-KneLz2WaehJmNfdr5yt2HQETpLaCYagRdWwIwkTqRVFCv4DxRQ2ChPVW9jeTj4YfAAhfzE6F8hn7wkQ/Jfj6ZA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.13.1.tgz",
+      "integrity": "sha512-1CqrOW1ypVrB4Lssh02hP//YxluoIYXAQCpg03L+/RiXJlCs+uIqlzC0ctpQPmxSlTK6h07kr50JQoYH/TIM9w==",
       "requires": {
-        "@algolia/client-common": "4.13.0",
-        "@algolia/requester-common": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/client-common": "4.13.1",
+        "@algolia/requester-common": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "@algolia/client-search": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.13.0.tgz",
-      "integrity": "sha512-blgCKYbZh1NgJWzeGf+caKE32mo3j54NprOf0LZVCubQb3Kx37tk1Hc8SDs9bCAE8hUvf3cazMPIg7wscSxspA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.13.1.tgz",
+      "integrity": "sha512-YQKYA83MNRz3FgTNM+4eRYbSmHi0WWpo019s5SeYcL3HUan/i5R09VO9dk3evELDFJYciiydSjbsmhBzbpPP2A==",
       "requires": {
-        "@algolia/client-common": "4.13.0",
-        "@algolia/requester-common": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/client-common": "4.13.1",
+        "@algolia/requester-common": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "@algolia/events": {
@@ -13138,47 +13564,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/logger-common": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.13.0.tgz",
-      "integrity": "sha512-8yqXk7rMtmQJ9wZiHOt/6d4/JDEg5VCk83gJ39I+X/pwUPzIsbKy9QiK4uJ3aJELKyoIiDT1hpYVt+5ia+94IA=="
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.13.1.tgz",
+      "integrity": "sha512-L6slbL/OyZaAXNtS/1A8SAbOJeEXD5JcZeDCPYDqSTYScfHu+2ePRTDMgUTY4gQ7HsYZ39N1LujOd8WBTmM2Aw=="
     },
     "@algolia/logger-console": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.13.0.tgz",
-      "integrity": "sha512-YepRg7w2/87L0vSXRfMND6VJ5d6699sFJBRWzZPOlek2p5fLxxK7O0VncYuc/IbVHEgeApvgXx0WgCEa38GVuQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.13.1.tgz",
+      "integrity": "sha512-7jQOTftfeeLlnb3YqF8bNgA2GZht7rdKkJ31OCeSH2/61haO0tWPoNRjZq9XLlgMQZH276pPo0NdiArcYPHjCA==",
       "requires": {
-        "@algolia/logger-common": "4.13.0"
+        "@algolia/logger-common": "4.13.1"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.13.0.tgz",
-      "integrity": "sha512-Dj+bnoWR5MotrnjblzGKZ2kCdQi2cK/VzPURPnE616NU/il7Ypy6U6DLGZ/ZYz+tnwPa0yypNf21uqt84fOgrg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.13.1.tgz",
+      "integrity": "sha512-oa0CKr1iH6Nc7CmU6RE7TnXMjHnlyp7S80pP/LvZVABeJHX3p/BcSCKovNYWWltgTxUg0U1o+2uuy8BpMKljwA==",
       "requires": {
-        "@algolia/requester-common": "4.13.0"
+        "@algolia/requester-common": "4.13.1"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.13.0.tgz",
-      "integrity": "sha512-BRTDj53ecK+gn7ugukDWOOcBRul59C4NblCHqj4Zm5msd5UnHFjd/sGX+RLOEoFMhetILAnmg6wMrRrQVac9vw=="
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.13.1.tgz",
+      "integrity": "sha512-eGVf0ID84apfFEuXsaoSgIxbU3oFsIbz4XiotU3VS8qGCJAaLVUC5BUJEkiFENZIhon7hIB4d0RI13HY4RSA+w=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.13.0.tgz",
-      "integrity": "sha512-9b+3O4QFU4azLhGMrZAr/uZPydvzOR4aEZfSL8ZrpLZ7fbbqTO0S/5EVko+QIgglRAtVwxvf8UJ1wzTD2jvKxQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.13.1.tgz",
+      "integrity": "sha512-7C0skwtLdCz5heKTVe/vjvrqgL/eJxmiEjHqXdtypcE5GCQCYI15cb+wC4ytYioZDMiuDGeVYmCYImPoEgUGPw==",
       "requires": {
-        "@algolia/requester-common": "4.13.0"
+        "@algolia/requester-common": "4.13.1"
       }
     },
     "@algolia/transporter": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.13.0.tgz",
-      "integrity": "sha512-8tSQYE+ykQENAdeZdofvtkOr5uJ9VcQSWgRhQ9h01AehtBIPAczk/b2CLrMsw5yQZziLs5cZ3pJ3478yI+urhA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.13.1.tgz",
+      "integrity": "sha512-pICnNQN7TtrcYJqqPEXByV8rJ8ZRU2hCiIKLTLRyNpghtQG3VAFk6fVtdzlNfdUGZcehSKGarPIZEHlQXnKjgw==",
       "requires": {
-        "@algolia/cache-common": "4.13.0",
-        "@algolia/logger-common": "4.13.0",
-        "@algolia/requester-common": "4.13.0"
+        "@algolia/cache-common": "4.13.1",
+        "@algolia/logger-common": "4.13.1",
+        "@algolia/requester-common": "4.13.1"
       }
     },
     "@ampproject/remapping": {
@@ -14364,78 +14790,86 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "optional": true
+    },
     "@docsearch/css": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0.tgz",
-      "integrity": "sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.1.1.tgz",
+      "integrity": "sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg=="
     },
     "@docsearch/react": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0.tgz",
-      "integrity": "sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==",
       "requires": {
-        "@algolia/autocomplete-core": "1.5.2",
-        "@algolia/autocomplete-preset-algolia": "1.5.2",
-        "@docsearch/css": "3.0.0",
+        "@algolia/autocomplete-core": "1.7.1",
+        "@algolia/autocomplete-preset-algolia": "1.7.1",
+        "@docsearch/css": "3.1.1",
         "algoliasearch": "^4.0.0"
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.15.tgz",
-      "integrity": "sha512-zXhhD0fApMSvq/9Pkm9DQxa//hGOXVCq9yMHiXOkI5D1tLec7PxtnaC5cLfGHljkN9cKIfRDYUVcG1gHymVfpA==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.16.tgz",
+      "integrity": "sha512-0AbNSpTKapz+tctg7PHvuGQRtW7nd3Tm3axNqnFowO3SV2VvFCaBji2s1H3XCGXVRGveQ04g20vl2ZqG5GheUA==",
       "requires": {
-        "@babel/core": "^7.16.0",
-        "@babel/generator": "^7.16.0",
+        "@babel/core": "^7.17.5",
+        "@babel/generator": "^7.17.3",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.16.0",
-        "@babel/preset-env": "^7.16.4",
-        "@babel/preset-react": "^7.16.0",
-        "@babel/preset-typescript": "^7.16.0",
-        "@babel/runtime": "^7.16.3",
-        "@babel/runtime-corejs3": "^7.16.3",
-        "@babel/traverse": "^7.16.3",
-        "@docusaurus/cssnano-preset": "2.0.0-beta.15",
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/mdx-loader": "2.0.0-beta.15",
+        "@babel/plugin-transform-runtime": "^7.17.0",
+        "@babel/preset-env": "^7.16.11",
+        "@babel/preset-react": "^7.16.7",
+        "@babel/preset-typescript": "^7.16.7",
+        "@babel/runtime": "^7.17.2",
+        "@babel/runtime-corejs3": "^7.17.2",
+        "@babel/traverse": "^7.17.3",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/mdx-loader": "2.0.0-beta.16",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-common": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.0",
-        "@svgr/webpack": "^6.0.0",
-        "autoprefixer": "^10.3.5",
-        "babel-loader": "^8.2.2",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-common": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@slorber/static-site-generator-webpack-plugin": "^4.0.1",
+        "@svgr/webpack": "^6.2.1",
+        "autoprefixer": "^10.4.2",
+        "babel-loader": "^8.2.3",
         "babel-plugin-dynamic-import-node": "2.3.0",
-        "boxen": "^5.0.1",
-        "chokidar": "^3.5.2",
-        "clean-css": "^5.1.5",
+        "boxen": "^6.2.1",
+        "chokidar": "^3.5.3",
+        "clean-css": "^5.2.4",
+        "cli-table3": "^0.6.1",
+        "combine-promises": "^1.1.0",
         "commander": "^5.1.0",
-        "copy-webpack-plugin": "^10.2.0",
-        "core-js": "^3.18.0",
-        "css-loader": "^6.5.1",
-        "css-minimizer-webpack-plugin": "^3.3.1",
-        "cssnano": "^5.0.8",
+        "copy-webpack-plugin": "^10.2.4",
+        "core-js": "^3.21.1",
+        "css-loader": "^6.6.0",
+        "css-minimizer-webpack-plugin": "^3.4.1",
+        "cssnano": "^5.0.17",
         "del": "^6.0.0",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
         "eta": "^1.12.3",
         "file-loader": "^6.2.0",
-        "fs-extra": "^10.0.0",
-        "html-minifier-terser": "^6.0.2",
+        "fs-extra": "^10.0.1",
+        "html-minifier-terser": "^6.1.0",
         "html-tags": "^3.1.0",
-        "html-webpack-plugin": "^5.4.0",
+        "html-webpack-plugin": "^5.5.0",
         "import-fresh": "^3.3.0",
         "is-root": "^2.1.0",
         "leven": "^3.1.0",
-        "lodash": "^4.17.20",
-        "mini-css-extract-plugin": "^1.6.0",
+        "lodash": "^4.17.21",
+        "mini-css-extract-plugin": "^2.5.3",
         "nprogress": "^0.2.0",
-        "postcss": "^8.3.7",
-        "postcss-loader": "^6.1.1",
-        "prompts": "^2.4.1",
+        "postcss": "^8.4.6",
+        "postcss-loader": "^6.2.1",
+        "prompts": "^2.4.2",
         "react-dev-utils": "^12.0.0",
-        "react-helmet": "^6.1.0",
+        "react-helmet-async": "^1.2.3",
         "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
         "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
         "react-router": "^5.2.0",
@@ -14445,34 +14879,156 @@
         "rtl-detect": "^1.0.4",
         "semver": "^7.3.4",
         "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.4",
-        "strip-ansi": "^6.0.0",
-        "terser-webpack-plugin": "^5.2.4",
+        "shelljs": "^0.8.5",
+        "terser-webpack-plugin": "^5.3.1",
         "tslib": "^2.3.1",
         "update-notifier": "^5.1.0",
         "url-loader": "^4.1.1",
-        "wait-on": "^6.0.0",
-        "webpack": "^5.61.0",
-        "webpack-bundle-analyzer": "^4.4.2",
-        "webpack-dev-server": "^4.7.1",
+        "wait-on": "^6.0.1",
+        "webpack": "^5.69.1",
+        "webpack-bundle-analyzer": "^4.5.0",
+        "webpack-dev-server": "^4.7.4",
         "webpack-merge": "^5.8.0",
         "webpackbar": "^5.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "boxen": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-6.2.1.tgz",
+          "integrity": "sha512-H4PEsJXfFI/Pt8sjDWbHlQPx4zL/bvSQjcilJmaulGt5mLDorHOHpmdXAJcBcmru7PhYSp/cDMWRko4ZUMFkSw==",
+          "requires": {
+            "ansi-align": "^3.0.1",
+            "camelcase": "^6.2.0",
+            "chalk": "^4.1.2",
+            "cli-boxes": "^3.0.0",
+            "string-width": "^5.0.1",
+            "type-fest": "^2.5.0",
+            "widest-line": "^4.0.1",
+            "wrap-ansi": "^8.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cli-boxes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+          "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.15.1.tgz",
+          "integrity": "sha512-LYSjcIz3NmoQksXq/3/B7Nfad+T8mkaI628agAAnHCpXPTBRMK2ygt3eABpzII8CbZZM8dLdVQ4Gr8ousjFjMw=="
+        },
+        "widest-line": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+          "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+          "requires": {
+            "string-width": "^5.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
+          "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.0.tgz",
+              "integrity": "sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ=="
+            }
+          }
+        }
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.15.tgz",
-      "integrity": "sha512-55aYURbB5dqrx64lStNcZxDx5R6bKkAawlCB7mDKx3r+Qnp3ofGW7UExLQSCbTu3axT1vJCF5D7H6ljTRYJLtA==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.16.tgz",
+      "integrity": "sha512-dkGpb+xoFNmcp5m5EpwGcFlMT4C7kOTzgZ73QoNoU930NL6OXuqcJdMd4XI6yYuGz+t8Bo8UzzCryEjHTiObOg==",
       "requires": {
-        "cssnano-preset-advanced": "^5.1.4",
-        "postcss": "^8.3.7",
-        "postcss-sort-media-queries": "^4.1.0"
+        "cssnano-preset-advanced": "^5.1.12",
+        "postcss": "^8.4.6",
+        "postcss-sort-media-queries": "^4.2.1"
       }
     },
     "@docusaurus/logger": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.15.tgz",
-      "integrity": "sha512-5bDSHCyLfMtz6QnFfICdL5mgxbGfC7DW1V+/Q17nRdpZSPZgsNKK/Esp0zdDi1oxAyEpXMXx64nLaHL7joJxIg==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.16.tgz",
+      "integrity": "sha512-/fta5gCXHMLip+8WxYoi+hlB1pwJEeVpFc7Z4iIMwAxn8SrcmCJ0K3wPNjZpDdz0EHrpLHEJ/vEkCuL+7Su4ZQ==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.3.1"
@@ -14524,18 +15080,18 @@
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.15.tgz",
-      "integrity": "sha512-MVpytjDDao7hmPF1QSs9B5zoTgevZjiqjnX3FM1yjqdCv+chyUo0gnmYHjeG/4Gqu7jucp+dDdp6yQpzs4g09A==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.16.tgz",
+      "integrity": "sha512-NR0Cptz4UGlzgu08AITffRL4rj+SU8HYq2yNFxbY8FSuj/GWI3SrSsBi7grB6fKql0s4SGUKEEzSweewzW1Rgg==",
       "requires": {
-        "@babel/parser": "^7.16.4",
-        "@babel/traverse": "^7.16.3",
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@mdx-js/mdx": "^1.6.21",
+        "@babel/parser": "^7.17.3",
+        "@babel/traverse": "^7.17.3",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^10.0.1",
         "image-size": "^1.0.1",
         "mdast-util-to-string": "^2.0.0",
         "remark-emoji": "^2.1.0",
@@ -14543,131 +15099,141 @@
         "tslib": "^2.3.1",
         "unist-util-visit": "^2.0.2",
         "url-loader": "^4.1.1",
-        "webpack": "^5.61.0"
+        "webpack": "^5.69.1"
+      }
+    },
+    "@docusaurus/module-type-aliases": {
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.16.tgz",
+      "integrity": "sha512-x6/JlbrSfhGuDc6dWybt/E1T6xh/jjEJemlizAGArHpKB0mTuxRm5FRCmksX7z7IM8HZs43tpftGS8gXNL5gug==",
+      "requires": {
+        "@docusaurus/types": "2.0.0-beta.16",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*"
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.15.tgz",
-      "integrity": "sha512-VtEwkgkoNIS8JFPe+huBeBuJ8HG8Lq1JNYM/ItwQg/cwGAgP8EgwbEuKDn428oZKEI2PpgAuf5Gv4AzJWIes9A==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.16.tgz",
+      "integrity": "sha512-JSRzNKpuMPAndIDIZKbA4G2rA0sC3jPHO+TOmBliO8SBUkw1DL58MZTp98y+5EeUg+KjNIYoz7wRMj3YhFIhJA==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/mdx-loader": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-common": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/mdx-loader": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-common": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
         "cheerio": "^1.0.0-rc.10",
         "feed": "^4.2.2",
-        "fs-extra": "^10.0.0",
-        "lodash": "^4.17.20",
+        "fs-extra": "^10.0.1",
+        "lodash": "^4.17.21",
         "reading-time": "^1.5.0",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.61.0"
+        "webpack": "^5.69.1"
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.15.tgz",
-      "integrity": "sha512-HSwNZdUKz4rpJiGbFjl/OFhSleeZUSZ6E6lk98i4iL1A5u6fIm4CHsT53yp4UUOse+lFrePTFZsyqwMA4nZZYA==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.16.tgz",
+      "integrity": "sha512-IiNEud1WYj9a0rkNHjX1JNLfim8f6pyB5w17arRDK6HiY3w51zCQsZJo0popRp1KQQf/g66I+5Y3qP5rHGeU6Q==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/mdx-loader": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/mdx-loader": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
         "combine-promises": "^1.1.0",
-        "fs-extra": "^10.0.0",
-        "import-fresh": "^3.2.2",
-        "js-yaml": "^4.0.0",
-        "lodash": "^4.17.20",
+        "fs-extra": "^10.0.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "remark-admonitions": "^1.2.1",
-        "shelljs": "^0.8.4",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.61.0"
+        "webpack": "^5.69.1"
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.15.tgz",
-      "integrity": "sha512-N7YhW5RiOY6J228z4lOoP//qX0Q48cRtxDONZ/Ohd9C5OI2vS6TD8iQuDqOIYHxH+BshjNSsKvbJ+SMIQDwysg==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.16.tgz",
+      "integrity": "sha512-XH/dNfDhnad7qA+RUdyJW94Yf8LzALz0bJRwp8GbtjXeAmfP/DWGvVPT/egd9Pz99uO5UgiO9vR1i7UlktQSwA==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/mdx-loader": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
-        "fs-extra": "^10.0.0",
-        "globby": "^11.0.2",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/mdx-loader": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "fs-extra": "^10.0.1",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
-        "webpack": "^5.61.0"
+        "webpack": "^5.69.1"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.15.tgz",
-      "integrity": "sha512-Jth11jB/rVqPwCGdkVKSUWeXZPAr/NyPn+yeknTBk2LgQKBJ3YU5dNG0uyt0Ay+UYT01TkousPJkXhLuy4Qrsw==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.16.tgz",
+      "integrity": "sha512-uzp4hrL/PozgDNEWF/Y+DH+nH0GoC+dOyNLqsyFqQLlzykFHTJYLMK1tfwKHUJ3WqhQFbRwLTR4rzFC89Kaf7g==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "fs-extra": "^10.0.0",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "fs-extra": "^10.0.1",
         "react-json-view": "^1.21.3",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.15.tgz",
-      "integrity": "sha512-ELAnxNYiC2i7gfu/ViurNIdm1/DdnbEfVDmpffS9niQhOREM1U3jpxkz/ff1GIC6heOLyHTtini/CZBDoroVGw==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.16.tgz",
+      "integrity": "sha512-UKd1RWYHeSm/RLjJ2ZflLTT6hbiWQWFAxVzYRBiyOnDbBP+un8qmP692QZCIP+rrm+KkxsV1FGte0NtrcsFUEw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.15.tgz",
-      "integrity": "sha512-E5Rm3+dN7i3A9V5uq5sl9xTNA3aXsLwTZEA2SpOkY571dCpd+sfVvz1lR+KRY9Fy6ZHk8PqrNImgCWfIerRuZQ==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.16.tgz",
+      "integrity": "sha512-WUD1Kh5y/9VaV/ubg8c6a43gE2+N+yeLUL/qfrUZuLHheaBaozGjioHRbndmfN6W7l2EhuxO1QRN3SlBqc7kjA==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.15.tgz",
-      "integrity": "sha512-PBjeQb2Qpe4uPdRefWL/eXCeYjrgNB/UArExYeUuP4wiY1dpw2unGNCvFUxv4hzJGmARoTLsnRkeYkUim809LQ==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.16.tgz",
+      "integrity": "sha512-B8fa2qvScNSiuCos6vZjPERikRTbbebzy33s5zV+VTZsqLtrjs4//Y0HlJ0tuz5qHWCzavb6nFX/mgFAJoyqFQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-common": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
-        "fs-extra": "^10.0.0",
-        "sitemap": "^7.0.0",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-common": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "fs-extra": "^10.0.1",
+        "sitemap": "^7.1.1",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.15.tgz",
-      "integrity": "sha512-3NZIXWTAzk+kOgiB8uAbD+FZv3VFR1qkU6+TW24DRenjRnXof3CkRuldhI1QI0hILm1fuJ319QRkakV8FFtXyA==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.16.tgz",
+      "integrity": "sha512-HLY2dC412Lexe2ZupUEUJpY44yz6uqtvibKTXvXH392hFB43Thp7MKr5zACRTwacjbddIoqPVbdzRWtvugSU2g==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.15",
-        "@docusaurus/plugin-debug": "2.0.0-beta.15",
-        "@docusaurus/plugin-google-analytics": "2.0.0-beta.15",
-        "@docusaurus/plugin-google-gtag": "2.0.0-beta.15",
-        "@docusaurus/plugin-sitemap": "2.0.0-beta.15",
-        "@docusaurus/theme-classic": "2.0.0-beta.15",
-        "@docusaurus/theme-common": "2.0.0-beta.15",
-        "@docusaurus/theme-search-algolia": "2.0.0-beta.15"
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
+        "@docusaurus/plugin-debug": "2.0.0-beta.16",
+        "@docusaurus/plugin-google-analytics": "2.0.0-beta.16",
+        "@docusaurus/plugin-google-gtag": "2.0.0-beta.16",
+        "@docusaurus/plugin-sitemap": "2.0.0-beta.16",
+        "@docusaurus/theme-classic": "2.0.0-beta.16",
+        "@docusaurus/theme-common": "2.0.0-beta.16",
+        "@docusaurus/theme-search-algolia": "2.0.0-beta.16"
       }
     },
     "@docusaurus/react-loadable": {
@@ -14680,126 +15246,129 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.15.tgz",
-      "integrity": "sha512-WwNRcQvMtQ7KDhOEHFKFHxXCdoZwLg66hT3vhqNIFMfGQuPzOP91MX5LUSo1QWHhlrD3H3Og+r7Ik/fy2bf5lQ==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.16.tgz",
+      "integrity": "sha512-7cylhb2hwAUSM+ZD2ClQwS/Ag8tnt5gTDrma9WzWA+sB7Zd/b5Dc9WHFowzUjieC++UZ+KxYktCfKE/1RWF77w==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.15",
-        "@docusaurus/theme-common": "2.0.0-beta.15",
-        "@docusaurus/theme-translations": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-common": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
-        "@mdx-js/react": "^1.6.21",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
+        "@docusaurus/theme-common": "2.0.0-beta.16",
+        "@docusaurus/theme-translations": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-common": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
         "copy-text-to-clipboard": "^3.0.1",
         "infima": "0.2.0-alpha.37",
-        "lodash": "^4.17.20",
-        "postcss": "^8.3.7",
+        "lodash": "^4.17.21",
+        "postcss": "^8.4.6",
         "prism-react-renderer": "^1.2.1",
-        "prismjs": "^1.23.0",
+        "prismjs": "^1.27.0",
         "react-router-dom": "^5.2.0",
         "rtlcss": "^3.3.0"
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.15.tgz",
-      "integrity": "sha512-+pvarmzcyECE4nWxw+dCMKRIoes0NegrRuM9+nRsUrS/E5ywsF539kpupKIEqaMjq6AuM0CJtDoHxHHPNe0KaQ==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.16.tgz",
+      "integrity": "sha512-7jP+lVrNMlEXH9bUvjnRxyF1MQpIC0Z+FpBmahTwi1lNAVe1kbs3r7SVsXnBHwI4F+tIWaRMkpEfZfNhH1MjNA==",
       "requires": {
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.15",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.15",
+        "@docusaurus/module-type-aliases": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
         "clsx": "^1.1.1",
         "parse-numeric-range": "^1.3.0",
+        "prism-react-renderer": "^1.3.1",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0"
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.15.tgz",
-      "integrity": "sha512-XrrQKyjOPzmEuOcdsaAn1tzNJkNMA3PC86PwPZUaah0cYPpBGptcJYDlIW4VHIrCBfkQvhvmg/B3qKF6bMMi8g==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.16.tgz",
+      "integrity": "sha512-yNQ7nWWAzT+abQiiSgnPT3FDE07KDIt4UZgxEwo2WvynDD4O7G+6uUkBryAZXYvgc2GEMw7u0E/8+2EPbJ5yyg==",
       "requires": {
-        "@docsearch/react": "^3.0.0-alpha.39",
-        "@docusaurus/core": "2.0.0-beta.15",
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/theme-common": "2.0.0-beta.15",
-        "@docusaurus/theme-translations": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "@docusaurus/utils-validation": "2.0.0-beta.15",
-        "algoliasearch": "^4.10.5",
-        "algoliasearch-helper": "^3.5.5",
+        "@docsearch/react": "^3.0.0",
+        "@docusaurus/core": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/theme-common": "2.0.0-beta.16",
+        "@docusaurus/theme-translations": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "algoliasearch": "^4.12.1",
+        "algoliasearch-helper": "^3.7.0",
         "clsx": "^1.1.1",
         "eta": "^1.12.3",
-        "lodash": "^4.17.20",
+        "fs-extra": "^10.0.1",
+        "lodash": "^4.17.21",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0"
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.15.tgz",
-      "integrity": "sha512-Lu2JDsnZaB2BcJe8Hpq5nrbS7+7bd09jT08b9vztQyvzR8PgzsthnzlLN4ilOeamRIuYJKo1pUGm0EsQBOP6Nw==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.16.tgz",
+      "integrity": "sha512-OMYjraIbkQyPEdpPGe4zc9gDUm1FxruyBMcxW9pnqh8BoEogPpyFGTJwXiKzOWS6W+xiyctWJYIYmS5laDkriw==",
       "requires": {
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^10.0.1",
         "tslib": "^2.3.1"
       }
     },
-    "@docusaurus/utils": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.15.tgz",
-      "integrity": "sha512-xkoPmFxCBkDqbZR4U3SE752OcXtWTGgZnc/pZWxItzb1IYRGNZHrzdIr7CnI7rppriuZzsyivDGiC4Ud9MWhkA==",
+    "@docusaurus/types": {
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.16.tgz",
+      "integrity": "sha512-ttej9CFthe9+mDMGKMI1wRegXJHLXUZUhxsiYaGczW7PZXdbCQZvKVAoMtrEp/Oa/KOMtqwva60iEEot//KGnQ==",
       "requires": {
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@mdx-js/runtime": "^1.6.22",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "querystring": "0.2.1",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.69.1",
+        "webpack-merge": "^5.8.0"
+      }
+    },
+    "@docusaurus/utils": {
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.16.tgz",
+      "integrity": "sha512-ngOVqWlT+JvHsWDYH1i0oou9Dhhm6gKcTB3PR3nkIlDOdn+MViuhhKivTBD9et5JxAnf8A1hk/oaUO9tBU7WGA==",
+      "requires": {
+        "@docusaurus/logger": "2.0.0-beta.16",
         "@svgr/webpack": "^6.0.0",
         "file-loader": "^6.2.0",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^10.0.1",
         "github-slugger": "^1.4.0",
         "globby": "^11.0.4",
         "gray-matter": "^4.0.3",
-        "js-yaml": "^4.0.0",
-        "lodash": "^4.17.20",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "micromatch": "^4.0.4",
-        "remark-mdx-remove-exports": "^1.6.22",
-        "remark-mdx-remove-imports": "^1.6.22",
         "resolve-pathname": "^3.0.0",
+        "shelljs": "^0.8.5",
         "tslib": "^2.3.1",
-        "url-loader": "^4.1.1"
-      },
-      "dependencies": {
-        "@mdx-js/runtime": {
-          "version": "1.6.22",
-          "resolved": "https://registry.npmjs.org/@mdx-js/runtime/-/runtime-1.6.22.tgz",
-          "integrity": "sha512-p17spaO2+55VLCuxXA3LVHC4phRx60NR2XMdZ+qgVU1lKvEX4y88dmFNOzGDCPLJ03IZyKrJ/rPWWRiBrd9JrQ==",
-          "requires": {
-            "@mdx-js/mdx": "1.6.22",
-            "@mdx-js/react": "1.6.22",
-            "buble-jsx-only": "^0.19.8"
-          }
-        }
+        "url-loader": "^4.1.1",
+        "webpack": "^5.69.1"
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.15.tgz",
-      "integrity": "sha512-kIGlSIvbE/oniUpUjI8GOkSpH8o4NXbYqAh9dqPn+TJ0KbEFY3fc80gzZQU+9SunCwJMJbIxIGevX9Ry+nackw==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.16.tgz",
+      "integrity": "sha512-xAUBVX/BftMPAw9rvdeIKBKmmAX2xus+HbXciL+5VKNG9ePI5X+W739lCqJVm6C2fDRXENBbeaKnnMx9wTeEUg==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.15.tgz",
-      "integrity": "sha512-1oOVBCkRrsTXSYrBTsMdnj3a/R56zrx11rjF4xo0+dmm8C01Xw4msFtc3uA7VLX0HQvgHsk8xPzU5GERNdsNpg==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.16.tgz",
+      "integrity": "sha512-gXAKMP1D5ERX3d5SF88Yp7G9ROYd2XOhyLSErPRaHs5b9SzYhI9lIiPUoXFk6VyRnUjXiUley2/MtdrEgt989A==",
       "requires": {
-        "@docusaurus/logger": "2.0.0-beta.15",
-        "@docusaurus/utils": "2.0.0-beta.15",
-        "joi": "^17.4.2",
+        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.16",
+        "joi": "^17.6.0",
         "tslib": "^2.3.1"
       }
     },
@@ -15313,6 +15882,11 @@
         "@types/unist": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -15382,6 +15956,35 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz",
+      "integrity": "sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==",
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-config": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-router-config/-/react-router-config-5.0.6.tgz",
+      "integrity": "sha512-db1mx37a1EJDf1XeX8jJN7R3PZABmJQXR8r28yUjVMFSjkmnQo6X6pOEEmNl+Tp2gYQOGPdYbFIipBtdElZ3Yg==",
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/retry": {
@@ -15606,12 +16209,6 @@
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
       "requires": {}
     },
-    "acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
-    },
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
@@ -15675,30 +16272,30 @@
       "requires": {}
     },
     "algoliasearch": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.13.0.tgz",
-      "integrity": "sha512-oHv4faI1Vl2s+YC0YquwkK/TsaJs79g2JFg5FDm2rKN12VItPTAeQ7hyJMHarOPPYuCnNC5kixbtcqvb21wchw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.13.1.tgz",
+      "integrity": "sha512-dtHUSE0caWTCE7liE1xaL+19AFf6kWEcyn76uhcitWpntqvicFHXKFoZe5JJcv9whQOTRM6+B8qJz6sFj+rDJA==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.13.0",
-        "@algolia/cache-common": "4.13.0",
-        "@algolia/cache-in-memory": "4.13.0",
-        "@algolia/client-account": "4.13.0",
-        "@algolia/client-analytics": "4.13.0",
-        "@algolia/client-common": "4.13.0",
-        "@algolia/client-personalization": "4.13.0",
-        "@algolia/client-search": "4.13.0",
-        "@algolia/logger-common": "4.13.0",
-        "@algolia/logger-console": "4.13.0",
-        "@algolia/requester-browser-xhr": "4.13.0",
-        "@algolia/requester-common": "4.13.0",
-        "@algolia/requester-node-http": "4.13.0",
-        "@algolia/transporter": "4.13.0"
+        "@algolia/cache-browser-local-storage": "4.13.1",
+        "@algolia/cache-common": "4.13.1",
+        "@algolia/cache-in-memory": "4.13.1",
+        "@algolia/client-account": "4.13.1",
+        "@algolia/client-analytics": "4.13.1",
+        "@algolia/client-common": "4.13.1",
+        "@algolia/client-personalization": "4.13.1",
+        "@algolia/client-search": "4.13.1",
+        "@algolia/logger-common": "4.13.1",
+        "@algolia/logger-console": "4.13.1",
+        "@algolia/requester-browser-xhr": "4.13.1",
+        "@algolia/requester-common": "4.13.1",
+        "@algolia/requester-node-http": "4.13.1",
+        "@algolia/transporter": "4.13.1"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.8.2.tgz",
-      "integrity": "sha512-AXxiF0zT9oYwl8ZBgU/eRXvfYhz7cBA5YrLPlw9inZHdaYF0QEya/f1Zp1mPYMXc1v6VkHwBq4pk6/vayBLICg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.10.0.tgz",
+      "integrity": "sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -15756,9 +16353,9 @@
       }
     },
     "arg": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "argparse": {
       "version": "2.0.1",
@@ -15778,7 +16375,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -15800,12 +16397,12 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "autoprefixer": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
-      "integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
+      "version": "10.4.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
+      "integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
       "requires": {
-        "browserslist": "^4.20.2",
-        "caniuse-lite": "^1.0.30001317",
+        "browserslist": "^4.20.3",
+        "caniuse-lite": "^1.0.30001335",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -15929,7 +16526,7 @@
     "base16": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
-      "integrity": "sha1-4pf2DX7BAUp6lxo568ipjAtoHnA="
+      "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
     "batch": {
       "version": "0.6.1",
@@ -16090,42 +16687,14 @@
       }
     },
     "browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.1.tgz",
+      "integrity": "sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
-        "picocolors": "^1.0.0"
-      }
-    },
-    "buble-jsx-only": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/buble-jsx-only/-/buble-jsx-only-0.19.8.tgz",
-      "integrity": "sha512-7AW19pf7PrKFnGTEDzs6u9+JZqQwM1VnLS19OlqYDhXomtFFknnoQJAPHeg84RMFWAvOhYrG7harizJNwUKJsA==",
-      "requires": {
-        "acorn": "^6.1.1",
-        "acorn-dynamic-import": "^4.0.0",
-        "acorn-jsx": "^5.0.1",
-        "chalk": "^2.4.2",
-        "magic-string": "^0.25.3",
-        "minimist": "^1.2.0",
-        "regexpu-core": "^4.5.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
-        },
-        "acorn-dynamic-import": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-          "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-          "requires": {}
-        }
+        "caniuse-lite": "^1.0.30001359",
+        "electron-to-chromium": "^1.4.172",
+        "node-releases": "^2.0.5",
+        "update-browserslist-db": "^1.0.4"
       }
     },
     "buffer-from": {
@@ -16217,9 +16786,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw=="
+      "version": "1.0.30001361",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz",
+      "integrity": "sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ=="
     },
     "ccount": {
       "version": "1.1.0",
@@ -16252,29 +16821,131 @@
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
     "cheerio": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
-      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
       "requires": {
-        "cheerio-select": "^1.5.0",
-        "dom-serializer": "^1.3.2",
-        "domhandler": "^4.2.0",
-        "htmlparser2": "^6.1.0",
-        "parse5": "^6.0.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.1",
-        "tslib": "^2.2.0"
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.1"
+          }
+        },
+        "entities": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+        },
+        "htmlparser2": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+          "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "domutils": "^3.0.1",
+            "entities": "^4.3.0"
+          }
+        },
+        "parse5": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+          "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+          "requires": {
+            "entities": "^4.3.0"
+          }
+        }
       }
     },
     "cheerio-select": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
-      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "requires": {
-        "css-select": "^4.3.0",
-        "css-what": "^6.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0"
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+          "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^6.1.0",
+            "domhandler": "^5.0.2",
+            "domutils": "^3.0.1",
+            "nth-check": "^2.0.1"
+          }
+        },
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.1"
+          }
+        },
+        "entities": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+        }
       }
     },
     "chokidar": {
@@ -16334,6 +17005,15 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-table3": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+      "requires": {
+        "@colors/colors": "1.5.0",
+        "string-width": "^4.2.0"
       }
     },
     "cli-truncate": {
@@ -16697,9 +17377,9 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
     "css-declaration-sorter": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
-      "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.0.tgz",
+      "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==",
       "requires": {}
     },
     "css-loader": {
@@ -16821,12 +17501,12 @@
       }
     },
     "cssnano-preset-advanced": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.3.tgz",
-      "integrity": "sha512-AB9SmTSC2Gd8T7PpKUsXFJ3eNsg7dc4CTZ0+XAJ29MNxyJsrCEk7N1lw31bpHrsQH2PVJr21bbWgGAfA9j0dIA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.8.tgz",
+      "integrity": "sha512-xUlLLnEB1LjpEik+zgRNlk8Y/koBPPtONZjp7JKbXigeAmCrFvq9H0pXW5jJV45bQWAlmJ0sKy+IMr0XxLYQZg==",
       "requires": {
         "autoprefixer": "^10.3.7",
-        "cssnano-preset-default": "^5.2.7",
+        "cssnano-preset-default": "^5.2.12",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -16834,35 +17514,35 @@
       }
     },
     "cssnano-preset-default": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.7.tgz",
-      "integrity": "sha512-JiKP38ymZQK+zVKevphPzNSGHSlTI+AOwlasoSRtSVMUU285O7/6uZyd5NbW92ZHp41m0sSHe6JoZosakj63uA==",
+      "version": "5.2.12",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
+      "integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
       "requires": {
-        "css-declaration-sorter": "^6.2.2",
+        "css-declaration-sorter": "^6.3.0",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
         "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.0",
-        "postcss-discard-comments": "^5.1.1",
+        "postcss-convert-values": "^5.1.2",
+        "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.4",
-        "postcss-merge-rules": "^5.1.1",
+        "postcss-merge-longhand": "^5.1.6",
+        "postcss-merge-rules": "^5.1.2",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.2",
-        "postcss-minify-selectors": "^5.2.0",
+        "postcss-minify-params": "^5.1.3",
+        "postcss-minify-selectors": "^5.2.1",
         "postcss-normalize-charset": "^5.1.0",
         "postcss-normalize-display-values": "^5.1.0",
-        "postcss-normalize-positions": "^5.1.0",
-        "postcss-normalize-repeat-style": "^5.1.0",
+        "postcss-normalize-positions": "^5.1.1",
+        "postcss-normalize-repeat-style": "^5.1.1",
         "postcss-normalize-string": "^5.1.0",
         "postcss-normalize-timing-functions": "^5.1.0",
         "postcss-normalize-unicode": "^5.1.0",
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
-        "postcss-ordered-values": "^5.1.1",
+        "postcss-ordered-values": "^5.1.3",
         "postcss-reduce-initial": "^5.1.0",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
@@ -17047,9 +17727,9 @@
       }
     },
     "domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domhandler": {
       "version": "4.3.1",
@@ -17106,8 +17786,7 @@
     "eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -17115,9 +17794,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.4.118",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.118.tgz",
-      "integrity": "sha512-maZIKjnYDvF7Fs35nvVcyr44UcKNwybr93Oba2n3HkKDFAtk0svERkLN/HyczJDS3Fo4wU9th9fUQd09ZLtj1w=="
+      "version": "1.4.176",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.176.tgz",
+      "integrity": "sha512-92JdgyRlcNDwuy75MjuFSb3clt6DGJ2IXSpg0MCjKd3JV9eSmuUAIyWiGAp/EtT0z2D4rqbYqThQLV90maH3Zw=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -18280,6 +18959,14 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -18821,7 +19508,7 @@
     "lodash.curry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
+      "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -18846,7 +19533,7 @@
     "lodash.flow": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
+      "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
     },
     "lodash.foreach": {
       "version": "4.5.0",
@@ -18980,14 +19667,6 @@
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
-      }
-    },
-    "magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "requires": {
-        "sourcemap-codec": "^1.4.8"
       }
     },
     "make-dir": {
@@ -19141,27 +19820,46 @@
       }
     },
     "mini-css-extract-plugin": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
-      "integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz",
+      "integrity": "sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==",
       "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0",
-        "webpack-sources": "^1.1.0"
+        "schema-utils": "^4.0.0"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "webpack-sources": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "schema-utils": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+          "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "ajv": "^8.8.0",
+            "ajv-formats": "^2.1.1",
+            "ajv-keywords": "^5.0.0"
           }
         }
       }
@@ -19262,9 +19960,9 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
+      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -19274,7 +19972,7 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="
     },
     "normalize-url": {
       "version": "6.1.0",
@@ -19491,11 +20189,35 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
       "requires": {
-        "parse5": "^6.0.1"
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "entities": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+        },
+        "parse5": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+          "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+          "requires": {
+            "entities": "^4.3.0"
+          }
+        }
       }
     },
     "parseurl": {
@@ -19665,17 +20387,18 @@
       }
     },
     "postcss-convert-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.0.tgz",
-      "integrity": "sha512-GkyPbZEYJiWtQB0KZ0X6qusqFHUepguBCNFi9t5JJc7I2OTXG7C0twbTLvCfaKOLl3rSXmpAwV7W5txd91V84g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
+      "integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
       "requires": {
+        "browserslist": "^4.20.3",
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-discard-comments": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
-      "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
       "requires": {}
     },
     "postcss-discard-duplicates": {
@@ -19724,18 +20447,18 @@
       }
     },
     "postcss-merge-longhand": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.4.tgz",
-      "integrity": "sha512-hbqRRqYfmXoGpzYKeW0/NCZhvNyQIlQeWVSao5iKWdyx7skLvCfQFGIUsP9NUs3dSbPac2IC4Go85/zG+7MlmA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
+      "integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
       "requires": {
         "postcss-value-parser": "^4.2.0",
         "stylehacks": "^5.1.0"
       }
     },
     "postcss-merge-rules": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.1.tgz",
-      "integrity": "sha512-8wv8q2cXjEuCcgpIB1Xx1pIy8/rhMPIQqYKNzEdyx37m6gpq83mQQdCxgIkFgliyEnKvdwJf/C61vN4tQDq4Ww==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
+      "integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
       "requires": {
         "browserslist": "^4.16.6",
         "caniuse-api": "^3.0.0",
@@ -19762,9 +20485,9 @@
       }
     },
     "postcss-minify-params": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.2.tgz",
-      "integrity": "sha512-aEP+p71S/urY48HWaRHasyx4WHQJyOYaKpQ6eXl8k0kxg66Wt/30VR6/woh8THgcpRbonJD5IeD+CzNhPi1L8g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
+      "integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
       "requires": {
         "browserslist": "^4.16.6",
         "cssnano-utils": "^3.1.0",
@@ -19772,9 +20495,9 @@
       }
     },
     "postcss-minify-selectors": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.0.tgz",
-      "integrity": "sha512-vYxvHkW+iULstA+ctVNx0VoRAR4THQQRkG77o0oa4/mBS0OzGvvzLIvHDv/nNEM0crzN2WIyFU5X7wZhaUK3RA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
+      "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
       "requires": {
         "postcss-selector-parser": "^6.0.5"
       }
@@ -19826,17 +20549,17 @@
       }
     },
     "postcss-normalize-positions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.0.tgz",
-      "integrity": "sha512-8gmItgA4H5xiUxgN/3TVvXRoJxkAWLW6f/KKhdsH03atg0cB8ilXnrB5PpSshwVu/dD2ZsRFQcR1OEmSBDAgcQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
+      "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-normalize-repeat-style": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.0.tgz",
-      "integrity": "sha512-IR3uBjc+7mcWGL6CtniKNQ4Rr5fTxwkaDHwMBDGGs1x9IVRkYIT/M4NelZWkAOBdV6v3Z9S46zqaKGlyzHSchw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
+      "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
@@ -19884,9 +20607,9 @@
       }
     },
     "postcss-ordered-values": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.1.tgz",
-      "integrity": "sha512-7lxgXF0NaoMIgyihL/2boNAEZKiW0+HkMhdKMTD93CjW8TdCy2hSdj8lsAo+uwm7EDG16Da2Jdmtqpedl0cMfw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
+      "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
       "requires": {
         "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
@@ -19988,9 +20711,9 @@
       "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA=="
     },
     "prism-react-renderer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.1.tgz",
-      "integrity": "sha512-xUeDMEz074d0zc5y6rxiMp/dlC7C+5IDDlaEUlcBOFE2wddz7hz5PNupb087mPwTt7T9BrFmewObfCBuf/LKwQ==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
+      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
       "requires": {}
     },
     "prismjs": {
@@ -20084,12 +20807,17 @@
     "pure-color": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
-      "integrity": "sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4="
+      "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
     },
     "qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
+    },
+    "querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
     },
     "queue": {
       "version": "6.0.2",
@@ -20158,7 +20886,7 @@
     "react-base16-styling": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
-      "integrity": "sha1-7yFW1mz0E5aVyKFniGy2nqZgeSw=",
+      "integrity": "sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==",
       "requires": {
         "base16": "^1.0.0",
         "lodash.curry": "^4.0.1",
@@ -20327,15 +21055,16 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
-    "react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+    "react-helmet-async": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
       "requires": {
-        "object-assign": "^4.1.1",
+        "@babel/runtime": "^7.12.5",
+        "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
+        "react-fast-compare": "^3.2.0",
+        "shallowequal": "^1.1.0"
       }
     },
     "react-is": {
@@ -20427,20 +21156,14 @@
         "tiny-warning": "^1.0.0"
       }
     },
-    "react-side-effect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
-      "requires": {}
-    },
     "react-textarea-autosize": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
-      "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
+      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
       "requires": {
         "@babel/runtime": "^7.10.2",
-        "use-composed-ref": "^1.0.0",
-        "use-latest": "^1.0.0"
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
       }
     },
     "readable-stream": {
@@ -20707,22 +21430,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
-      }
-    },
-    "remark-mdx-remove-exports": {
-      "version": "1.6.22",
-      "resolved": "https://registry.npmjs.org/remark-mdx-remove-exports/-/remark-mdx-remove-exports-1.6.22.tgz",
-      "integrity": "sha512-7g2uiTmTGfz5QyVb+toeX25frbk1Y6yd03RXGPtqx0+DVh86Gb7MkNYbk7H2X27zdZ3CQv1W/JqlFO0Oo8IxVA==",
-      "requires": {
-        "unist-util-remove": "2.0.0"
-      }
-    },
-    "remark-mdx-remove-imports": {
-      "version": "1.6.22",
-      "resolved": "https://registry.npmjs.org/remark-mdx-remove-imports/-/remark-mdx-remove-imports-1.6.22.tgz",
-      "integrity": "sha512-lmjAXD8Ltw0TsvBzb45S+Dxx7LTJAtDaMneMAv8LAUIPEyYoKkmGbmVsiF0/pY6mhM1Q16swCmu1TN+ie/vn/A==",
-      "requires": {
-        "unist-util-remove": "2.0.0"
       }
     },
     "remark-parse": {
@@ -21155,7 +21862,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -21169,6 +21876,11 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -21303,11 +22015,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "space-separated-tokens": {
       "version": "1.1.5",
@@ -21587,7 +22294,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "trim": {
       "version": "0.0.1",
@@ -21774,6 +22481,15 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "update-browserslist-db": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
+      "integrity": "sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==",
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
     "update-notifier": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
@@ -21879,11 +22595,11 @@
       "requires": {}
     },
     "use-latest": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.0.tgz",
-      "integrity": "sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
       "requires": {
-        "use-isomorphic-layout-effect": "^1.0.0"
+        "use-isomorphic-layout-effect": "^1.1.1"
       }
     },
     "util-deprecate": {
@@ -21983,7 +22699,7 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
       "version": "5.72.0",
@@ -22303,7 +23019,7 @@
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^1.10.2",
-    "@docusaurus/core": "2.0.0-beta.15",
-    "@docusaurus/preset-classic": "2.0.0-beta.15",
+    "@docusaurus/core": "^2.0.0-beta.16",
+    "@docusaurus/preset-classic": "^2.0.0-beta.16",
     "clsx": "^1.1.1",
     "docusaurus-gtm-plugin": "0.0.2",
     "mixpanel-browser": "^2.45.0",

--- a/sidebars.js
+++ b/sidebars.js
@@ -213,9 +213,6 @@ module.exports = {
             "components/zeebe/open-source/get-help-get-involved",
           ],
         },
-        {
-          Appendix: [],
-        },
       ],
       Operate: [
         "components/operate/index",

--- a/versioned_sidebars/version-0.25-sidebars.json
+++ b/versioned_sidebars/version-0.25-sidebars.json
@@ -805,12 +805,6 @@
               "id": "version-0.25/components/tasklist/deployment/authentication"
             }
           ]
-        },
-        {
-          "collapsed": true,
-          "type": "category",
-          "label": "User Guide",
-          "items": []
         }
       ]
     }

--- a/versioned_sidebars/version-0.26-sidebars.json
+++ b/versioned_sidebars/version-0.26-sidebars.json
@@ -671,12 +671,6 @@
               "id": "version-0.26/components/zeebe/open-source/deprecated-features"
             }
           ]
-        },
-        {
-          "collapsed": true,
-          "type": "category",
-          "label": "Appendix",
-          "items": []
         }
       ]
     },

--- a/versioned_sidebars/version-1.0-sidebars.json
+++ b/versioned_sidebars/version-1.0-sidebars.json
@@ -670,12 +670,6 @@
               "id": "version-1.0/components/zeebe/third-party-libraries/zeebe-dependencies"
             }
           ]
-        },
-        {
-          "collapsed": true,
-          "type": "category",
-          "label": "Appendix",
-          "items": []
         }
       ]
     },

--- a/versioned_sidebars/version-1.1-sidebars.json
+++ b/versioned_sidebars/version-1.1-sidebars.json
@@ -682,12 +682,6 @@
               "id": "version-1.1/components/zeebe/third-party-libraries/zeebe-dependencies"
             }
           ]
-        },
-        {
-          "collapsed": true,
-          "type": "category",
-          "label": "Appendix",
-          "items": []
         }
       ]
     },

--- a/versioned_sidebars/version-1.2-sidebars.json
+++ b/versioned_sidebars/version-1.2-sidebars.json
@@ -371,13 +371,6 @@
               "id": "version-1.2/components/zeebe/open-source/get-help-get-involved"
             }
           ]
-        },
-        {
-          "type": "category",
-          "collapsed": true,
-          "collapsible": true,
-          "label": "Appendix",
-          "items": []
         }
       ]
     },

--- a/versioned_sidebars/version-1.3-sidebars.json
+++ b/versioned_sidebars/version-1.3-sidebars.json
@@ -197,9 +197,6 @@
             "components/zeebe/open-source/community-contributions",
             "components/zeebe/open-source/get-help-get-involved"
           ]
-        },
-        {
-          "Appendix": []
         }
       ],
       "Operate": [


### PR DESCRIPTION
The main goal of this PR is to update from docusaurus beta-15 to beta-16, but it includes a couple side-quests required by this update: 

* Configures a standalone Algolia DocSearch instance
* Removes empty sidebar items

## Proof that the new algolia instance works

### Before: Production site before publishing a new doc

Note that there is no link in the sidebar titled "Create decision tables using DMN" under Next Steps. This doc was merged but not yet published:
 
<img width="382" alt="image" src="https://user-images.githubusercontent.com/1627089/176963477-ffce17fd-c104-48a4-884d-dde2e0d86979.png">

### Before: Local search results (using new algolia index) before publishing the new doc

Note that there are no search results for the new article, searched by exact title: 

<img width="1499" alt="image" src="https://user-images.githubusercontent.com/1627089/176964167-619206a1-daee-47cf-b9f9-9056a0ff6a63.png">

### ...And then I published the new doc

Note that the DMN article now appears under Next Steps, so it's live:

<img width="395" alt="image" src="https://user-images.githubusercontent.com/1627089/176964356-d4c22eef-6017-4a40-b5fb-c27fd1788181.png">

### ...And then I triggered a re-crawl of the new index

Note that the search results locally, pointed at the new algolia instance, found the new doc by exact title: 

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/1627089/176964569-7e0f025b-b93b-47f8-b124-bfc713d93836.png">
