### PR TITLE
chore(deps): Update docusaurus from beta-16 to beta-17, including rewriting dark mode suppression

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -196,42 +196,6 @@ module.exports = {
       appId: "6KYF3VMCXZ",
       indexName: "camunda",
     },
-    // Disabling Dark Mode
-    // https://github.com/camunda-cloud/camunda-cloud-documentation/issues/125
-    //
-    colorMode: {
-      // "light" | "dark"
-      defaultMode: "light",
-
-      // Hides the switch in the navbar
-      // Useful if you want to support a single color mode
-      disableSwitch: true,
-
-      // Should we use the prefers-color-scheme media-query,
-      // using user system preferences, instead of the hardcoded defaultMode
-      respectPrefersColorScheme: false,
-
-      // Dark/light switch icon options
-      switchConfig: {
-        // Icon for the switch while in dark mode
-        darkIcon: "🌙",
-
-        // CSS to apply to dark icon,
-        // React inline style object
-        // see https://reactjs.org/docs/dom-elements.html#style
-        darkIconStyle: {
-          marginLeft: "2px",
-        },
-
-        // Unicode icons such as '\u2600' will work
-        // Unicode with 5 chars require brackets: '\u{1F602}'
-        lightIcon: "\u{1F602}",
-
-        lightIconStyle: {
-          marginLeft: "1px",
-        },
-      },
-    },
   },
   presets: [
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@auth0/auth0-react": "^1.10.2",
-        "@docusaurus/core": "^2.0.0-beta.16",
-        "@docusaurus/preset-classic": "^2.0.0-beta.16",
+        "@docusaurus/core": "^2.0.0-beta.17",
+        "@docusaurus/preset-classic": "^2.0.0-beta.17",
         "clsx": "^1.1.1",
         "docusaurus-gtm-plugin": "0.0.2",
         "mixpanel-browser": "^2.45.0",
@@ -1930,9 +1930,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.16.tgz",
-      "integrity": "sha512-0AbNSpTKapz+tctg7PHvuGQRtW7nd3Tm3axNqnFowO3SV2VvFCaBji2s1H3XCGXVRGveQ04g20vl2ZqG5GheUA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.17.tgz",
+      "integrity": "sha512-iNdW7CsmHNOgc4PxD9BFxa+MD8+i7ln7erOBkF3FSMMPnsKUeVqsR3rr31aLmLZRlTXMITSPLxlXwtBZa3KPCw==",
       "dependencies": {
         "@babel/core": "^7.17.5",
         "@babel/generator": "^7.17.3",
@@ -1944,13 +1944,13 @@
         "@babel/runtime": "^7.17.2",
         "@babel/runtime-corejs3": "^7.17.2",
         "@babel/traverse": "^7.17.3",
-        "@docusaurus/cssnano-preset": "2.0.0-beta.16",
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/mdx-loader": "2.0.0-beta.16",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/mdx-loader": "2.0.0-beta.17",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-common": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-common": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.1",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.2",
@@ -1982,7 +1982,7 @@
         "lodash": "^4.17.21",
         "mini-css-extract-plugin": "^2.5.3",
         "nprogress": "^0.2.0",
-        "postcss": "^8.4.6",
+        "postcss": "^8.4.7",
         "postcss-loader": "^6.2.1",
         "prompts": "^2.4.2",
         "react-dev-utils": "^12.0.0",
@@ -2214,19 +2214,19 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.16.tgz",
-      "integrity": "sha512-dkGpb+xoFNmcp5m5EpwGcFlMT4C7kOTzgZ73QoNoU930NL6OXuqcJdMd4XI6yYuGz+t8Bo8UzzCryEjHTiObOg==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.17.tgz",
+      "integrity": "sha512-DoBwtLjJ9IY9/lNMHIEdo90L4NDayvU28nLgtjR2Sc6aBIMEB/3a5Ndjehnp+jZAkwcDdNASA86EkZVUyz1O1A==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.1.12",
-        "postcss": "^8.4.6",
+        "postcss": "^8.4.7",
         "postcss-sort-media-queries": "^4.2.1"
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.16.tgz",
-      "integrity": "sha512-/fta5gCXHMLip+8WxYoi+hlB1pwJEeVpFc7Z4iIMwAxn8SrcmCJ0K3wPNjZpDdz0EHrpLHEJ/vEkCuL+7Su4ZQ==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.17.tgz",
+      "integrity": "sha512-F9JDl06/VLg+ylsvnq9NpILSUeWtl0j4H2LtlLzX5gufEL4dGiCMlnUzYdHl7FSHSzYJ0A/R7vu0SYofsexC4w==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.3.1"
@@ -2300,14 +2300,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.16.tgz",
-      "integrity": "sha512-NR0Cptz4UGlzgu08AITffRL4rj+SU8HYq2yNFxbY8FSuj/GWI3SrSsBi7grB6fKql0s4SGUKEEzSweewzW1Rgg==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.17.tgz",
+      "integrity": "sha512-AhJ3GWRmjQYCyINHE595pff5tn3Rt83oGpdev5UT9uvG9lPYPC8nEmh1LI6c0ogfw7YkNznzxWSW4hyyVbYQ3A==",
       "dependencies": {
         "@babel/parser": "^7.17.3",
         "@babel/traverse": "^7.17.3",
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2330,11 +2330,11 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.16.tgz",
-      "integrity": "sha512-x6/JlbrSfhGuDc6dWybt/E1T6xh/jjEJemlizAGArHpKB0mTuxRm5FRCmksX7z7IM8HZs43tpftGS8gXNL5gug==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.17.tgz",
+      "integrity": "sha512-Tu+8geC/wyygBudbSwvWIHEvt5RwyA7dEoE1JmPbgQtmqUxOZ9bgnfemwXpJW5mKuDiJASbN4of1DhbLqf4sPg==",
       "dependencies": {
-        "@docusaurus/types": "2.0.0-beta.16",
+        "@docusaurus/types": "2.0.0-beta.17",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
@@ -2346,16 +2346,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.16.tgz",
-      "integrity": "sha512-JSRzNKpuMPAndIDIZKbA4G2rA0sC3jPHO+TOmBliO8SBUkw1DL58MZTp98y+5EeUg+KjNIYoz7wRMj3YhFIhJA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.17.tgz",
+      "integrity": "sha512-gcX4UR+WKT4bhF8FICBQHy+ESS9iRMeaglSboTZbA/YHGax/3EuZtcPU3dU4E/HFJeZ866wgUdbLKpIpsZOidg==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/mdx-loader": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-common": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/mdx-loader": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-common": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "cheerio": "^1.0.0-rc.10",
         "feed": "^4.2.2",
         "fs-extra": "^10.0.1",
@@ -2375,15 +2375,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.16.tgz",
-      "integrity": "sha512-IiNEud1WYj9a0rkNHjX1JNLfim8f6pyB5w17arRDK6HiY3w51zCQsZJo0popRp1KQQf/g66I+5Y3qP5rHGeU6Q==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.17.tgz",
+      "integrity": "sha512-YYrBpuRfTfE6NtENrpSHTJ7K7PZifn6j6hcuvdC0QKE+WD8pS+O2/Ws30yoyvHwLnAnfhvaderh1v9Kaa0/ANg==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/mdx-loader": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/mdx-loader": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.0.1",
         "import-fresh": "^3.3.0",
@@ -2403,14 +2403,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.16.tgz",
-      "integrity": "sha512-XH/dNfDhnad7qA+RUdyJW94Yf8LzALz0bJRwp8GbtjXeAmfP/DWGvVPT/egd9Pz99uO5UgiO9vR1i7UlktQSwA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.17.tgz",
+      "integrity": "sha512-d5x0mXTMJ44ojRQccmLyshYoamFOep2AnBe69osCDnwWMbD3Or3pnc2KMK9N7mVpQFnNFKbHNCLrX3Rv0uwEHA==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/mdx-loader": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/mdx-loader": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "fs-extra": "^10.0.1",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
@@ -2425,12 +2425,12 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.16.tgz",
-      "integrity": "sha512-uzp4hrL/PozgDNEWF/Y+DH+nH0GoC+dOyNLqsyFqQLlzykFHTJYLMK1tfwKHUJ3WqhQFbRwLTR4rzFC89Kaf7g==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.17.tgz",
+      "integrity": "sha512-p26fjYFRSC0esEmKo/kRrLVwXoFnzPCFDumwrImhPyqfVxbj+IKFaiXkayb2qHnyEGE/1KSDIgRF4CHt/pyhiw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
         "fs-extra": "^10.0.1",
         "react-json-view": "^1.21.3",
         "tslib": "^2.3.1"
@@ -2444,12 +2444,12 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.16.tgz",
-      "integrity": "sha512-UKd1RWYHeSm/RLjJ2ZflLTT6hbiWQWFAxVzYRBiyOnDbBP+un8qmP692QZCIP+rrm+KkxsV1FGte0NtrcsFUEw==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.17.tgz",
+      "integrity": "sha512-jvgYIhggYD1W2jymqQVAAyjPJUV1xMCn70bAzaCMxriureMWzhQ/kQMVQpop0ijTMvifOxaV9yTcL1VRXev++A==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2461,12 +2461,12 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.16.tgz",
-      "integrity": "sha512-WUD1Kh5y/9VaV/ubg8c6a43gE2+N+yeLUL/qfrUZuLHheaBaozGjioHRbndmfN6W7l2EhuxO1QRN3SlBqc7kjA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.17.tgz",
+      "integrity": "sha512-1pnWHtIk1Jfeqwvr8PlcPE5SODWT1gW4TI+ptmJbJ296FjjyvL/pG0AcGEJmYLY/OQc3oz0VQ0W2ognw9jmFIw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2478,14 +2478,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.16.tgz",
-      "integrity": "sha512-B8fa2qvScNSiuCos6vZjPERikRTbbebzy33s5zV+VTZsqLtrjs4//Y0HlJ0tuz5qHWCzavb6nFX/mgFAJoyqFQ==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.17.tgz",
+      "integrity": "sha512-19/PaGCsap6cjUPZPGs87yV9e1hAIyd0CTSeVV6Caega8nmOKk20FTrQGFJjZPeX8jvD9QIXcdg6BJnPxcKkaQ==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-common": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-common": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "fs-extra": "^10.0.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.3.1"
@@ -2499,21 +2499,21 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.16.tgz",
-      "integrity": "sha512-HLY2dC412Lexe2ZupUEUJpY44yz6uqtvibKTXvXH392hFB43Thp7MKr5zACRTwacjbddIoqPVbdzRWtvugSU2g==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.17.tgz",
+      "integrity": "sha512-7YUxPEgM09aZWr25/hpDEp1gPl+1KsCPV1ZTRW43sbQ9TinPm+9AKR3rHVDa8ea8MdiS7BpqCVyK+H/eiyQrUw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
-        "@docusaurus/plugin-debug": "2.0.0-beta.16",
-        "@docusaurus/plugin-google-analytics": "2.0.0-beta.16",
-        "@docusaurus/plugin-google-gtag": "2.0.0-beta.16",
-        "@docusaurus/plugin-sitemap": "2.0.0-beta.16",
-        "@docusaurus/theme-classic": "2.0.0-beta.16",
-        "@docusaurus/theme-common": "2.0.0-beta.16",
-        "@docusaurus/theme-search-algolia": "2.0.0-beta.16"
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
+        "@docusaurus/plugin-debug": "2.0.0-beta.17",
+        "@docusaurus/plugin-google-analytics": "2.0.0-beta.17",
+        "@docusaurus/plugin-google-gtag": "2.0.0-beta.17",
+        "@docusaurus/plugin-sitemap": "2.0.0-beta.17",
+        "@docusaurus/theme-classic": "2.0.0-beta.17",
+        "@docusaurus/theme-common": "2.0.0-beta.17",
+        "@docusaurus/theme-search-algolia": "2.0.0-beta.17"
       },
       "engines": {
         "node": ">=14"
@@ -2536,25 +2536,25 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.16.tgz",
-      "integrity": "sha512-7cylhb2hwAUSM+ZD2ClQwS/Ag8tnt5gTDrma9WzWA+sB7Zd/b5Dc9WHFowzUjieC++UZ+KxYktCfKE/1RWF77w==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.17.tgz",
+      "integrity": "sha512-xfZ9kpgqo0lP9YO4rJj79wtiQJXU6ARo5wYy10IIwiWN+lg00scJHhkmNV431b05xIUjUr0cKeH9nqZmEsQRKg==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
-        "@docusaurus/theme-common": "2.0.0-beta.16",
-        "@docusaurus/theme-translations": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-common": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
+        "@docusaurus/theme-common": "2.0.0-beta.17",
+        "@docusaurus/theme-translations": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-common": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
         "copy-text-to-clipboard": "^3.0.1",
         "infima": "0.2.0-alpha.37",
         "lodash": "^4.17.21",
-        "postcss": "^8.4.6",
+        "postcss": "^8.4.7",
         "prism-react-renderer": "^1.2.1",
         "prismjs": "^1.27.0",
         "react-router-dom": "^5.2.0",
@@ -2569,14 +2569,14 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.16.tgz",
-      "integrity": "sha512-7jP+lVrNMlEXH9bUvjnRxyF1MQpIC0Z+FpBmahTwi1lNAVe1kbs3r7SVsXnBHwI4F+tIWaRMkpEfZfNhH1MjNA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.17.tgz",
+      "integrity": "sha512-LJBDhx+Qexn1JHBqZbE4k+7lBaV1LgpE33enXf43ShB7ebhC91d5HLHhBwgt0pih4+elZU4rG+BG/roAmsNM0g==",
       "dependencies": {
-        "@docusaurus/module-type-aliases": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
+        "@docusaurus/module-type-aliases": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
         "clsx": "^1.1.1",
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.1",
@@ -2592,17 +2592,17 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.16.tgz",
-      "integrity": "sha512-yNQ7nWWAzT+abQiiSgnPT3FDE07KDIt4UZgxEwo2WvynDD4O7G+6uUkBryAZXYvgc2GEMw7u0E/8+2EPbJ5yyg==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.17.tgz",
+      "integrity": "sha512-W12XKM7QC5Jmrec359bJ7aDp5U8DNkCxjVKsMNIs8rDunBoI/N+R35ERJ0N7Bg9ONAWO6o7VkUERQsfGqdvr9w==",
       "dependencies": {
         "@docsearch/react": "^3.0.0",
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/theme-common": "2.0.0-beta.16",
-        "@docusaurus/theme-translations": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/theme-common": "2.0.0-beta.17",
+        "@docusaurus/theme-translations": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "algoliasearch": "^4.12.1",
         "algoliasearch-helper": "^3.7.0",
         "clsx": "^1.1.1",
@@ -2621,9 +2621,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.16.tgz",
-      "integrity": "sha512-OMYjraIbkQyPEdpPGe4zc9gDUm1FxruyBMcxW9pnqh8BoEogPpyFGTJwXiKzOWS6W+xiyctWJYIYmS5laDkriw==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.17.tgz",
+      "integrity": "sha512-oxCX6khjZH3lgdRCL0DH06KkUM/kDr9+lzB35+vY8rpFeQruVgRdi8ekPqG3+Wr0U/N+LMhcYE5BmCb6D0Fv2A==",
       "dependencies": {
         "fs-extra": "^10.0.1",
         "tslib": "^2.3.1"
@@ -2633,9 +2633,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.16.tgz",
-      "integrity": "sha512-ttej9CFthe9+mDMGKMI1wRegXJHLXUZUhxsiYaGczW7PZXdbCQZvKVAoMtrEp/Oa/KOMtqwva60iEEot//KGnQ==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.17.tgz",
+      "integrity": "sha512-4o7TXu5sKlQpybfFFtsGUElBXwSpiXKsQyyWaRKj7DRBkvMtkDX6ITZNnZO9+EHfLbP/cfrokB8C/oO7mCQ5BQ==",
       "dependencies": {
         "commander": "^5.1.0",
         "joi": "^17.6.0",
@@ -2646,11 +2646,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.16.tgz",
-      "integrity": "sha512-ngOVqWlT+JvHsWDYH1i0oou9Dhhm6gKcTB3PR3nkIlDOdn+MViuhhKivTBD9et5JxAnf8A1hk/oaUO9tBU7WGA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.17.tgz",
+      "integrity": "sha512-yRKGdzSc5v6M/6GyQ4omkrAHCleevwKYiIrufCJgRbOtkhYE574d8mIjjirOuA/emcyLxjh+TLtqAA5TwhIryA==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.17",
         "@svgr/webpack": "^6.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.1",
@@ -2671,9 +2671,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.16.tgz",
-      "integrity": "sha512-xAUBVX/BftMPAw9rvdeIKBKmmAX2xus+HbXciL+5VKNG9ePI5X+W739lCqJVm6C2fDRXENBbeaKnnMx9wTeEUg==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.17.tgz",
+      "integrity": "sha512-90WCVdj6zYzs7neEIS594qfLO78cUL6EVK1CsRHJgVkkGjcYlCQ1NwkyO7bOb+nIAwdJrPJRc2FBSpuEGxPD3w==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -2682,12 +2682,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.16.tgz",
-      "integrity": "sha512-gXAKMP1D5ERX3d5SF88Yp7G9ROYd2XOhyLSErPRaHs5b9SzYhI9lIiPUoXFk6VyRnUjXiUley2/MtdrEgt989A==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.17.tgz",
+      "integrity": "sha512-5UjayUP16fDjgd52eSEhL7SlN9x60pIhyS+K7kt7RmpSLy42+4/bSr2pns2VlATmuaoNOO6iIFdB2jgSYJ6SGA==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
         "joi": "^17.6.0",
         "tslib": "^2.3.1"
       },
@@ -4655,9 +4655,9 @@
       }
     },
     "node_modules/cheerio-select/node_modules/entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
-      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
       "engines": {
         "node": ">=0.12"
       },
@@ -4706,9 +4706,9 @@
       }
     },
     "node_modules/cheerio/node_modules/entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
-      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
       "engines": {
         "node": ">=0.12"
       },
@@ -9288,9 +9288,9 @@
       }
     },
     "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
-      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
       "engines": {
         "node": ">=0.12"
       },
@@ -14813,9 +14813,9 @@
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.16.tgz",
-      "integrity": "sha512-0AbNSpTKapz+tctg7PHvuGQRtW7nd3Tm3axNqnFowO3SV2VvFCaBji2s1H3XCGXVRGveQ04g20vl2ZqG5GheUA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.17.tgz",
+      "integrity": "sha512-iNdW7CsmHNOgc4PxD9BFxa+MD8+i7ln7erOBkF3FSMMPnsKUeVqsR3rr31aLmLZRlTXMITSPLxlXwtBZa3KPCw==",
       "requires": {
         "@babel/core": "^7.17.5",
         "@babel/generator": "^7.17.3",
@@ -14827,13 +14827,13 @@
         "@babel/runtime": "^7.17.2",
         "@babel/runtime-corejs3": "^7.17.2",
         "@babel/traverse": "^7.17.3",
-        "@docusaurus/cssnano-preset": "2.0.0-beta.16",
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/mdx-loader": "2.0.0-beta.16",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/mdx-loader": "2.0.0-beta.17",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-common": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-common": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.1",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.2",
@@ -14865,7 +14865,7 @@
         "lodash": "^4.17.21",
         "mini-css-extract-plugin": "^2.5.3",
         "nprogress": "^0.2.0",
-        "postcss": "^8.4.6",
+        "postcss": "^8.4.7",
         "postcss-loader": "^6.2.1",
         "prompts": "^2.4.2",
         "react-dev-utils": "^12.0.0",
@@ -15016,19 +15016,19 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.16.tgz",
-      "integrity": "sha512-dkGpb+xoFNmcp5m5EpwGcFlMT4C7kOTzgZ73QoNoU930NL6OXuqcJdMd4XI6yYuGz+t8Bo8UzzCryEjHTiObOg==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.17.tgz",
+      "integrity": "sha512-DoBwtLjJ9IY9/lNMHIEdo90L4NDayvU28nLgtjR2Sc6aBIMEB/3a5Ndjehnp+jZAkwcDdNASA86EkZVUyz1O1A==",
       "requires": {
         "cssnano-preset-advanced": "^5.1.12",
-        "postcss": "^8.4.6",
+        "postcss": "^8.4.7",
         "postcss-sort-media-queries": "^4.2.1"
       }
     },
     "@docusaurus/logger": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.16.tgz",
-      "integrity": "sha512-/fta5gCXHMLip+8WxYoi+hlB1pwJEeVpFc7Z4iIMwAxn8SrcmCJ0K3wPNjZpDdz0EHrpLHEJ/vEkCuL+7Su4ZQ==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.17.tgz",
+      "integrity": "sha512-F9JDl06/VLg+ylsvnq9NpILSUeWtl0j4H2LtlLzX5gufEL4dGiCMlnUzYdHl7FSHSzYJ0A/R7vu0SYofsexC4w==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.3.1"
@@ -15080,14 +15080,14 @@
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.16.tgz",
-      "integrity": "sha512-NR0Cptz4UGlzgu08AITffRL4rj+SU8HYq2yNFxbY8FSuj/GWI3SrSsBi7grB6fKql0s4SGUKEEzSweewzW1Rgg==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.17.tgz",
+      "integrity": "sha512-AhJ3GWRmjQYCyINHE595pff5tn3Rt83oGpdev5UT9uvG9lPYPC8nEmh1LI6c0ogfw7YkNznzxWSW4hyyVbYQ3A==",
       "requires": {
         "@babel/parser": "^7.17.3",
         "@babel/traverse": "^7.17.3",
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -15103,11 +15103,11 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.16.tgz",
-      "integrity": "sha512-x6/JlbrSfhGuDc6dWybt/E1T6xh/jjEJemlizAGArHpKB0mTuxRm5FRCmksX7z7IM8HZs43tpftGS8gXNL5gug==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.17.tgz",
+      "integrity": "sha512-Tu+8geC/wyygBudbSwvWIHEvt5RwyA7dEoE1JmPbgQtmqUxOZ9bgnfemwXpJW5mKuDiJASbN4of1DhbLqf4sPg==",
       "requires": {
-        "@docusaurus/types": "2.0.0-beta.16",
+        "@docusaurus/types": "2.0.0-beta.17",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
@@ -15115,16 +15115,16 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.16.tgz",
-      "integrity": "sha512-JSRzNKpuMPAndIDIZKbA4G2rA0sC3jPHO+TOmBliO8SBUkw1DL58MZTp98y+5EeUg+KjNIYoz7wRMj3YhFIhJA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.17.tgz",
+      "integrity": "sha512-gcX4UR+WKT4bhF8FICBQHy+ESS9iRMeaglSboTZbA/YHGax/3EuZtcPU3dU4E/HFJeZ866wgUdbLKpIpsZOidg==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/mdx-loader": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-common": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/mdx-loader": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-common": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "cheerio": "^1.0.0-rc.10",
         "feed": "^4.2.2",
         "fs-extra": "^10.0.1",
@@ -15137,15 +15137,15 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.16.tgz",
-      "integrity": "sha512-IiNEud1WYj9a0rkNHjX1JNLfim8f6pyB5w17arRDK6HiY3w51zCQsZJo0popRp1KQQf/g66I+5Y3qP5rHGeU6Q==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.17.tgz",
+      "integrity": "sha512-YYrBpuRfTfE6NtENrpSHTJ7K7PZifn6j6hcuvdC0QKE+WD8pS+O2/Ws30yoyvHwLnAnfhvaderh1v9Kaa0/ANg==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/mdx-loader": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/mdx-loader": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.0.1",
         "import-fresh": "^3.3.0",
@@ -15158,14 +15158,14 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.16.tgz",
-      "integrity": "sha512-XH/dNfDhnad7qA+RUdyJW94Yf8LzALz0bJRwp8GbtjXeAmfP/DWGvVPT/egd9Pz99uO5UgiO9vR1i7UlktQSwA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.17.tgz",
+      "integrity": "sha512-d5x0mXTMJ44ojRQccmLyshYoamFOep2AnBe69osCDnwWMbD3Or3pnc2KMK9N7mVpQFnNFKbHNCLrX3Rv0uwEHA==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/mdx-loader": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/mdx-loader": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "fs-extra": "^10.0.1",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
@@ -15173,67 +15173,67 @@
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.16.tgz",
-      "integrity": "sha512-uzp4hrL/PozgDNEWF/Y+DH+nH0GoC+dOyNLqsyFqQLlzykFHTJYLMK1tfwKHUJ3WqhQFbRwLTR4rzFC89Kaf7g==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.17.tgz",
+      "integrity": "sha512-p26fjYFRSC0esEmKo/kRrLVwXoFnzPCFDumwrImhPyqfVxbj+IKFaiXkayb2qHnyEGE/1KSDIgRF4CHt/pyhiw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
         "fs-extra": "^10.0.1",
         "react-json-view": "^1.21.3",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.16.tgz",
-      "integrity": "sha512-UKd1RWYHeSm/RLjJ2ZflLTT6hbiWQWFAxVzYRBiyOnDbBP+un8qmP692QZCIP+rrm+KkxsV1FGte0NtrcsFUEw==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.17.tgz",
+      "integrity": "sha512-jvgYIhggYD1W2jymqQVAAyjPJUV1xMCn70bAzaCMxriureMWzhQ/kQMVQpop0ijTMvifOxaV9yTcL1VRXev++A==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.16.tgz",
-      "integrity": "sha512-WUD1Kh5y/9VaV/ubg8c6a43gE2+N+yeLUL/qfrUZuLHheaBaozGjioHRbndmfN6W7l2EhuxO1QRN3SlBqc7kjA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.17.tgz",
+      "integrity": "sha512-1pnWHtIk1Jfeqwvr8PlcPE5SODWT1gW4TI+ptmJbJ296FjjyvL/pG0AcGEJmYLY/OQc3oz0VQ0W2ognw9jmFIw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.16.tgz",
-      "integrity": "sha512-B8fa2qvScNSiuCos6vZjPERikRTbbebzy33s5zV+VTZsqLtrjs4//Y0HlJ0tuz5qHWCzavb6nFX/mgFAJoyqFQ==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.17.tgz",
+      "integrity": "sha512-19/PaGCsap6cjUPZPGs87yV9e1hAIyd0CTSeVV6Caega8nmOKk20FTrQGFJjZPeX8jvD9QIXcdg6BJnPxcKkaQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-common": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-common": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "fs-extra": "^10.0.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.16.tgz",
-      "integrity": "sha512-HLY2dC412Lexe2ZupUEUJpY44yz6uqtvibKTXvXH392hFB43Thp7MKr5zACRTwacjbddIoqPVbdzRWtvugSU2g==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.17.tgz",
+      "integrity": "sha512-7YUxPEgM09aZWr25/hpDEp1gPl+1KsCPV1ZTRW43sbQ9TinPm+9AKR3rHVDa8ea8MdiS7BpqCVyK+H/eiyQrUw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
-        "@docusaurus/plugin-debug": "2.0.0-beta.16",
-        "@docusaurus/plugin-google-analytics": "2.0.0-beta.16",
-        "@docusaurus/plugin-google-gtag": "2.0.0-beta.16",
-        "@docusaurus/plugin-sitemap": "2.0.0-beta.16",
-        "@docusaurus/theme-classic": "2.0.0-beta.16",
-        "@docusaurus/theme-common": "2.0.0-beta.16",
-        "@docusaurus/theme-search-algolia": "2.0.0-beta.16"
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
+        "@docusaurus/plugin-debug": "2.0.0-beta.17",
+        "@docusaurus/plugin-google-analytics": "2.0.0-beta.17",
+        "@docusaurus/plugin-google-gtag": "2.0.0-beta.17",
+        "@docusaurus/plugin-sitemap": "2.0.0-beta.17",
+        "@docusaurus/theme-classic": "2.0.0-beta.17",
+        "@docusaurus/theme-common": "2.0.0-beta.17",
+        "@docusaurus/theme-search-algolia": "2.0.0-beta.17"
       }
     },
     "@docusaurus/react-loadable": {
@@ -15246,25 +15246,25 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.16.tgz",
-      "integrity": "sha512-7cylhb2hwAUSM+ZD2ClQwS/Ag8tnt5gTDrma9WzWA+sB7Zd/b5Dc9WHFowzUjieC++UZ+KxYktCfKE/1RWF77w==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.17.tgz",
+      "integrity": "sha512-xfZ9kpgqo0lP9YO4rJj79wtiQJXU6ARo5wYy10IIwiWN+lg00scJHhkmNV431b05xIUjUr0cKeH9nqZmEsQRKg==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
-        "@docusaurus/theme-common": "2.0.0-beta.16",
-        "@docusaurus/theme-translations": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-common": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
+        "@docusaurus/theme-common": "2.0.0-beta.17",
+        "@docusaurus/theme-translations": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-common": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
         "copy-text-to-clipboard": "^3.0.1",
         "infima": "0.2.0-alpha.37",
         "lodash": "^4.17.21",
-        "postcss": "^8.4.6",
+        "postcss": "^8.4.7",
         "prism-react-renderer": "^1.2.1",
         "prismjs": "^1.27.0",
         "react-router-dom": "^5.2.0",
@@ -15272,14 +15272,14 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.16.tgz",
-      "integrity": "sha512-7jP+lVrNMlEXH9bUvjnRxyF1MQpIC0Z+FpBmahTwi1lNAVe1kbs3r7SVsXnBHwI4F+tIWaRMkpEfZfNhH1MjNA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.17.tgz",
+      "integrity": "sha512-LJBDhx+Qexn1JHBqZbE4k+7lBaV1LgpE33enXf43ShB7ebhC91d5HLHhBwgt0pih4+elZU4rG+BG/roAmsNM0g==",
       "requires": {
-        "@docusaurus/module-type-aliases": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.16",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.16",
+        "@docusaurus/module-type-aliases": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
         "clsx": "^1.1.1",
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.1",
@@ -15288,17 +15288,17 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.16.tgz",
-      "integrity": "sha512-yNQ7nWWAzT+abQiiSgnPT3FDE07KDIt4UZgxEwo2WvynDD4O7G+6uUkBryAZXYvgc2GEMw7u0E/8+2EPbJ5yyg==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.17.tgz",
+      "integrity": "sha512-W12XKM7QC5Jmrec359bJ7aDp5U8DNkCxjVKsMNIs8rDunBoI/N+R35ERJ0N7Bg9ONAWO6o7VkUERQsfGqdvr9w==",
       "requires": {
         "@docsearch/react": "^3.0.0",
-        "@docusaurus/core": "2.0.0-beta.16",
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/theme-common": "2.0.0-beta.16",
-        "@docusaurus/theme-translations": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
-        "@docusaurus/utils-validation": "2.0.0-beta.16",
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/theme-common": "2.0.0-beta.17",
+        "@docusaurus/theme-translations": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
         "algoliasearch": "^4.12.1",
         "algoliasearch-helper": "^3.7.0",
         "clsx": "^1.1.1",
@@ -15310,18 +15310,18 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.16.tgz",
-      "integrity": "sha512-OMYjraIbkQyPEdpPGe4zc9gDUm1FxruyBMcxW9pnqh8BoEogPpyFGTJwXiKzOWS6W+xiyctWJYIYmS5laDkriw==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.17.tgz",
+      "integrity": "sha512-oxCX6khjZH3lgdRCL0DH06KkUM/kDr9+lzB35+vY8rpFeQruVgRdi8ekPqG3+Wr0U/N+LMhcYE5BmCb6D0Fv2A==",
       "requires": {
         "fs-extra": "^10.0.1",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/types": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.16.tgz",
-      "integrity": "sha512-ttej9CFthe9+mDMGKMI1wRegXJHLXUZUhxsiYaGczW7PZXdbCQZvKVAoMtrEp/Oa/KOMtqwva60iEEot//KGnQ==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.17.tgz",
+      "integrity": "sha512-4o7TXu5sKlQpybfFFtsGUElBXwSpiXKsQyyWaRKj7DRBkvMtkDX6ITZNnZO9+EHfLbP/cfrokB8C/oO7mCQ5BQ==",
       "requires": {
         "commander": "^5.1.0",
         "joi": "^17.6.0",
@@ -15332,11 +15332,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.16.tgz",
-      "integrity": "sha512-ngOVqWlT+JvHsWDYH1i0oou9Dhhm6gKcTB3PR3nkIlDOdn+MViuhhKivTBD9et5JxAnf8A1hk/oaUO9tBU7WGA==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.17.tgz",
+      "integrity": "sha512-yRKGdzSc5v6M/6GyQ4omkrAHCleevwKYiIrufCJgRbOtkhYE574d8mIjjirOuA/emcyLxjh+TLtqAA5TwhIryA==",
       "requires": {
-        "@docusaurus/logger": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.17",
         "@svgr/webpack": "^6.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.1",
@@ -15354,20 +15354,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.16.tgz",
-      "integrity": "sha512-xAUBVX/BftMPAw9rvdeIKBKmmAX2xus+HbXciL+5VKNG9ePI5X+W739lCqJVm6C2fDRXENBbeaKnnMx9wTeEUg==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.17.tgz",
+      "integrity": "sha512-90WCVdj6zYzs7neEIS594qfLO78cUL6EVK1CsRHJgVkkGjcYlCQ1NwkyO7bOb+nIAwdJrPJRc2FBSpuEGxPD3w==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.16.tgz",
-      "integrity": "sha512-gXAKMP1D5ERX3d5SF88Yp7G9ROYd2XOhyLSErPRaHs5b9SzYhI9lIiPUoXFk6VyRnUjXiUley2/MtdrEgt989A==",
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.17.tgz",
+      "integrity": "sha512-5UjayUP16fDjgd52eSEhL7SlN9x60pIhyS+K7kt7RmpSLy42+4/bSr2pns2VlATmuaoNOO6iIFdB2jgSYJ6SGA==",
       "requires": {
-        "@docusaurus/logger": "2.0.0-beta.16",
-        "@docusaurus/utils": "2.0.0-beta.16",
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
         "joi": "^17.6.0",
         "tslib": "^2.3.1"
       }
@@ -16863,9 +16863,9 @@
           }
         },
         "entities": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
-          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+          "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
         },
         "htmlparser2": {
           "version": "8.0.1",
@@ -16942,9 +16942,9 @@
           }
         },
         "entities": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
-          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+          "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
         }
       }
     },
@@ -20206,9 +20206,9 @@
           }
         },
         "entities": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
-          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+          "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
         },
         "parse5": {
           "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^1.10.2",
-    "@docusaurus/core": "^2.0.0-beta.16",
-    "@docusaurus/preset-classic": "^2.0.0-beta.16",
+    "@docusaurus/core": "^2.0.0-beta.17",
+    "@docusaurus/preset-classic": "^2.0.0-beta.17",
     "clsx": "^1.1.1",
     "docusaurus-gtm-plugin": "0.0.2",
     "mixpanel-browser": "^2.45.0",

--- a/src/theme/ColorModeToggle/index.js
+++ b/src/theme/ColorModeToggle/index.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function ColorModeToggle() {
+  return <></>;
+}


### PR DESCRIPTION
Partially addresses #1024 

This PR updates docusaurus dependencies from beta-16 to beta-17. As a necessary side-quest due to feature deprecation, it rewrites our dark-mode suppression according to [docusaurus's recommendation](https://github.com/facebook/docusaurus/pull/6771). 

## Proof that there's still no option to switch color modes

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/1627089/177628614-d2afaa67-56a1-4e21-aa85-8dc877eae720.png">

### What it would look like if the color mode switch wasn't suppressed

In other words, what it looks like if I delete the swizzled ColorModeToggle from this PR, to show that the file is actively doing something: 

https://user-images.githubusercontent.com/1627089/177629810-a64172f0-4911-43a0-9806-eb702ce332b2.mov


