### PR TITLE
Improve TLS examples with self signed certificates

### DIFF
--- a/docs/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -122,6 +122,32 @@ To configure `zbctl` to disable TLS:
 
 Since `zbctl` is based on the Go client, setting the appropriate environment variables will override these parameters.
 
+## Self signed certificates
+
+It may be useful, for testing or development purposes, to use TLS between the client and the gateway; to simplify things, we can use self-signed certificates for this.
+
+### Testing & example
+
+To generate your own self-signed certificates for testing/development, you will need `openssl` install on your local machine. Then you can run:
+
+```sh
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 --nodes -addext 'subjectAltName=IP:127.0.0.1'
+```
+
+This will generate a new certificate, `cert.pem`, and a new passwordless key, `key.pem`. 
+
+:::warning
+Do not use these in production! Again, this is for development and testing purposes only.
+:::
+
+Then start up your gateway with the certificate and key specified above. For example, if we run a broker with an embedded gateway directly using Docker:
+
+```sh
+docker run -p 26500:26500 -e ZEEBE_BROKER_NETWORK_HOST=0.0.0.0 -e ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED=true -e ZEEBE_BROKER_GATEWAY_SECURITY_CERTIFICATECHAINPATH=/usr/local/zeebe/cert.pem -e ZEEBE_BROKER_GATEWAY_SECURITY_PRIVATEKEYPATH=/usr/local/zeebe/key.pem --mount type=bind,source="$(pwd)"/cert.pem,target=/usr/local/zeebe/cert.pem --mount type=bind,source="$(pwd)"/key.pem,target=/usr/local/zeebe/key.pem camunda/zeebe
+```
+
+There is one caveat: in order for the client to accept this self-signed certificate, you will need to trust it. The simplest way is to specify it as part of the client's configuration. For example, if you're using `zbctl`, you can then do `zbctl --certPath cert.pem status`. Refer to the documentation above on how to configure your clients.
+
 ## Troubleshooting authentication issues
 
 Here we will describe a few ways the clients and gateway could be misconfigured and what those errors look like. Hopefully, this will help you recognize these situations and provide an easy fix.

--- a/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -133,7 +133,7 @@ For this example, whenever you are asked for input, feel free to just press ente
 :::
 
 ```shell
-openssl req -new -newkey rsa:2048 -nodes -out ca.csr -keyout ca.key
+openssl req -config <(printf "[req]\ndistinguished_name=dn\n[dn]\n[ext]\nbasicConstraints=CA:TRUE,pathlen:0") -new -newkey rsa:2048 -nodes -subj "/C=DE/O=Test/OU=Test/ST=BE/CN=cluster.local" -x509 -extensions ext -keyout ca.key -out ca.pem
 openssl x509 -trustout -signkey ca.key -days 365 -req -in ca.csr -out ca.pem
 ```
 
@@ -160,10 +160,13 @@ openssl req -new -key nodeC.key -out nodeC.csr
 3. Create the final certificates for each node:
 
 ```shell
-openssl x509 -req -days 365 -in nodeA.csr -CA ca.pem -CAkey ca.key -set_serial 01 -out nodeA.pem
-openssl x509 -req -days 365 -in nodeB.csr -CA ca.pem -CAkey ca.key -set_serial 01 -out nodeB.pem
-openssl x509 -req -days 365 -in nodeC.csr -CA ca.pem -CAkey ca.key -set_serial 01 -out nodeC.pem
+openssl x509 -req -days 365 -in nodeA.csr -CA ca.pem -CAkey ca.key -set_serial 01 -extfile <(printf "subjectAltName = IP.1:127.0.0.1") -out nodeA.pem
+openssl x509 -req -days 365 -in nodeB.csr -CA ca.pem -CAkey ca.key -set_serial 01 -extfile <(printf "subjectAltName = IP.1:127.0.0.1") -out nodeB.pem
+openssl x509 -req -days 365 -in nodeC.csr -CA ca.pem -CAkey ca.key -set_serial 01 -extfile <(printf "subjectAltName = IP.1:127.0.0.1") -out nodeC.pem
 ```
+
+Make sure to replace `IP.1:127.0.0.1` with the advertised host of the broker. If it's an IP address, then keep the `IP.1` prefix. If it's a hostname/DNS entry, then you can write it out as `DNS.1:advertisedHost`. To be flexible, you can also use a wildcard host. For example, if you're deploying in Kubernetes, you could use `subjectAltName = DNS.1:*.cluster.local"`. You can also omit the whole `-extfile` parameter if you do not wish to use hostname verification at all.
+
 
 4. Create the certificate chain so that each node is able to verify the identity of the others:
 


### PR DESCRIPTION
This PR improves the documentation when testing Zeebe with self-signed certificates, both for client/gateway and inter-cluster communication.

Hopefully it's a little clearer and covers more edge cases now.