### PR TITLE
chore(deps): update docusaurus from beta-17 to beta-18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@auth0/auth0-react": "^1.10.2",
-        "@docusaurus/core": "^2.0.0-beta.17",
-        "@docusaurus/preset-classic": "^2.0.0-beta.17",
+        "@docusaurus/core": "^2.0.0-beta.18",
+        "@docusaurus/preset-classic": "^2.0.0-beta.18",
         "clsx": "^1.1.1",
         "docusaurus-gtm-plugin": "0.0.2",
         "mixpanel-browser": "^2.45.0",
@@ -50,74 +50,74 @@
       "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.13.1.tgz",
-      "integrity": "sha512-UAUVG2PEfwd/FfudsZtYnidJ9eSCpS+LW9cQiesePQLz41NAcddKxBak6eP2GErqyFagSlnVXe/w2E9h2m2ttg==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.0.tgz",
+      "integrity": "sha512-vSX0uPTgTuWdKOv0DbjFBl5AGlWDzYADtv5ChLBBKHTBhAKp4f9b38zDB0v89pCbcoAGZjtb6UTM+pUEVSTuSw==",
       "dependencies": {
-        "@algolia/cache-common": "4.13.1"
+        "@algolia/cache-common": "4.14.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.13.1.tgz",
-      "integrity": "sha512-7Vaf6IM4L0Jkl3sYXbwK+2beQOgVJ0mKFbz/4qSxKd1iy2Sp77uTAazcX+Dlexekg1fqGUOSO7HS4Sx47ZJmjA=="
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.0.tgz",
+      "integrity": "sha512-9bCWX78td6DEtyVIJc2R8MokniFFgbS5r9ADVvBuBeDtVuNhOwDO/MYZ2WlAQJTwos9TtS9v0iJ9Ym0rDHMldA=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.13.1.tgz",
-      "integrity": "sha512-pZzybCDGApfA/nutsFK1P0Sbsq6fYJU3DwIvyKg4pURerlJM4qZbB9bfLRef0FkzfQu7W11E4cVLCIOWmyZeuQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.0.tgz",
+      "integrity": "sha512-kIH9JjebSsZVxnTjaWarunFkWaHnMZ5vG98KwvQj++I4PCMgk7z/GBm9bMNgPUsDPqHxQ0p9HO/j8YgN6VYxgQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.13.1"
+        "@algolia/cache-common": "4.14.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.13.1.tgz",
-      "integrity": "sha512-TFLiZ1KqMiir3FNHU+h3b0MArmyaHG+eT8Iojio6TdpeFcAQ1Aiy+2gb3SZk3+pgRJa/BxGmDkRUwE5E/lv3QQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.0.tgz",
+      "integrity": "sha512-b0rAB3D2rf5qOeBZbUNcixl9EmiVPz6QgEvP2TC3Ed85+8xdVhtbyLD5EzTHQr2BPXvklo5NK1K5Q3UOZ9ojJQ==",
       "dependencies": {
-        "@algolia/client-common": "4.13.1",
-        "@algolia/client-search": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/client-common": "4.14.0",
+        "@algolia/client-search": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.13.1.tgz",
-      "integrity": "sha512-iOS1JBqh7xaL5x00M5zyluZ9+9Uy9GqtYHv/2SMuzNW1qP7/0doz1lbcsP3S7KBbZANJTFHUOfuqyRLPk91iFA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.0.tgz",
+      "integrity": "sha512-HcuAbUP2D2SZiV8pvBd6ZoJNJ1Zu5bvUctCknGS7QVQv4xfeDHFcQulwEPftKBhIoJmVZPsQznpeLf+PTGTA+w==",
       "dependencies": {
-        "@algolia/client-common": "4.13.1",
-        "@algolia/client-search": "4.13.1",
-        "@algolia/requester-common": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/client-common": "4.14.0",
+        "@algolia/client-search": "4.14.0",
+        "@algolia/requester-common": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.13.1.tgz",
-      "integrity": "sha512-LcDoUE0Zz3YwfXJL6lJ2OMY2soClbjrrAKB6auYVMNJcoKZZ2cbhQoFR24AYoxnGUYBER/8B+9sTBj5bj/Gqbg==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.0.tgz",
+      "integrity": "sha512-7pmtPOicY6QEBQEYinChkVVi0SnDGcgJn1P0GkWxIMD23ZQk7o0/eMAQYqkGR3TET6YB/bZDeDrpL5v4DKN3tg==",
       "dependencies": {
-        "@algolia/requester-common": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/requester-common": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.13.1.tgz",
-      "integrity": "sha512-1CqrOW1ypVrB4Lssh02hP//YxluoIYXAQCpg03L+/RiXJlCs+uIqlzC0ctpQPmxSlTK6h07kr50JQoYH/TIM9w==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.0.tgz",
+      "integrity": "sha512-O/vADaSZYAzL0o8L+2QeTZr1O3VXu8DjBUXnEWWgn96v6zqTH0aoQsQ7gvYEsGNvTGiZZwNJNruzMaBNG0GNUA==",
       "dependencies": {
-        "@algolia/client-common": "4.13.1",
-        "@algolia/requester-common": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/client-common": "4.14.0",
+        "@algolia/requester-common": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.13.1.tgz",
-      "integrity": "sha512-YQKYA83MNRz3FgTNM+4eRYbSmHi0WWpo019s5SeYcL3HUan/i5R09VO9dk3evELDFJYciiydSjbsmhBzbpPP2A==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.0.tgz",
+      "integrity": "sha512-gFxteVMUzEMq6lDEex/gZKNudrFmOFLuWS9SQCU+sXeTCRw32aY5/RBDigOkD6Yp6nLkfnYWvPnDshwY6WgTbw==",
       "dependencies": {
-        "@algolia/client-common": "4.13.1",
-        "@algolia/requester-common": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/client-common": "4.14.0",
+        "@algolia/requester-common": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -126,47 +126,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.13.1.tgz",
-      "integrity": "sha512-L6slbL/OyZaAXNtS/1A8SAbOJeEXD5JcZeDCPYDqSTYScfHu+2ePRTDMgUTY4gQ7HsYZ39N1LujOd8WBTmM2Aw=="
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.0.tgz",
+      "integrity": "sha512-1Fw+5Nd4d7NWNA9FhOIIXzESJn+j5VTO/f3YK+XhoOlbAwfMbD32InWEjNglrcHnSO8kpqrizFXveKTx1CzoKw=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.13.1.tgz",
-      "integrity": "sha512-7jQOTftfeeLlnb3YqF8bNgA2GZht7rdKkJ31OCeSH2/61haO0tWPoNRjZq9XLlgMQZH276pPo0NdiArcYPHjCA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.0.tgz",
+      "integrity": "sha512-nBJwg1TVdzAZCIA5tIFYKA+QqYGD9iRhO8yEdm68VcOeckyNTQuvJtAkWyvzr2qNL6GD+bN8nUQ8Cf5HFy/wZg==",
       "dependencies": {
-        "@algolia/logger-common": "4.13.1"
+        "@algolia/logger-common": "4.14.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.13.1.tgz",
-      "integrity": "sha512-oa0CKr1iH6Nc7CmU6RE7TnXMjHnlyp7S80pP/LvZVABeJHX3p/BcSCKovNYWWltgTxUg0U1o+2uuy8BpMKljwA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.0.tgz",
+      "integrity": "sha512-J4ND/l0/wOyztyOA3F4kFNIj/QDTeiS45m3hqSCVXpIJn/iq1ZP8zYW5q0/2sEMehO8TawVJiHnXYV0kO0Dk0Q==",
       "dependencies": {
-        "@algolia/requester-common": "4.13.1"
+        "@algolia/requester-common": "4.14.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.13.1.tgz",
-      "integrity": "sha512-eGVf0ID84apfFEuXsaoSgIxbU3oFsIbz4XiotU3VS8qGCJAaLVUC5BUJEkiFENZIhon7hIB4d0RI13HY4RSA+w=="
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.0.tgz",
+      "integrity": "sha512-8DGIW5keIbAFet2TKGr/C9DVJ1r8IWFjgf4URPHn6NHMf6R+ruQp0gOf7xBP1Bw6JIS3/DbvlGqbw8sNO/N+Hw=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.13.1.tgz",
-      "integrity": "sha512-7C0skwtLdCz5heKTVe/vjvrqgL/eJxmiEjHqXdtypcE5GCQCYI15cb+wC4ytYioZDMiuDGeVYmCYImPoEgUGPw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.0.tgz",
+      "integrity": "sha512-DP0k1H9c6+lR4G/jKG4kez3QW1ksUDSSSSy3I8nhPZErIGgd0IqCTXDt1GwykDEkvYj/l4sA3x8pJtDMW3JSzw==",
       "dependencies": {
-        "@algolia/requester-common": "4.13.1"
+        "@algolia/requester-common": "4.14.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.13.1.tgz",
-      "integrity": "sha512-pICnNQN7TtrcYJqqPEXByV8rJ8ZRU2hCiIKLTLRyNpghtQG3VAFk6fVtdzlNfdUGZcehSKGarPIZEHlQXnKjgw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.0.tgz",
+      "integrity": "sha512-AP+8Qxeg0XvQ3rFbj4pIUzDMmtjo5pgBMx/57ADbge5Y4Y9ByDdQNjEKk6QFIe70SAwR/cGzglwYg7nl8mK/OA==",
       "dependencies": {
-        "@algolia/cache-common": "4.13.1",
-        "@algolia/logger-common": "4.13.1",
-        "@algolia/requester-common": "4.13.1"
+        "@algolia/cache-common": "4.14.0",
+        "@algolia/logger-common": "4.14.0",
+        "@algolia/requester-common": "4.14.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1930,31 +1930,31 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.17.tgz",
-      "integrity": "sha512-iNdW7CsmHNOgc4PxD9BFxa+MD8+i7ln7erOBkF3FSMMPnsKUeVqsR3rr31aLmLZRlTXMITSPLxlXwtBZa3KPCw==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.18.tgz",
+      "integrity": "sha512-puV7l+0/BPSi07Xmr8tVktfs1BzhC8P5pm6Bs2CfvysCJ4nefNCD1CosPc1PGBWy901KqeeEJ1aoGwj9tU3AUA==",
       "dependencies": {
-        "@babel/core": "^7.17.5",
-        "@babel/generator": "^7.17.3",
+        "@babel/core": "^7.17.8",
+        "@babel/generator": "^7.17.7",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",
-        "@babel/runtime": "^7.17.2",
-        "@babel/runtime-corejs3": "^7.17.2",
+        "@babel/runtime": "^7.17.8",
+        "@babel/runtime-corejs3": "^7.17.8",
         "@babel/traverse": "^7.17.3",
-        "@docusaurus/cssnano-preset": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.18",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/mdx-loader": "2.0.0-beta.18",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.1",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-common": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
+        "@slorber/static-site-generator-webpack-plugin": "^4.0.4",
         "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.2",
-        "babel-loader": "^8.2.3",
+        "autoprefixer": "^10.4.4",
+        "babel-loader": "^8.2.4",
         "babel-plugin-dynamic-import-node": "2.3.0",
         "boxen": "^6.2.1",
         "chokidar": "^3.5.3",
@@ -1964,9 +1964,9 @@
         "commander": "^5.1.0",
         "copy-webpack-plugin": "^10.2.4",
         "core-js": "^3.21.1",
-        "css-loader": "^6.6.0",
+        "css-loader": "^6.7.1",
         "css-minimizer-webpack-plugin": "^3.4.1",
-        "cssnano": "^5.0.17",
+        "cssnano": "^5.1.5",
         "del": "^6.0.0",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
@@ -1980,9 +1980,9 @@
         "is-root": "^2.1.0",
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.5.3",
+        "mini-css-extract-plugin": "^2.6.0",
         "nprogress": "^0.2.0",
-        "postcss": "^8.4.7",
+        "postcss": "^8.4.12",
         "postcss-loader": "^6.2.1",
         "prompts": "^2.4.2",
         "react-dev-utils": "^12.0.0",
@@ -1994,7 +1994,7 @@
         "react-router-dom": "^5.2.0",
         "remark-admonitions": "^1.2.1",
         "rtl-detect": "^1.0.4",
-        "semver": "^7.3.4",
+        "semver": "^7.3.5",
         "serve-handler": "^6.1.3",
         "shelljs": "^0.8.5",
         "terser-webpack-plugin": "^5.3.1",
@@ -2002,7 +2002,7 @@
         "update-notifier": "^5.1.0",
         "url-loader": "^4.1.1",
         "wait-on": "^6.0.1",
-        "webpack": "^5.69.1",
+        "webpack": "^5.70.0",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-dev-server": "^4.7.4",
         "webpack-merge": "^5.8.0",
@@ -2214,19 +2214,19 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.17.tgz",
-      "integrity": "sha512-DoBwtLjJ9IY9/lNMHIEdo90L4NDayvU28nLgtjR2Sc6aBIMEB/3a5Ndjehnp+jZAkwcDdNASA86EkZVUyz1O1A==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.18.tgz",
+      "integrity": "sha512-VxhYmpyx16Wv00W9TUfLVv0NgEK/BwP7pOdWoaiELEIAMV7SO1+6iB8gsFUhtfKZ31I4uPVLMKrCyWWakoFeFA==",
       "dependencies": {
-        "cssnano-preset-advanced": "^5.1.12",
-        "postcss": "^8.4.7",
+        "cssnano-preset-advanced": "^5.3.1",
+        "postcss": "^8.4.12",
         "postcss-sort-media-queries": "^4.2.1"
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.17.tgz",
-      "integrity": "sha512-F9JDl06/VLg+ylsvnq9NpILSUeWtl0j4H2LtlLzX5gufEL4dGiCMlnUzYdHl7FSHSzYJ0A/R7vu0SYofsexC4w==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.18.tgz",
+      "integrity": "sha512-frNe5vhH3mbPmH980Lvzaz45+n1PQl3TkslzWYXQeJOkFX17zUd3e3U7F9kR1+DocmAqHkgAoWuXVcvEoN29fg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.3.1"
@@ -2300,14 +2300,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.17.tgz",
-      "integrity": "sha512-AhJ3GWRmjQYCyINHE595pff5tn3Rt83oGpdev5UT9uvG9lPYPC8nEmh1LI6c0ogfw7YkNznzxWSW4hyyVbYQ3A==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.18.tgz",
+      "integrity": "sha512-pOmAQM4Y1jhuZTbEhjh4ilQa74Mh6Q0pMZn1xgIuyYDdqvIOrOlM/H0i34YBn3+WYuwsGim4/X0qynJMLDUA4A==",
       "dependencies": {
-        "@babel/parser": "^7.17.3",
+        "@babel/parser": "^7.17.8",
         "@babel/traverse": "^7.17.3",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2319,7 +2319,7 @@
         "tslib": "^2.3.1",
         "unist-util-visit": "^2.0.2",
         "url-loader": "^4.1.1",
-        "webpack": "^5.69.1"
+        "webpack": "^5.70.0"
       },
       "engines": {
         "node": ">=14"
@@ -2330,11 +2330,11 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.17.tgz",
-      "integrity": "sha512-Tu+8geC/wyygBudbSwvWIHEvt5RwyA7dEoE1JmPbgQtmqUxOZ9bgnfemwXpJW5mKuDiJASbN4of1DhbLqf4sPg==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.18.tgz",
+      "integrity": "sha512-e6mples8FZRyT7QyqidGS6BgkROjM+gljJsdOqoctbtBp+SZ5YDjwRHOmoY7eqEfsQNOaFZvT2hK38ui87hCRA==",
       "dependencies": {
-        "@docusaurus/types": "2.0.0-beta.17",
+        "@docusaurus/types": "2.0.0-beta.18",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
@@ -2346,16 +2346,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.17.tgz",
-      "integrity": "sha512-gcX4UR+WKT4bhF8FICBQHy+ESS9iRMeaglSboTZbA/YHGax/3EuZtcPU3dU4E/HFJeZ866wgUdbLKpIpsZOidg==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.18.tgz",
+      "integrity": "sha512-qzK83DgB+mxklk3PQC2nuTGPQD/8ogw1nXSmaQpyXAyhzcz4CXAZ9Swl/Ee9A/bvPwQGnSHSP3xqIYl8OkFtfw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/mdx-loader": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-common": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "cheerio": "^1.0.0-rc.10",
         "feed": "^4.2.2",
         "fs-extra": "^10.0.1",
@@ -2364,7 +2364,7 @@
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.69.1"
+        "webpack": "^5.70.0"
       },
       "engines": {
         "node": ">=14"
@@ -2375,15 +2375,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.17.tgz",
-      "integrity": "sha512-YYrBpuRfTfE6NtENrpSHTJ7K7PZifn6j6hcuvdC0QKE+WD8pS+O2/Ws30yoyvHwLnAnfhvaderh1v9Kaa0/ANg==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.18.tgz",
+      "integrity": "sha512-z4LFGBJuzn4XQiUA7OEA2SZTqlp+IYVjd3NrCk/ZUfNi1tsTJS36ATkk9Y6d0Nsp7K2kRXqaXPsz4adDgeIU+Q==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/mdx-loader": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.0.1",
         "import-fresh": "^3.3.0",
@@ -2392,7 +2392,7 @@
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.69.1"
+        "webpack": "^5.70.0"
       },
       "engines": {
         "node": ">=14"
@@ -2403,18 +2403,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.17.tgz",
-      "integrity": "sha512-d5x0mXTMJ44ojRQccmLyshYoamFOep2AnBe69osCDnwWMbD3Or3pnc2KMK9N7mVpQFnNFKbHNCLrX3Rv0uwEHA==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.18.tgz",
+      "integrity": "sha512-CJ2Xeb9hQrMeF4DGywSDVX2TFKsQpc8ZA7czyeBAAbSFsoRyxXPYeSh8aWljqR4F1u/EKGSKy0Shk/D4wumaHw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/mdx-loader": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "fs-extra": "^10.0.1",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
-        "webpack": "^5.69.1"
+        "webpack": "^5.70.0"
       },
       "engines": {
         "node": ">=14"
@@ -2425,12 +2425,12 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.17.tgz",
-      "integrity": "sha512-p26fjYFRSC0esEmKo/kRrLVwXoFnzPCFDumwrImhPyqfVxbj+IKFaiXkayb2qHnyEGE/1KSDIgRF4CHt/pyhiw==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.18.tgz",
+      "integrity": "sha512-inLnLERgG7q0WlVmK6nYGHwVqREz13ivkynmNygEibJZToFRdgnIPW+OwD8QzgC5MpQTJw7+uYjcitpBumy1Gw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
         "fs-extra": "^10.0.1",
         "react-json-view": "^1.21.3",
         "tslib": "^2.3.1"
@@ -2444,12 +2444,12 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.17.tgz",
-      "integrity": "sha512-jvgYIhggYD1W2jymqQVAAyjPJUV1xMCn70bAzaCMxriureMWzhQ/kQMVQpop0ijTMvifOxaV9yTcL1VRXev++A==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.18.tgz",
+      "integrity": "sha512-s9dRBWDrZ1uu3wFXPCF7yVLo/+5LUFAeoxpXxzory8gn9GYDt8ZDj80h5DUyCLxiy72OG6bXWNOYS/Vc6cOPXQ==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2461,12 +2461,12 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.17.tgz",
-      "integrity": "sha512-1pnWHtIk1Jfeqwvr8PlcPE5SODWT1gW4TI+ptmJbJ296FjjyvL/pG0AcGEJmYLY/OQc3oz0VQ0W2ognw9jmFIw==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.18.tgz",
+      "integrity": "sha512-h7vPuLVo/9pHmbFcvb4tCpjg4SxxX4k+nfVDyippR254FM++Z/nA5pRB0WvvIJ3ZTe0ioOb5Wlx2xdzJIBHUNg==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2478,14 +2478,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.17.tgz",
-      "integrity": "sha512-19/PaGCsap6cjUPZPGs87yV9e1hAIyd0CTSeVV6Caega8nmOKk20FTrQGFJjZPeX8jvD9QIXcdg6BJnPxcKkaQ==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.18.tgz",
+      "integrity": "sha512-Klonht0Ye3FivdBpS80hkVYNOH+8lL/1rbCPEV92rKhwYdwnIejqhdKct4tUTCl8TYwWiyeUFQqobC/5FNVZPQ==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-common": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "fs-extra": "^10.0.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.3.1"
@@ -2499,21 +2499,21 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.17.tgz",
-      "integrity": "sha512-7YUxPEgM09aZWr25/hpDEp1gPl+1KsCPV1ZTRW43sbQ9TinPm+9AKR3rHVDa8ea8MdiS7BpqCVyK+H/eiyQrUw==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.18.tgz",
+      "integrity": "sha512-TfDulvFt/vLWr/Yy7O0yXgwHtJhdkZ739bTlFNwEkRMAy8ggi650e52I1I0T79s67llecb4JihgHPW+mwiVkCQ==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
-        "@docusaurus/plugin-debug": "2.0.0-beta.17",
-        "@docusaurus/plugin-google-analytics": "2.0.0-beta.17",
-        "@docusaurus/plugin-google-gtag": "2.0.0-beta.17",
-        "@docusaurus/plugin-sitemap": "2.0.0-beta.17",
-        "@docusaurus/theme-classic": "2.0.0-beta.17",
-        "@docusaurus/theme-common": "2.0.0-beta.17",
-        "@docusaurus/theme-search-algolia": "2.0.0-beta.17"
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.18",
+        "@docusaurus/plugin-debug": "2.0.0-beta.18",
+        "@docusaurus/plugin-google-analytics": "2.0.0-beta.18",
+        "@docusaurus/plugin-google-gtag": "2.0.0-beta.18",
+        "@docusaurus/plugin-sitemap": "2.0.0-beta.18",
+        "@docusaurus/theme-classic": "2.0.0-beta.18",
+        "@docusaurus/theme-common": "2.0.0-beta.18",
+        "@docusaurus/theme-search-algolia": "2.0.0-beta.18"
       },
       "engines": {
         "node": ">=14"
@@ -2536,29 +2536,29 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.17.tgz",
-      "integrity": "sha512-xfZ9kpgqo0lP9YO4rJj79wtiQJXU6ARo5wYy10IIwiWN+lg00scJHhkmNV431b05xIUjUr0cKeH9nqZmEsQRKg==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.18.tgz",
+      "integrity": "sha512-WJWofvSGKC4Luidk0lyUwkLnO3DDynBBHwmt4QrV+aAVWWSOHUjA2mPOF6GLGuzkZd3KfL9EvAfsU0aGE1Hh5g==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
-        "@docusaurus/theme-common": "2.0.0-beta.17",
-        "@docusaurus/theme-translations": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.18",
+        "@docusaurus/theme-common": "2.0.0-beta.18",
+        "@docusaurus/theme-translations": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-common": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
         "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.37",
+        "infima": "0.2.0-alpha.38",
         "lodash": "^4.17.21",
-        "postcss": "^8.4.7",
-        "prism-react-renderer": "^1.2.1",
+        "postcss": "^8.4.12",
+        "prism-react-renderer": "^1.3.1",
         "prismjs": "^1.27.0",
         "react-router-dom": "^5.2.0",
-        "rtlcss": "^3.3.0"
+        "rtlcss": "^3.5.0"
       },
       "engines": {
         "node": ">=14"
@@ -2569,14 +2569,14 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.17.tgz",
-      "integrity": "sha512-LJBDhx+Qexn1JHBqZbE4k+7lBaV1LgpE33enXf43ShB7ebhC91d5HLHhBwgt0pih4+elZU4rG+BG/roAmsNM0g==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.18.tgz",
+      "integrity": "sha512-3pI2Q6ttScDVTDbuUKAx+TdC8wmwZ2hfWk8cyXxksvC9bBHcyzXhSgcK8LTsszn2aANyZ3e3QY2eNSOikTFyng==",
       "dependencies": {
-        "@docusaurus/module-type-aliases": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
+        "@docusaurus/module-type-aliases": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.18",
         "clsx": "^1.1.1",
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.1",
@@ -2592,19 +2592,20 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.17.tgz",
-      "integrity": "sha512-W12XKM7QC5Jmrec359bJ7aDp5U8DNkCxjVKsMNIs8rDunBoI/N+R35ERJ0N7Bg9ONAWO6o7VkUERQsfGqdvr9w==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.18.tgz",
+      "integrity": "sha512-2w97KO/gnjI49WVtYQqENpQ8iO1Sem0yaTxw7/qv/ndlmIAQD0syU4yx6GsA7bTQCOGwKOWWzZSetCgUmTnWgA==",
       "dependencies": {
         "@docsearch/react": "^3.0.0",
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/theme-common": "2.0.0-beta.17",
-        "@docusaurus/theme-translations": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
-        "algoliasearch": "^4.12.1",
-        "algoliasearch-helper": "^3.7.0",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.18",
+        "@docusaurus/theme-common": "2.0.0-beta.18",
+        "@docusaurus/theme-translations": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
+        "algoliasearch": "^4.13.0",
+        "algoliasearch-helper": "^3.7.4",
         "clsx": "^1.1.1",
         "eta": "^1.12.3",
         "fs-extra": "^10.0.1",
@@ -2621,9 +2622,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.17.tgz",
-      "integrity": "sha512-oxCX6khjZH3lgdRCL0DH06KkUM/kDr9+lzB35+vY8rpFeQruVgRdi8ekPqG3+Wr0U/N+LMhcYE5BmCb6D0Fv2A==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.18.tgz",
+      "integrity": "sha512-1uTEUXlKC9nco1Lx9H5eOwzB+LP4yXJG5wfv1PMLE++kJEdZ40IVorlUi3nJnaa9/lJNq5vFvvUDrmeNWsxy/Q==",
       "dependencies": {
         "fs-extra": "^10.0.1",
         "tslib": "^2.3.1"
@@ -2633,47 +2634,46 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.17.tgz",
-      "integrity": "sha512-4o7TXu5sKlQpybfFFtsGUElBXwSpiXKsQyyWaRKj7DRBkvMtkDX6ITZNnZO9+EHfLbP/cfrokB8C/oO7mCQ5BQ==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.18.tgz",
+      "integrity": "sha512-zkuSmPQYP3+z4IjGHlW0nGzSSpY7Sit0Nciu/66zSb5m07TK72t6T1MlpCAn/XijcB9Cq6nenC3kJh66nGsKYg==",
       "dependencies": {
         "commander": "^5.1.0",
         "joi": "^17.6.0",
-        "querystring": "0.2.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.69.1",
+        "webpack": "^5.70.0",
         "webpack-merge": "^5.8.0"
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.17.tgz",
-      "integrity": "sha512-yRKGdzSc5v6M/6GyQ4omkrAHCleevwKYiIrufCJgRbOtkhYE574d8mIjjirOuA/emcyLxjh+TLtqAA5TwhIryA==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.18.tgz",
+      "integrity": "sha512-v2vBmH7xSbPwx3+GB90HgLSQdj+Rh5ELtZWy7M20w907k0ROzDmPQ/8Ke2DK3o5r4pZPGnCrsB3SaYI83AEmAA==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@svgr/webpack": "^6.0.0",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.1",
         "github-slugger": "^1.4.0",
-        "globby": "^11.0.4",
+        "globby": "^11.1.0",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
-        "micromatch": "^4.0.4",
+        "micromatch": "^4.0.5",
         "resolve-pathname": "^3.0.0",
         "shelljs": "^0.8.5",
         "tslib": "^2.3.1",
         "url-loader": "^4.1.1",
-        "webpack": "^5.69.1"
+        "webpack": "^5.70.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.17.tgz",
-      "integrity": "sha512-90WCVdj6zYzs7neEIS594qfLO78cUL6EVK1CsRHJgVkkGjcYlCQ1NwkyO7bOb+nIAwdJrPJRc2FBSpuEGxPD3w==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.18.tgz",
+      "integrity": "sha512-pK83EcOIiKCLGhrTwukZMo5jqd1sqqqhQwOVyxyvg+x9SY/lsnNzScA96OEfm+qQLBwK1OABA7Xc1wfkgkUxvw==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -2682,13 +2682,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.17.tgz",
-      "integrity": "sha512-5UjayUP16fDjgd52eSEhL7SlN9x60pIhyS+K7kt7RmpSLy42+4/bSr2pns2VlATmuaoNOO6iIFdB2jgSYJ6SGA==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.18.tgz",
+      "integrity": "sha512-3aDrXjJJ8Cw2MAYEk5JMNnr8UHPxmVNbPU/PIHFWmWK09nJvs3IQ8nc9+8I30aIjRdIyc/BIOCxgvAcJ4hsxTA==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
         "joi": "^17.6.0",
+        "js-yaml": "^4.1.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -3811,24 +3812,24 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.13.1.tgz",
-      "integrity": "sha512-dtHUSE0caWTCE7liE1xaL+19AFf6kWEcyn76uhcitWpntqvicFHXKFoZe5JJcv9whQOTRM6+B8qJz6sFj+rDJA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.0.tgz",
+      "integrity": "sha512-r1rt5UQnrmqwjloi4tZzggUC7oWjNR/gfk+fjx0x4oP2UeDW5c8/XCovVFs9nwJ4n2xNKlxELyMAedcuLrBdng==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.13.1",
-        "@algolia/cache-common": "4.13.1",
-        "@algolia/cache-in-memory": "4.13.1",
-        "@algolia/client-account": "4.13.1",
-        "@algolia/client-analytics": "4.13.1",
-        "@algolia/client-common": "4.13.1",
-        "@algolia/client-personalization": "4.13.1",
-        "@algolia/client-search": "4.13.1",
-        "@algolia/logger-common": "4.13.1",
-        "@algolia/logger-console": "4.13.1",
-        "@algolia/requester-browser-xhr": "4.13.1",
-        "@algolia/requester-common": "4.13.1",
-        "@algolia/requester-node-http": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/cache-browser-local-storage": "4.14.0",
+        "@algolia/cache-common": "4.14.0",
+        "@algolia/cache-in-memory": "4.14.0",
+        "@algolia/client-account": "4.14.0",
+        "@algolia/client-analytics": "4.14.0",
+        "@algolia/client-common": "4.14.0",
+        "@algolia/client-personalization": "4.14.0",
+        "@algolia/client-search": "4.14.0",
+        "@algolia/logger-common": "4.14.0",
+        "@algolia/logger-console": "4.14.0",
+        "@algolia/requester-browser-xhr": "4.14.0",
+        "@algolia/requester-common": "4.14.0",
+        "@algolia/requester-node-http": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "node_modules/algoliasearch-helper": {
@@ -7479,9 +7480,9 @@
       }
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.37.tgz",
-      "integrity": "sha512-4GX7Baw+/lwS4PPW/UJNY89tWSvYG1DL6baKVdpK6mC593iRgMssxNtORMTFArLPJ/A/lzsGhRmx+z6MaMxj0Q==",
+      "version": "0.2.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.38.tgz",
+      "integrity": "sha512-1WsmqSMI5IqzrUx3goq+miJznHBonbE3aoqZ1AR/i/oHhroxNeSV6Awv5VoVfXBhfTzLSnxkHaRI2qpAMYcCzw==",
       "engines": {
         "node": ">=12"
       }
@@ -10221,15 +10222,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/queue": {
@@ -13488,74 +13480,74 @@
       "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.13.1.tgz",
-      "integrity": "sha512-UAUVG2PEfwd/FfudsZtYnidJ9eSCpS+LW9cQiesePQLz41NAcddKxBak6eP2GErqyFagSlnVXe/w2E9h2m2ttg==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.0.tgz",
+      "integrity": "sha512-vSX0uPTgTuWdKOv0DbjFBl5AGlWDzYADtv5ChLBBKHTBhAKp4f9b38zDB0v89pCbcoAGZjtb6UTM+pUEVSTuSw==",
       "requires": {
-        "@algolia/cache-common": "4.13.1"
+        "@algolia/cache-common": "4.14.0"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.13.1.tgz",
-      "integrity": "sha512-7Vaf6IM4L0Jkl3sYXbwK+2beQOgVJ0mKFbz/4qSxKd1iy2Sp77uTAazcX+Dlexekg1fqGUOSO7HS4Sx47ZJmjA=="
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.0.tgz",
+      "integrity": "sha512-9bCWX78td6DEtyVIJc2R8MokniFFgbS5r9ADVvBuBeDtVuNhOwDO/MYZ2WlAQJTwos9TtS9v0iJ9Ym0rDHMldA=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.13.1.tgz",
-      "integrity": "sha512-pZzybCDGApfA/nutsFK1P0Sbsq6fYJU3DwIvyKg4pURerlJM4qZbB9bfLRef0FkzfQu7W11E4cVLCIOWmyZeuQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.0.tgz",
+      "integrity": "sha512-kIH9JjebSsZVxnTjaWarunFkWaHnMZ5vG98KwvQj++I4PCMgk7z/GBm9bMNgPUsDPqHxQ0p9HO/j8YgN6VYxgQ==",
       "requires": {
-        "@algolia/cache-common": "4.13.1"
+        "@algolia/cache-common": "4.14.0"
       }
     },
     "@algolia/client-account": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.13.1.tgz",
-      "integrity": "sha512-TFLiZ1KqMiir3FNHU+h3b0MArmyaHG+eT8Iojio6TdpeFcAQ1Aiy+2gb3SZk3+pgRJa/BxGmDkRUwE5E/lv3QQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.0.tgz",
+      "integrity": "sha512-b0rAB3D2rf5qOeBZbUNcixl9EmiVPz6QgEvP2TC3Ed85+8xdVhtbyLD5EzTHQr2BPXvklo5NK1K5Q3UOZ9ojJQ==",
       "requires": {
-        "@algolia/client-common": "4.13.1",
-        "@algolia/client-search": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/client-common": "4.14.0",
+        "@algolia/client-search": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.13.1.tgz",
-      "integrity": "sha512-iOS1JBqh7xaL5x00M5zyluZ9+9Uy9GqtYHv/2SMuzNW1qP7/0doz1lbcsP3S7KBbZANJTFHUOfuqyRLPk91iFA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.0.tgz",
+      "integrity": "sha512-HcuAbUP2D2SZiV8pvBd6ZoJNJ1Zu5bvUctCknGS7QVQv4xfeDHFcQulwEPftKBhIoJmVZPsQznpeLf+PTGTA+w==",
       "requires": {
-        "@algolia/client-common": "4.13.1",
-        "@algolia/client-search": "4.13.1",
-        "@algolia/requester-common": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/client-common": "4.14.0",
+        "@algolia/client-search": "4.14.0",
+        "@algolia/requester-common": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "@algolia/client-common": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.13.1.tgz",
-      "integrity": "sha512-LcDoUE0Zz3YwfXJL6lJ2OMY2soClbjrrAKB6auYVMNJcoKZZ2cbhQoFR24AYoxnGUYBER/8B+9sTBj5bj/Gqbg==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.0.tgz",
+      "integrity": "sha512-7pmtPOicY6QEBQEYinChkVVi0SnDGcgJn1P0GkWxIMD23ZQk7o0/eMAQYqkGR3TET6YB/bZDeDrpL5v4DKN3tg==",
       "requires": {
-        "@algolia/requester-common": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/requester-common": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.13.1.tgz",
-      "integrity": "sha512-1CqrOW1ypVrB4Lssh02hP//YxluoIYXAQCpg03L+/RiXJlCs+uIqlzC0ctpQPmxSlTK6h07kr50JQoYH/TIM9w==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.0.tgz",
+      "integrity": "sha512-O/vADaSZYAzL0o8L+2QeTZr1O3VXu8DjBUXnEWWgn96v6zqTH0aoQsQ7gvYEsGNvTGiZZwNJNruzMaBNG0GNUA==",
       "requires": {
-        "@algolia/client-common": "4.13.1",
-        "@algolia/requester-common": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/client-common": "4.14.0",
+        "@algolia/requester-common": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "@algolia/client-search": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.13.1.tgz",
-      "integrity": "sha512-YQKYA83MNRz3FgTNM+4eRYbSmHi0WWpo019s5SeYcL3HUan/i5R09VO9dk3evELDFJYciiydSjbsmhBzbpPP2A==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.0.tgz",
+      "integrity": "sha512-gFxteVMUzEMq6lDEex/gZKNudrFmOFLuWS9SQCU+sXeTCRw32aY5/RBDigOkD6Yp6nLkfnYWvPnDshwY6WgTbw==",
       "requires": {
-        "@algolia/client-common": "4.13.1",
-        "@algolia/requester-common": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/client-common": "4.14.0",
+        "@algolia/requester-common": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "@algolia/events": {
@@ -13564,47 +13556,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/logger-common": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.13.1.tgz",
-      "integrity": "sha512-L6slbL/OyZaAXNtS/1A8SAbOJeEXD5JcZeDCPYDqSTYScfHu+2ePRTDMgUTY4gQ7HsYZ39N1LujOd8WBTmM2Aw=="
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.0.tgz",
+      "integrity": "sha512-1Fw+5Nd4d7NWNA9FhOIIXzESJn+j5VTO/f3YK+XhoOlbAwfMbD32InWEjNglrcHnSO8kpqrizFXveKTx1CzoKw=="
     },
     "@algolia/logger-console": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.13.1.tgz",
-      "integrity": "sha512-7jQOTftfeeLlnb3YqF8bNgA2GZht7rdKkJ31OCeSH2/61haO0tWPoNRjZq9XLlgMQZH276pPo0NdiArcYPHjCA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.0.tgz",
+      "integrity": "sha512-nBJwg1TVdzAZCIA5tIFYKA+QqYGD9iRhO8yEdm68VcOeckyNTQuvJtAkWyvzr2qNL6GD+bN8nUQ8Cf5HFy/wZg==",
       "requires": {
-        "@algolia/logger-common": "4.13.1"
+        "@algolia/logger-common": "4.14.0"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.13.1.tgz",
-      "integrity": "sha512-oa0CKr1iH6Nc7CmU6RE7TnXMjHnlyp7S80pP/LvZVABeJHX3p/BcSCKovNYWWltgTxUg0U1o+2uuy8BpMKljwA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.0.tgz",
+      "integrity": "sha512-J4ND/l0/wOyztyOA3F4kFNIj/QDTeiS45m3hqSCVXpIJn/iq1ZP8zYW5q0/2sEMehO8TawVJiHnXYV0kO0Dk0Q==",
       "requires": {
-        "@algolia/requester-common": "4.13.1"
+        "@algolia/requester-common": "4.14.0"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.13.1.tgz",
-      "integrity": "sha512-eGVf0ID84apfFEuXsaoSgIxbU3oFsIbz4XiotU3VS8qGCJAaLVUC5BUJEkiFENZIhon7hIB4d0RI13HY4RSA+w=="
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.0.tgz",
+      "integrity": "sha512-8DGIW5keIbAFet2TKGr/C9DVJ1r8IWFjgf4URPHn6NHMf6R+ruQp0gOf7xBP1Bw6JIS3/DbvlGqbw8sNO/N+Hw=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.13.1.tgz",
-      "integrity": "sha512-7C0skwtLdCz5heKTVe/vjvrqgL/eJxmiEjHqXdtypcE5GCQCYI15cb+wC4ytYioZDMiuDGeVYmCYImPoEgUGPw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.0.tgz",
+      "integrity": "sha512-DP0k1H9c6+lR4G/jKG4kez3QW1ksUDSSSSy3I8nhPZErIGgd0IqCTXDt1GwykDEkvYj/l4sA3x8pJtDMW3JSzw==",
       "requires": {
-        "@algolia/requester-common": "4.13.1"
+        "@algolia/requester-common": "4.14.0"
       }
     },
     "@algolia/transporter": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.13.1.tgz",
-      "integrity": "sha512-pICnNQN7TtrcYJqqPEXByV8rJ8ZRU2hCiIKLTLRyNpghtQG3VAFk6fVtdzlNfdUGZcehSKGarPIZEHlQXnKjgw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.0.tgz",
+      "integrity": "sha512-AP+8Qxeg0XvQ3rFbj4pIUzDMmtjo5pgBMx/57ADbge5Y4Y9ByDdQNjEKk6QFIe70SAwR/cGzglwYg7nl8mK/OA==",
       "requires": {
-        "@algolia/cache-common": "4.13.1",
-        "@algolia/logger-common": "4.13.1",
-        "@algolia/requester-common": "4.13.1"
+        "@algolia/cache-common": "4.14.0",
+        "@algolia/logger-common": "4.14.0",
+        "@algolia/requester-common": "4.14.0"
       }
     },
     "@ampproject/remapping": {
@@ -14813,31 +14805,31 @@
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.17.tgz",
-      "integrity": "sha512-iNdW7CsmHNOgc4PxD9BFxa+MD8+i7ln7erOBkF3FSMMPnsKUeVqsR3rr31aLmLZRlTXMITSPLxlXwtBZa3KPCw==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.18.tgz",
+      "integrity": "sha512-puV7l+0/BPSi07Xmr8tVktfs1BzhC8P5pm6Bs2CfvysCJ4nefNCD1CosPc1PGBWy901KqeeEJ1aoGwj9tU3AUA==",
       "requires": {
-        "@babel/core": "^7.17.5",
-        "@babel/generator": "^7.17.3",
+        "@babel/core": "^7.17.8",
+        "@babel/generator": "^7.17.7",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",
-        "@babel/runtime": "^7.17.2",
-        "@babel/runtime-corejs3": "^7.17.2",
+        "@babel/runtime": "^7.17.8",
+        "@babel/runtime-corejs3": "^7.17.8",
         "@babel/traverse": "^7.17.3",
-        "@docusaurus/cssnano-preset": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.18",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/mdx-loader": "2.0.0-beta.18",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.1",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-common": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
+        "@slorber/static-site-generator-webpack-plugin": "^4.0.4",
         "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.2",
-        "babel-loader": "^8.2.3",
+        "autoprefixer": "^10.4.4",
+        "babel-loader": "^8.2.4",
         "babel-plugin-dynamic-import-node": "2.3.0",
         "boxen": "^6.2.1",
         "chokidar": "^3.5.3",
@@ -14847,9 +14839,9 @@
         "commander": "^5.1.0",
         "copy-webpack-plugin": "^10.2.4",
         "core-js": "^3.21.1",
-        "css-loader": "^6.6.0",
+        "css-loader": "^6.7.1",
         "css-minimizer-webpack-plugin": "^3.4.1",
-        "cssnano": "^5.0.17",
+        "cssnano": "^5.1.5",
         "del": "^6.0.0",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
@@ -14863,9 +14855,9 @@
         "is-root": "^2.1.0",
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.5.3",
+        "mini-css-extract-plugin": "^2.6.0",
         "nprogress": "^0.2.0",
-        "postcss": "^8.4.7",
+        "postcss": "^8.4.12",
         "postcss-loader": "^6.2.1",
         "prompts": "^2.4.2",
         "react-dev-utils": "^12.0.0",
@@ -14877,7 +14869,7 @@
         "react-router-dom": "^5.2.0",
         "remark-admonitions": "^1.2.1",
         "rtl-detect": "^1.0.4",
-        "semver": "^7.3.4",
+        "semver": "^7.3.5",
         "serve-handler": "^6.1.3",
         "shelljs": "^0.8.5",
         "terser-webpack-plugin": "^5.3.1",
@@ -14885,7 +14877,7 @@
         "update-notifier": "^5.1.0",
         "url-loader": "^4.1.1",
         "wait-on": "^6.0.1",
-        "webpack": "^5.69.1",
+        "webpack": "^5.70.0",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-dev-server": "^4.7.4",
         "webpack-merge": "^5.8.0",
@@ -15016,19 +15008,19 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.17.tgz",
-      "integrity": "sha512-DoBwtLjJ9IY9/lNMHIEdo90L4NDayvU28nLgtjR2Sc6aBIMEB/3a5Ndjehnp+jZAkwcDdNASA86EkZVUyz1O1A==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.18.tgz",
+      "integrity": "sha512-VxhYmpyx16Wv00W9TUfLVv0NgEK/BwP7pOdWoaiELEIAMV7SO1+6iB8gsFUhtfKZ31I4uPVLMKrCyWWakoFeFA==",
       "requires": {
-        "cssnano-preset-advanced": "^5.1.12",
-        "postcss": "^8.4.7",
+        "cssnano-preset-advanced": "^5.3.1",
+        "postcss": "^8.4.12",
         "postcss-sort-media-queries": "^4.2.1"
       }
     },
     "@docusaurus/logger": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.17.tgz",
-      "integrity": "sha512-F9JDl06/VLg+ylsvnq9NpILSUeWtl0j4H2LtlLzX5gufEL4dGiCMlnUzYdHl7FSHSzYJ0A/R7vu0SYofsexC4w==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.18.tgz",
+      "integrity": "sha512-frNe5vhH3mbPmH980Lvzaz45+n1PQl3TkslzWYXQeJOkFX17zUd3e3U7F9kR1+DocmAqHkgAoWuXVcvEoN29fg==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.3.1"
@@ -15080,14 +15072,14 @@
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.17.tgz",
-      "integrity": "sha512-AhJ3GWRmjQYCyINHE595pff5tn3Rt83oGpdev5UT9uvG9lPYPC8nEmh1LI6c0ogfw7YkNznzxWSW4hyyVbYQ3A==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.18.tgz",
+      "integrity": "sha512-pOmAQM4Y1jhuZTbEhjh4ilQa74Mh6Q0pMZn1xgIuyYDdqvIOrOlM/H0i34YBn3+WYuwsGim4/X0qynJMLDUA4A==",
       "requires": {
-        "@babel/parser": "^7.17.3",
+        "@babel/parser": "^7.17.8",
         "@babel/traverse": "^7.17.3",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -15099,15 +15091,15 @@
         "tslib": "^2.3.1",
         "unist-util-visit": "^2.0.2",
         "url-loader": "^4.1.1",
-        "webpack": "^5.69.1"
+        "webpack": "^5.70.0"
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.17.tgz",
-      "integrity": "sha512-Tu+8geC/wyygBudbSwvWIHEvt5RwyA7dEoE1JmPbgQtmqUxOZ9bgnfemwXpJW5mKuDiJASbN4of1DhbLqf4sPg==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.18.tgz",
+      "integrity": "sha512-e6mples8FZRyT7QyqidGS6BgkROjM+gljJsdOqoctbtBp+SZ5YDjwRHOmoY7eqEfsQNOaFZvT2hK38ui87hCRA==",
       "requires": {
-        "@docusaurus/types": "2.0.0-beta.17",
+        "@docusaurus/types": "2.0.0-beta.18",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
@@ -15115,16 +15107,16 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.17.tgz",
-      "integrity": "sha512-gcX4UR+WKT4bhF8FICBQHy+ESS9iRMeaglSboTZbA/YHGax/3EuZtcPU3dU4E/HFJeZ866wgUdbLKpIpsZOidg==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.18.tgz",
+      "integrity": "sha512-qzK83DgB+mxklk3PQC2nuTGPQD/8ogw1nXSmaQpyXAyhzcz4CXAZ9Swl/Ee9A/bvPwQGnSHSP3xqIYl8OkFtfw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/mdx-loader": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-common": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "cheerio": "^1.0.0-rc.10",
         "feed": "^4.2.2",
         "fs-extra": "^10.0.1",
@@ -15133,19 +15125,19 @@
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.69.1"
+        "webpack": "^5.70.0"
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.17.tgz",
-      "integrity": "sha512-YYrBpuRfTfE6NtENrpSHTJ7K7PZifn6j6hcuvdC0QKE+WD8pS+O2/Ws30yoyvHwLnAnfhvaderh1v9Kaa0/ANg==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.18.tgz",
+      "integrity": "sha512-z4LFGBJuzn4XQiUA7OEA2SZTqlp+IYVjd3NrCk/ZUfNi1tsTJS36ATkk9Y6d0Nsp7K2kRXqaXPsz4adDgeIU+Q==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/mdx-loader": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.0.1",
         "import-fresh": "^3.3.0",
@@ -15154,86 +15146,86 @@
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.69.1"
+        "webpack": "^5.70.0"
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.17.tgz",
-      "integrity": "sha512-d5x0mXTMJ44ojRQccmLyshYoamFOep2AnBe69osCDnwWMbD3Or3pnc2KMK9N7mVpQFnNFKbHNCLrX3Rv0uwEHA==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.18.tgz",
+      "integrity": "sha512-CJ2Xeb9hQrMeF4DGywSDVX2TFKsQpc8ZA7czyeBAAbSFsoRyxXPYeSh8aWljqR4F1u/EKGSKy0Shk/D4wumaHw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/mdx-loader": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "fs-extra": "^10.0.1",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
-        "webpack": "^5.69.1"
+        "webpack": "^5.70.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.17.tgz",
-      "integrity": "sha512-p26fjYFRSC0esEmKo/kRrLVwXoFnzPCFDumwrImhPyqfVxbj+IKFaiXkayb2qHnyEGE/1KSDIgRF4CHt/pyhiw==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.18.tgz",
+      "integrity": "sha512-inLnLERgG7q0WlVmK6nYGHwVqREz13ivkynmNygEibJZToFRdgnIPW+OwD8QzgC5MpQTJw7+uYjcitpBumy1Gw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
         "fs-extra": "^10.0.1",
         "react-json-view": "^1.21.3",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.17.tgz",
-      "integrity": "sha512-jvgYIhggYD1W2jymqQVAAyjPJUV1xMCn70bAzaCMxriureMWzhQ/kQMVQpop0ijTMvifOxaV9yTcL1VRXev++A==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.18.tgz",
+      "integrity": "sha512-s9dRBWDrZ1uu3wFXPCF7yVLo/+5LUFAeoxpXxzory8gn9GYDt8ZDj80h5DUyCLxiy72OG6bXWNOYS/Vc6cOPXQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.17.tgz",
-      "integrity": "sha512-1pnWHtIk1Jfeqwvr8PlcPE5SODWT1gW4TI+ptmJbJ296FjjyvL/pG0AcGEJmYLY/OQc3oz0VQ0W2ognw9jmFIw==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.18.tgz",
+      "integrity": "sha512-h7vPuLVo/9pHmbFcvb4tCpjg4SxxX4k+nfVDyippR254FM++Z/nA5pRB0WvvIJ3ZTe0ioOb5Wlx2xdzJIBHUNg==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.17.tgz",
-      "integrity": "sha512-19/PaGCsap6cjUPZPGs87yV9e1hAIyd0CTSeVV6Caega8nmOKk20FTrQGFJjZPeX8jvD9QIXcdg6BJnPxcKkaQ==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.18.tgz",
+      "integrity": "sha512-Klonht0Ye3FivdBpS80hkVYNOH+8lL/1rbCPEV92rKhwYdwnIejqhdKct4tUTCl8TYwWiyeUFQqobC/5FNVZPQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-common": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "fs-extra": "^10.0.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.17.tgz",
-      "integrity": "sha512-7YUxPEgM09aZWr25/hpDEp1gPl+1KsCPV1ZTRW43sbQ9TinPm+9AKR3rHVDa8ea8MdiS7BpqCVyK+H/eiyQrUw==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.18.tgz",
+      "integrity": "sha512-TfDulvFt/vLWr/Yy7O0yXgwHtJhdkZ739bTlFNwEkRMAy8ggi650e52I1I0T79s67llecb4JihgHPW+mwiVkCQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
-        "@docusaurus/plugin-debug": "2.0.0-beta.17",
-        "@docusaurus/plugin-google-analytics": "2.0.0-beta.17",
-        "@docusaurus/plugin-google-gtag": "2.0.0-beta.17",
-        "@docusaurus/plugin-sitemap": "2.0.0-beta.17",
-        "@docusaurus/theme-classic": "2.0.0-beta.17",
-        "@docusaurus/theme-common": "2.0.0-beta.17",
-        "@docusaurus/theme-search-algolia": "2.0.0-beta.17"
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.18",
+        "@docusaurus/plugin-debug": "2.0.0-beta.18",
+        "@docusaurus/plugin-google-analytics": "2.0.0-beta.18",
+        "@docusaurus/plugin-google-gtag": "2.0.0-beta.18",
+        "@docusaurus/plugin-sitemap": "2.0.0-beta.18",
+        "@docusaurus/theme-classic": "2.0.0-beta.18",
+        "@docusaurus/theme-common": "2.0.0-beta.18",
+        "@docusaurus/theme-search-algolia": "2.0.0-beta.18"
       }
     },
     "@docusaurus/react-loadable": {
@@ -15246,40 +15238,40 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.17.tgz",
-      "integrity": "sha512-xfZ9kpgqo0lP9YO4rJj79wtiQJXU6ARo5wYy10IIwiWN+lg00scJHhkmNV431b05xIUjUr0cKeH9nqZmEsQRKg==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.18.tgz",
+      "integrity": "sha512-WJWofvSGKC4Luidk0lyUwkLnO3DDynBBHwmt4QrV+aAVWWSOHUjA2mPOF6GLGuzkZd3KfL9EvAfsU0aGE1Hh5g==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
-        "@docusaurus/theme-common": "2.0.0-beta.17",
-        "@docusaurus/theme-translations": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.18",
+        "@docusaurus/theme-common": "2.0.0-beta.18",
+        "@docusaurus/theme-translations": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-common": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
         "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.37",
+        "infima": "0.2.0-alpha.38",
         "lodash": "^4.17.21",
-        "postcss": "^8.4.7",
-        "prism-react-renderer": "^1.2.1",
+        "postcss": "^8.4.12",
+        "prism-react-renderer": "^1.3.1",
         "prismjs": "^1.27.0",
         "react-router-dom": "^5.2.0",
-        "rtlcss": "^3.3.0"
+        "rtlcss": "^3.5.0"
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.17.tgz",
-      "integrity": "sha512-LJBDhx+Qexn1JHBqZbE4k+7lBaV1LgpE33enXf43ShB7ebhC91d5HLHhBwgt0pih4+elZU4rG+BG/roAmsNM0g==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.18.tgz",
+      "integrity": "sha512-3pI2Q6ttScDVTDbuUKAx+TdC8wmwZ2hfWk8cyXxksvC9bBHcyzXhSgcK8LTsszn2aANyZ3e3QY2eNSOikTFyng==",
       "requires": {
-        "@docusaurus/module-type-aliases": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
+        "@docusaurus/module-type-aliases": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.18",
         "clsx": "^1.1.1",
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.1",
@@ -15288,19 +15280,20 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.17.tgz",
-      "integrity": "sha512-W12XKM7QC5Jmrec359bJ7aDp5U8DNkCxjVKsMNIs8rDunBoI/N+R35ERJ0N7Bg9ONAWO6o7VkUERQsfGqdvr9w==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.18.tgz",
+      "integrity": "sha512-2w97KO/gnjI49WVtYQqENpQ8iO1Sem0yaTxw7/qv/ndlmIAQD0syU4yx6GsA7bTQCOGwKOWWzZSetCgUmTnWgA==",
       "requires": {
         "@docsearch/react": "^3.0.0",
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/theme-common": "2.0.0-beta.17",
-        "@docusaurus/theme-translations": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
-        "algoliasearch": "^4.12.1",
-        "algoliasearch-helper": "^3.7.0",
+        "@docusaurus/core": "2.0.0-beta.18",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.18",
+        "@docusaurus/theme-common": "2.0.0-beta.18",
+        "@docusaurus/theme-translations": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
+        "@docusaurus/utils-validation": "2.0.0-beta.18",
+        "algoliasearch": "^4.13.0",
+        "algoliasearch-helper": "^3.7.4",
         "clsx": "^1.1.1",
         "eta": "^1.12.3",
         "fs-extra": "^10.0.1",
@@ -15310,65 +15303,65 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.17.tgz",
-      "integrity": "sha512-oxCX6khjZH3lgdRCL0DH06KkUM/kDr9+lzB35+vY8rpFeQruVgRdi8ekPqG3+Wr0U/N+LMhcYE5BmCb6D0Fv2A==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.18.tgz",
+      "integrity": "sha512-1uTEUXlKC9nco1Lx9H5eOwzB+LP4yXJG5wfv1PMLE++kJEdZ40IVorlUi3nJnaa9/lJNq5vFvvUDrmeNWsxy/Q==",
       "requires": {
         "fs-extra": "^10.0.1",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/types": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.17.tgz",
-      "integrity": "sha512-4o7TXu5sKlQpybfFFtsGUElBXwSpiXKsQyyWaRKj7DRBkvMtkDX6ITZNnZO9+EHfLbP/cfrokB8C/oO7mCQ5BQ==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.18.tgz",
+      "integrity": "sha512-zkuSmPQYP3+z4IjGHlW0nGzSSpY7Sit0Nciu/66zSb5m07TK72t6T1MlpCAn/XijcB9Cq6nenC3kJh66nGsKYg==",
       "requires": {
         "commander": "^5.1.0",
         "joi": "^17.6.0",
-        "querystring": "0.2.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.69.1",
+        "webpack": "^5.70.0",
         "webpack-merge": "^5.8.0"
       }
     },
     "@docusaurus/utils": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.17.tgz",
-      "integrity": "sha512-yRKGdzSc5v6M/6GyQ4omkrAHCleevwKYiIrufCJgRbOtkhYE574d8mIjjirOuA/emcyLxjh+TLtqAA5TwhIryA==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.18.tgz",
+      "integrity": "sha512-v2vBmH7xSbPwx3+GB90HgLSQdj+Rh5ELtZWy7M20w907k0ROzDmPQ/8Ke2DK3o5r4pZPGnCrsB3SaYI83AEmAA==",
       "requires": {
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@svgr/webpack": "^6.0.0",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.1",
         "github-slugger": "^1.4.0",
-        "globby": "^11.0.4",
+        "globby": "^11.1.0",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
-        "micromatch": "^4.0.4",
+        "micromatch": "^4.0.5",
         "resolve-pathname": "^3.0.0",
         "shelljs": "^0.8.5",
         "tslib": "^2.3.1",
         "url-loader": "^4.1.1",
-        "webpack": "^5.69.1"
+        "webpack": "^5.70.0"
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.17.tgz",
-      "integrity": "sha512-90WCVdj6zYzs7neEIS594qfLO78cUL6EVK1CsRHJgVkkGjcYlCQ1NwkyO7bOb+nIAwdJrPJRc2FBSpuEGxPD3w==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.18.tgz",
+      "integrity": "sha512-pK83EcOIiKCLGhrTwukZMo5jqd1sqqqhQwOVyxyvg+x9SY/lsnNzScA96OEfm+qQLBwK1OABA7Xc1wfkgkUxvw==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.17.tgz",
-      "integrity": "sha512-5UjayUP16fDjgd52eSEhL7SlN9x60pIhyS+K7kt7RmpSLy42+4/bSr2pns2VlATmuaoNOO6iIFdB2jgSYJ6SGA==",
+      "version": "2.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.18.tgz",
+      "integrity": "sha512-3aDrXjJJ8Cw2MAYEk5JMNnr8UHPxmVNbPU/PIHFWmWK09nJvs3IQ8nc9+8I30aIjRdIyc/BIOCxgvAcJ4hsxTA==",
       "requires": {
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.18",
+        "@docusaurus/utils": "2.0.0-beta.18",
         "joi": "^17.6.0",
+        "js-yaml": "^4.1.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16272,24 +16265,24 @@
       "requires": {}
     },
     "algoliasearch": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.13.1.tgz",
-      "integrity": "sha512-dtHUSE0caWTCE7liE1xaL+19AFf6kWEcyn76uhcitWpntqvicFHXKFoZe5JJcv9whQOTRM6+B8qJz6sFj+rDJA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.0.tgz",
+      "integrity": "sha512-r1rt5UQnrmqwjloi4tZzggUC7oWjNR/gfk+fjx0x4oP2UeDW5c8/XCovVFs9nwJ4n2xNKlxELyMAedcuLrBdng==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.13.1",
-        "@algolia/cache-common": "4.13.1",
-        "@algolia/cache-in-memory": "4.13.1",
-        "@algolia/client-account": "4.13.1",
-        "@algolia/client-analytics": "4.13.1",
-        "@algolia/client-common": "4.13.1",
-        "@algolia/client-personalization": "4.13.1",
-        "@algolia/client-search": "4.13.1",
-        "@algolia/logger-common": "4.13.1",
-        "@algolia/logger-console": "4.13.1",
-        "@algolia/requester-browser-xhr": "4.13.1",
-        "@algolia/requester-common": "4.13.1",
-        "@algolia/requester-node-http": "4.13.1",
-        "@algolia/transporter": "4.13.1"
+        "@algolia/cache-browser-local-storage": "4.14.0",
+        "@algolia/cache-common": "4.14.0",
+        "@algolia/cache-in-memory": "4.14.0",
+        "@algolia/client-account": "4.14.0",
+        "@algolia/client-analytics": "4.14.0",
+        "@algolia/client-common": "4.14.0",
+        "@algolia/client-personalization": "4.14.0",
+        "@algolia/client-search": "4.14.0",
+        "@algolia/logger-common": "4.14.0",
+        "@algolia/logger-console": "4.14.0",
+        "@algolia/requester-browser-xhr": "4.14.0",
+        "@algolia/requester-common": "4.14.0",
+        "@algolia/requester-node-http": "4.14.0",
+        "@algolia/transporter": "4.14.0"
       }
     },
     "algoliasearch-helper": {
@@ -18926,9 +18919,9 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "infima": {
-      "version": "0.2.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.37.tgz",
-      "integrity": "sha512-4GX7Baw+/lwS4PPW/UJNY89tWSvYG1DL6baKVdpK6mC593iRgMssxNtORMTFArLPJ/A/lzsGhRmx+z6MaMxj0Q=="
+      "version": "0.2.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.38.tgz",
+      "integrity": "sha512-1WsmqSMI5IqzrUx3goq+miJznHBonbE3aoqZ1AR/i/oHhroxNeSV6Awv5VoVfXBhfTzLSnxkHaRI2qpAMYcCzw=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -20813,11 +20806,6 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
-    },
-    "querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
     },
     "queue": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^1.10.2",
-    "@docusaurus/core": "^2.0.0-beta.17",
-    "@docusaurus/preset-classic": "^2.0.0-beta.17",
+    "@docusaurus/core": "^2.0.0-beta.18",
+    "@docusaurus/preset-classic": "^2.0.0-beta.18",
     "clsx": "^1.1.1",
     "docusaurus-gtm-plugin": "0.0.2",
     "mixpanel-browser": "^2.45.0",


### PR DESCRIPTION
Partially addresses #1024 

This PR updates docusaurus dependencies from beta-17 to beta-18. 

None of [the breaking changes from this update](https://docusaurus.io/changelog/2.0.0-beta.18#-breaking-change) affect us. This is a nice easy update...the calm before the storm of the next one 😅 