### PR TITLE
Link to new Go getting started guide

### DIFF
--- a/docs/apis-clients/go-client/get-started.md
+++ b/docs/apis-clients/go-client/get-started.md
@@ -6,7 +6,7 @@ sidebar_label: "Getting started guide"
 
 In this tutorial, you will learn how to use the Go client in a Go application to interact with Camunda Platform 8.
 
-You can find the complete source code on [GitHub](https://github.com/zeebe-io/zeebe-get-started-go-client).
+You can find a complete example on [GitHub](https://github.com/camunda/camunda-platform-get-started/tree/main/go).
 
 ## Prerequisites
 


### PR DESCRIPTION
We added a new getting started guide for the Go client, but forgot to update the link in the docs.

One thing to note: the code in the getting started guide on GitHub, and the one here in the docs, differs. I thought about aligning them, but decided against, primarily because the [code on GitHub](https://github.com/camunda/camunda-platform-get-started/tree/main/go) is more of a complete sample application, and the one here in the docs is just showing how to do specific things.