### PR TITLE
docs rename selfmanaged

### DIFF
--- a/docs/apis-clients/operate-api/index.md
+++ b/docs/apis-clients/operate-api/index.md
@@ -69,7 +69,7 @@ curl -b cookie.txt -X POST 'http://localhost:8080/v1/process-definitions/search'
 
 ### Authentication for Self-Managed cluster
 
-The authentication is described in [Operate Configuration - Authentication](/docs/self-managed/operate-deployment/authentication/#identity).
+The authentication is described in [Operate Configuration - Authentication](/docs/self-managed/operate-deployment/operate-authentication/#identity).
 
 ## Endpoints
 

--- a/docs/apis-clients/tasklist-api/tasklist-api-overview.md
+++ b/docs/apis-clients/tasklist-api/tasklist-api-overview.md
@@ -73,7 +73,7 @@ If the authorization is successful, the authorization server sends back the acce
 
 ## Authentication for Self-Managed cluster
 
-The authentication is described in [Tasklist Configuration - Authentication](/docs/self-managed/tasklist-deployment/authentication/#identity).
+The authentication is described in [Tasklist Configuration - Authentication](/docs/self-managed/tasklist-deployment/tasklist-authentication/#identity).
 
 ## Obtaining the Tasklist schema
 

--- a/docs/components/best-practices/architecture/deciding-about-your-stack.md
+++ b/docs/components/best-practices/architecture/deciding-about-your-stack.md
@@ -70,7 +70,7 @@ You can develop process solutions as decribed with Java above also in any other 
 
 ### Running Camunda Platform 8 self-managed
 
-You can also run Camunda Platform 8 self-managed on your own Kubernetes cluster. Details can be found in the [docs](/docs/self-managed/platform-deployment/platform-8-deployment.md).
+You can also run Camunda Platform 8 self-managed on your own Kubernetes cluster. Details can be found in the [docs](../../../self-managed/platform-deployment/platform-8-deployment.md).
 
 While there [exists a Docker Compose configuration](/docs/self-managed/platform-deployment/docker/) to run Camunda Cload locally, this is not meant to be used for production, but rather to quickly startup compenents on a developer machine to be able to play around.
 

--- a/docs/components/best-practices/architecture/deciding-about-your-stack.md
+++ b/docs/components/best-practices/architecture/deciding-about-your-stack.md
@@ -70,7 +70,7 @@ You can develop process solutions as decribed with Java above also in any other 
 
 ### Running Camunda Platform 8 self-managed
 
-You can also run Camunda Platform 8 self-managed on your own Kubernetes cluster. Details can be found in the [docs](/docs/self-managed/platform-deployment).
+You can also run Camunda Platform 8 self-managed on your own Kubernetes cluster. Details can be found in the [docs](/docs/self-managed/platform-deployment/platform-8-deployment.md).
 
 While there [exists a Docker Compose configuration](/docs/self-managed/platform-deployment/docker/) to run Camunda Cload locally, this is not meant to be used for production, but rather to quickly startup compenents on a developer machine to be able to play around.
 

--- a/docs/components/best-practices/operations/operating-camunda-c7.md
+++ b/docs/components/best-practices/operations/operating-camunda-c7.md
@@ -12,7 +12,7 @@ tags:
 To successfully operate Camunda Platform 7.x, you need to take into account operation requirements when modeling business processes. Use your existing tools and infrastructure for technical monitoring and alarming. When appropriate, use Camunda Cockpit and consider extending it with plugins instead of writing your own tooling.
 
 :::caution Camunda Platform 7 only
-This best practice targets Camunda Platform 7.x only! The Camunda Platform 8 stacks differs and operating it is discussed in [Camunda Platform 8 Self-Managed](/docs/self-managed/overview/).
+This best practice targets Camunda Platform 7.x only! The Camunda Platform 8 stacks differs and operating it is discussed in [Camunda Platform 8 Self-Managed](/docs/self-managed/about-self-managed/).
 :::
 
 ## Installing Camunda Platform 7.x

--- a/docs/components/components-overview.md
+++ b/docs/components/components-overview.md
@@ -18,6 +18,6 @@ This section contains product manual content for each component in Camunda Platf
 
 :::note Looking for deployment guides?
 
-Deployment guides for Camunda Platform 8 components are available in the [Self-Managed section](./self-managed/overview.md).
+Deployment guides for Camunda Platform 8 components are available in the [Self-Managed section](./self-managed/about-self-managed.md).
 
 :::

--- a/docs/components/modeler/desktop-modeler/connect-to-camunda-cloud.md
+++ b/docs/components/modeler/desktop-modeler/connect-to-camunda-cloud.md
@@ -9,7 +9,7 @@ Desktop Modeler can directly deploy diagrams and start process instances in Camu
 
 ![deployment icon](./img/deploy-icon.png)
 
-2. Click **Camunda Platform 8 SaaS**, or alternatively, select **Camunda Platform 8 Self-Managed** if you want to deploy to a [local installation](../../../../self-managed/platform-deployment/), for example:
+1. Click **Camunda Platform 8 SaaS**, or alternatively, select **Camunda Platform 8 Self-Managed** if you want to deploy to a [local installation](../../../self-managed/platform-deployment/platform-8-deployment.md), for example:
 
 ![deployment configuration](./img/deploy-diagram-camunda-cloud.png)
 

--- a/docs/components/zeebe/zeebe-overview.md
+++ b/docs/components/zeebe/zeebe-overview.md
@@ -18,7 +18,7 @@ With Zeebe you can:
 - Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter) added in Camunda Platform 8 Self-Managed).
 - Engage with an active community.
 
-For documentation on deploying Zeebe as part of Camunda Platform 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/index.md).
+For documentation on deploying Zeebe as part of Camunda Platform 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).
 
 ## Enterprise support for Zeebe
 

--- a/docs/guides/update-guide/026-to-100.md
+++ b/docs/guides/update-guide/026-to-100.md
@@ -271,7 +271,7 @@ histroy or audit purpose, but cannot be loaded by Camunda Cloud 1.0.
 
 If you want to keep the existing data in Elasticsearch, ensure you set a
 new index prefix for all systems. See the configuration documentation for
-[Zeebe](self-managed/zeebe-deployment/index.md),
+[Zeebe](self-managed/zeebe-deployment/zeebe-installation.md),
 [Operate](self-managed/operate-deployment/operate-configuration.md), and [Tasklist](self-managed/tasklist-deployment/tasklist-configuration.md).
 
 ## Client

--- a/docs/guides/update-guide/026-to-100.md
+++ b/docs/guides/update-guide/026-to-100.md
@@ -272,7 +272,7 @@ histroy or audit purpose, but cannot be loaded by Camunda Cloud 1.0.
 If you want to keep the existing data in Elasticsearch, ensure you set a
 new index prefix for all systems. See the configuration documentation for
 [Zeebe](self-managed/zeebe-deployment/index.md),
-[Operate](self-managed/operate-deployment/configuration.md), and [Tasklist](self-managed/tasklist-deployment/configuration.md).
+[Operate](self-managed/operate-deployment/operate-configuration.md), and [Tasklist](self-managed/tasklist-deployment/configuration.md).
 
 ## Client
 

--- a/docs/guides/update-guide/026-to-100.md
+++ b/docs/guides/update-guide/026-to-100.md
@@ -272,7 +272,7 @@ histroy or audit purpose, but cannot be loaded by Camunda Cloud 1.0.
 If you want to keep the existing data in Elasticsearch, ensure you set a
 new index prefix for all systems. See the configuration documentation for
 [Zeebe](self-managed/zeebe-deployment/index.md),
-[Operate](self-managed/operate-deployment/operate-configuration.md), and [Tasklist](self-managed/tasklist-deployment/configuration.md).
+[Operate](self-managed/operate-deployment/operate-configuration.md), and [Tasklist](self-managed/tasklist-deployment/tasklist-configuration.md).
 
 ## Client
 

--- a/docs/guides/update-guide/130-to-800.md
+++ b/docs/guides/update-guide/130-to-800.md
@@ -57,9 +57,9 @@ With version 8.0, Operate offers a new [REST API](/apis-clients/operate-api/inde
 
 ### Tasklist
 
-With Camunda Platform 8 the IAM component was replaced with the new [Identity](/self-managed/identity/what-is-identity.md) project. There is no update path from IAM to Identity, which means all configured roles and permissions have to be recreated after the update. Please refer to the [Tasklist documentation](/self-managed/tasklist-deployment/authentication.md#identity) how to connect Tasklist with Identity.
+With Camunda Platform 8 the IAM component was replaced with the new [Identity](/self-managed/identity/what-is-identity.md) project. There is no update path from IAM to Identity, which means all configured roles and permissions have to be recreated after the update. Please refer to the [Tasklist documentation](/self-managed/tasklist-deployment/tasklist-authentication.md#identity) how to connect Tasklist with Identity.
 
-With version 8.0, Tasklist supports configuring secure connections to the Zeebe gateway, see the [connection configuration section](/self-managed/tasklist-deployment/configuration.md#settings-to-connect-1) in the Tasklist documentation.
+With version 8.0, Tasklist supports configuring secure connections to the Zeebe gateway, see the [connection configuration section](/self-managed/tasklist-deployment/tasklist-configuration.md#settings-to-connect-1) in the Tasklist documentation.
 
 ### IAM
 

--- a/docs/guides/update-guide/130-to-800.md
+++ b/docs/guides/update-guide/130-to-800.md
@@ -49,9 +49,9 @@ To configure if inserting or updating key-value pairs on RocksDB should check th
 
 ### Operate
 
-With Camunda Platform 8 the IAM component was replaced with the new [Identity](/self-managed/identity/what-is-identity.md) project. There is no update path from IAM to Identity, which means all configured roles and permissions have to be recreated after the update. Please refer to the [Operate documentation](/self-managed/operate-deployment/authentication.md#identity) how to connect Operate with Identity.
+With Camunda Platform 8 the IAM component was replaced with the new [Identity](/self-managed/identity/what-is-identity.md) project. There is no update path from IAM to Identity, which means all configured roles and permissions have to be recreated after the update. Please refer to the [Operate documentation](/self-managed/operate-deployment/operate-authentication.md#identity) how to connect Operate with Identity.
 
-With version 8.0, Operate supports configuring secure connections to the Zeebe gateway, see the [connection configuration section](/self-managed/operate-deployment/configuration.md#settings-to-connect-1) in the Operate documentation.
+With version 8.0, Operate supports configuring secure connections to the Zeebe gateway, see the [connection configuration section](/self-managed/operate-deployment/operate-configuration.md#settings-to-connect-1) in the Operate documentation.
 
 With version 8.0, Operate offers a new [REST API](/apis-clients/operate-api/index.md) to access process data.
 
@@ -63,7 +63,7 @@ With version 8.0, Tasklist supports configuring secure connections to the Zeebe 
 
 ### IAM
 
-With Camunda Platform 8 the IAM component was replaced with the new [Identity](/self-managed/identity/what-is-identity.md) project. Please refer to the [Identity documentation](/self-managed/identity/getting-started/index.md) to learn how to install and configure it.
+With Camunda Platform 8 the IAM component was replaced with the new [Identity](/self-managed/identity/what-is-identity.md) project. Please refer to the [Identity documentation](/self-managed/identity/getting-started/install-identity.md) to learn how to install and configure it.
 
 ## Client
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -52,7 +52,7 @@ A correlation is an attribute within a message used to match this message agains
 
 A process cannot execute unless it is known by the broker. Deployment is the process of pushing or deploying processes to the broker.
 
-- [Zeebe Deployment](./self-managed/overview.md)
+- [Zeebe Deployment](./self-managed/about-self-managed.md)
 
 ### Event
 

--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -28,7 +28,7 @@ _Hint: There are more [community-maintained Camunda Platform 8 clients](./apis-c
 
 ## Camunda Platform 8 Self-Managed
 
-We highly recommend running Camunda Platform 8 Self-Managed in a Kubernetes environment. We provide officially supported [Helm Charts](/docs/self-managed/platform-deployment/kubernetes-helm/) for this. Please follow the [Installation Guide](/docs/self-managed/platform-deployment/) to learn more about installation possibilities.
+We highly recommend running Camunda Platform 8 Self-Managed in a Kubernetes environment. We provide officially supported [Helm Charts](/docs/self-managed/platform-deployment/kubernetes-helm/) for this. Please follow the [Installation Guide](/docs/self-managed/platform-deployment/platform-8-deployment) to learn more about installation possibilities.
 
 Requirements for the components can be seen below:
 

--- a/docs/self-managed/about-self-managed.md
+++ b/docs/self-managed/about-self-managed.md
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: about-self-managed
 title: "Camunda Platform 8 Self-Managed"
 ---
 

--- a/docs/self-managed/identity/getting-started/install-identity.md
+++ b/docs/self-managed/identity/getting-started/install-identity.md
@@ -8,7 +8,7 @@ sidebar_label: "Installation and first steps"
 
 To use Identity, first install it locally via Docker or Kubernetes.
 
-Follow the [Installation Guide](/docs/self-managed/platform-deployment/).
+Follow the [Installation Guide](/docs/self-managed/platform-deployment/platform-8-deployment).
 
 ## Accessing the UI
 

--- a/docs/self-managed/identity/getting-started/install-identity.md
+++ b/docs/self-managed/identity/getting-started/install-identity.md
@@ -1,5 +1,5 @@
 ---
-id: index
+id: install-identity
 title: "Installation and first steps"
 sidebar_label: "Installation and first steps"
 ---

--- a/docs/self-managed/identity/troubleshooting/troubleshoot-identity.md
+++ b/docs/self-managed/identity/troubleshooting/troubleshoot-identity.md
@@ -1,5 +1,5 @@
 ---
-id: index
+id: troubleshoot-identity
 title: "Troubleshooting Identity"
 sidebar_label: "Overview"
 ---

--- a/docs/self-managed/identity/what-is-identity.md
+++ b/docs/self-managed/identity/what-is-identity.md
@@ -17,4 +17,4 @@ Identity is the component within the Camunda Platform 8 stack responsible for au
 
 ### Next steps
 
-If you're new to Identity, we suggest reviewing our [Getting Started Guide](../getting-started/).
+If you're new to Identity, we suggest reviewing our [Getting Started Guide](./getting-started/install-identity.md).

--- a/docs/self-managed/operate-deployment/install-and-start.md
+++ b/docs/self-managed/operate-deployment/install-and-start.md
@@ -4,4 +4,4 @@ title: Installation
 description: "Let's get started with Operate with these simple installation steps."
 ---
 
-Please refer to the [Installation Guide](/docs/self-managed/platform-deployment/) for details on how to install Operate.
+Please refer to the [Installation Guide](/docs/self-managed/platform-deployment/platform-8-deployment) for details on how to install Operate.

--- a/docs/self-managed/operate-deployment/operate-authentication.md
+++ b/docs/self-managed/operate-deployment/operate-authentication.md
@@ -1,5 +1,5 @@
 ---
-id: authentication
+id: operate-authentication
 title: Authentication
 description: "Let's take a closer look at how Operate authenticates for use."
 ---

--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -1,5 +1,5 @@
 ---
-id: configuration
+id: operate-configuration
 title: Configuration
 ---
 
@@ -13,7 +13,7 @@ By default, the configuration for Operate is stored in a YAML file (`application
 - [Zeebe Broker connection](#zeebe-broker-connection)
 - [Zeebe Elasticsearch Exporter](#zeebe-elasticsearch-exporter)
 - [Operation Executor](#operation-executor)
-- [Authentication](authentication.md)
+- [Authentication](operate-authentication.md)
 - [Scaling Operate](importer-and-archiver.md)
 - [Monitoring possibilities](#monitoring-operate)
 - [Logging configuration](#logging)

--- a/docs/self-managed/optimize-deployment/install-and-start.md
+++ b/docs/self-managed/optimize-deployment/install-and-start.md
@@ -6,7 +6,7 @@ description: "Install and configure Optimize Self-Managed."
 
 ## Camunda Platform 8 stack
 
-Please refer to the [Installation Guide](/docs/self-managed/platform-deployment/) for details on how to install Optimize as part of a Camunda 8 stack.
+Please refer to the [Installation Guide](/docs/self-managed/platform-deployment/platform-8-deployment) for details on how to install Optimize as part of a Camunda 8 stack.
 
 ## Camunda Platform 7 Enterprise stack
 

--- a/docs/self-managed/platform-deployment/docker.md
+++ b/docs/self-managed/platform-deployment/docker.md
@@ -16,7 +16,7 @@ The provided Docker images are supported for production usage only on Linux syst
 | Component | Docker image                                                         | Link to configuration options                                                                         |
 | --------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | Zeebe     | [camunda/zeebe:latest](https://hub.docker.com/r/camunda/zeebe)       | [Environment variables](../../zeebe-deployment/configuration/environment-variables/)                  |
-| Operate   | [camunda/operate:latest](https://hub.docker.com/r/camunda/operate)   | [Operate configuration](../../operate-deployment/configuration)                                       |
+| Operate   | [camunda/operate:latest](https://hub.docker.com/r/camunda/operate)   | [Operate configuration](../../operate-deployment/operate-configuration)                               |
 | Tasklist  | [camunda/tasklist:latest](https://hub.docker.com/r/camunda/tasklist) | [Tasklist configuration](../../tasklist-deployment/configuration)                                     |
 | Identity  | [camunda/identity:latest](https://hub.docker.com/r/camunda/identity) | [Configuration variables](../../identity/deployment/configuration-variables/)                         |
 | Optimize  | [camunda/optimize:latest](https://hub.docker.com/r/camunda/optimize) | [Environment variables](../../optimize-deployment/install-and-start/#available-environment-variables) |

--- a/docs/self-managed/platform-deployment/docker.md
+++ b/docs/self-managed/platform-deployment/docker.md
@@ -17,7 +17,7 @@ The provided Docker images are supported for production usage only on Linux syst
 | --------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | Zeebe     | [camunda/zeebe:latest](https://hub.docker.com/r/camunda/zeebe)       | [Environment variables](../../zeebe-deployment/configuration/environment-variables/)                  |
 | Operate   | [camunda/operate:latest](https://hub.docker.com/r/camunda/operate)   | [Operate configuration](../../operate-deployment/operate-configuration)                               |
-| Tasklist  | [camunda/tasklist:latest](https://hub.docker.com/r/camunda/tasklist) | [Tasklist configuration](../../tasklist-deployment/configuration)                                     |
+| Tasklist  | [camunda/tasklist:latest](https://hub.docker.com/r/camunda/tasklist) | [Tasklist configuration](../../tasklist-deployment/tasklist-configuration)                            |
 | Identity  | [camunda/identity:latest](https://hub.docker.com/r/camunda/identity) | [Configuration variables](../../identity/deployment/configuration-variables/)                         |
 | Optimize  | [camunda/optimize:latest](https://hub.docker.com/r/camunda/optimize) | [Environment variables](../../optimize-deployment/install-and-start/#available-environment-variables) |
 

--- a/docs/self-managed/platform-deployment/docker.md
+++ b/docs/self-managed/platform-deployment/docker.md
@@ -39,7 +39,7 @@ A Docker Compose configuration to run Zeebe, Operate, Tasklist, Optimize, and Id
 Follow the instructions in the [README](https://github.com/camunda/camunda-platform#using-docker-compose).
 
 :::warning
-While the Docker images themselves are supported for production usage, the Docker Compose files are designed to be used by developers to run an environment locally; they are not designed to be used in production. We recommend to use [Kubernetes](../kubernetes) in production, see also [Installation Overview](./).
+While the Docker images themselves are supported for production usage, the Docker Compose files are designed to be used by developers to run an environment locally; they are not designed to be used in production. We recommend to use [Kubernetes](./kubernetes.md) in production, see also [Installation Overview](./).
 :::
 
 This Docker Compose configuration serves two purposes:
@@ -48,7 +48,7 @@ This Docker Compose configuration serves two purposes:
 2. It documents how the various components need to be wired together.
 
 :::note
-We recommend to use [Helm + KIND](../kubernetes-helm/#installing-the-camunda-helm-chart-locally-using-kind) instead of Docker Compose for local environments, as the Helm configurations are battle-tested and much closer to production systems.
+We recommend to use [Helm + KIND](./kubernetes-helm.md#installing-the-camunda-helm-chart-locally-using-kind) instead of Docker Compose for local environments, as the Helm configurations are battle-tested and much closer to production systems.
 :::
 
 ## Configuration hints

--- a/docs/self-managed/platform-deployment/platform-8-deployment.md
+++ b/docs/self-managed/platform-deployment/platform-8-deployment.md
@@ -1,5 +1,5 @@
 ---
-id: index
+id: platform-8-deployment
 title: "Camunda Platform 8 deployment"
 sidebar_label: "Overview"
 ---

--- a/docs/self-managed/platform-deployment/platform-8-deployment.md
+++ b/docs/self-managed/platform-deployment/platform-8-deployment.md
@@ -1,7 +1,7 @@
 ---
 id: platform-8-deployment
 title: "Camunda Platform 8 deployment"
-sidebar_label: "Overview"
+sidebar_label: "Deployment"
 ---
 
 This chapter contains information for users who want to deploy and run Camunda Platform 8 Self-Managed, typically in your self-controlled cloud (public or private) or even on your own hardware.

--- a/docs/self-managed/platform-deployment/platform-8-deployment.md
+++ b/docs/self-managed/platform-deployment/platform-8-deployment.md
@@ -26,9 +26,9 @@ For details on supported environments (e.g. Java or Elasticsearch versions), see
 
 You have the following options to run the above components in a self-managed fashion:
 
-- [**Kubernetes**](./kubernetes): We strongly recommend using Kubernetes to run Camunda Platform 8 in production. Using minikube, Kubernetes can also be an interesting environment to run Camunda Platform 8 locally on developer machines.
-- [**Docker**](./docker): You can run the provided Docker images of the components, also in production. For your convenience, we provide a Docker Compose configuration to run Camunda Platform 8 on developer machines. Note that the Docker Compose configuration is **not** optimized for production usage, but for local development.
-- [**Local installation**](./local): You can run the Java applications on a local or virtual machine if it provides a supported Java Virtual Machine (JVM). This allows you to run Camunda on virtual machines or bare metal and offers a significant amount of flexibility. However, you will need to configure the details for the components to interact correctly yourself. We consider this a last resort. Note that Windows/Mac is **not** supported for production usage of Zeebe.
+- [**Kubernetes**](./kubernetes.md): We strongly recommend using Kubernetes to run Camunda Platform 8 in production. Using minikube, Kubernetes can also be an interesting environment to run Camunda Platform 8 locally on developer machines.
+- [**Docker**](./docker.md): You can run the provided Docker images of the components, also in production. For your convenience, we provide a Docker Compose configuration to run Camunda Platform 8 on developer machines. Note that the Docker Compose configuration is **not** optimized for production usage, but for local development.
+- [**Local installation**](./local.md): You can run the Java applications on a local or virtual machine if it provides a supported Java Virtual Machine (JVM). This allows you to run Camunda on virtual machines or bare metal and offers a significant amount of flexibility. However, you will need to configure the details for the components to interact correctly yourself. We consider this a last resort. Note that Windows/Mac is **not** supported for production usage of Zeebe.
 
 ## Deployment recommendation
 
@@ -36,25 +36,25 @@ As you can see below, we recommend [SaaS](https://camunda.com/get-started) whene
 
 ### Production
 
-For production usage, we highly recommend using a real Kubernetes cluster and our [Helm charts](./kubernetes-helm) if SaaS provided by Camunda is not an option for you.
+For production usage, we highly recommend using a real Kubernetes cluster and our [Helm charts](./kubernetes-helm.md) if SaaS provided by Camunda is not an option for you.
 
 We support the following deployment options (the sequence expresses preference) for production:
 
 1. **SaaS**
-2. [**Helm**](./kubernetes-helm) on a real Kubernetes cluster (independent where this is hosted, for example GKE).
-3. [**Docker**](./docker) images together with the [infrastructure as code (IaC) tool](https://en.wikipedia.org/wiki/Infrastructure_as_code) of your choice.
-4. [**Local installation**](./local) using the [infrastructure as code (IaC) tool](https://en.wikipedia.org/wiki/Infrastructure_as_code) of your choice.
+2. [**Helm**](./kubernetes-helm.md) on a real Kubernetes cluster (independent where this is hosted, for example GKE).
+3. [**Docker**](./docker.md) images together with the [infrastructure as code (IaC) tool](https://en.wikipedia.org/wiki/Infrastructure_as_code) of your choice.
+4. [**Local installation**](./local.md) using the [infrastructure as code (IaC) tool](https://en.wikipedia.org/wiki/Infrastructure_as_code) of your choice.
 
 ### Development
 
-For development usage, we highly recommend using our [Helm charts on KIND](./kubernetes-helm/#installing-the-camunda-helm-chart-locally-using-kind) if SaaS provided by Camunda is not an option for you. Those Helm charts are battle-tested and give you an experience close to production.
+For development usage, we highly recommend using our [Helm charts on KIND](./kubernetes-helm.md#installing-the-camunda-helm-chart-locally-using-kind) if SaaS provided by Camunda is not an option for you. Those Helm charts are battle-tested and give you an experience close to production.
 
 We support the following deployment options (the sequence expresses preference) for production:
 
 1. **SaaS**
-2. [**Helm** charts on KIND](./kubernetes-helm/#installing-the-camunda-helm-chart-locally-using-kind) or [Helm](./kubernetes-helm) on a managed Kubernetes offering (like GKE) or [Helm](./kubernetes-helm) on a local Kubernetes installation like minikube.
-3. [**Docker Compose**](./docker/#docker-compose)
-4. [**Local installation**](./local) as a last resort if you only need the Zeebe broker. We don't recommend setting up the whole toolchain in this fashion.
+2. [**Helm** charts on KIND](./kubernetes-helm.md#installing-the-camunda-helm-chart-locally-using-kind) or [Helm](./kubernetes-helm.md) on a managed Kubernetes offering (like GKE) or [Helm](./kubernetes-helm.md) on a local Kubernetes installation like minikube.
+3. [**Docker Compose**](./docker.md#docker-compose)
+4. [**Local installation**](./local.md) as a last resort if you only need the Zeebe broker. We don't recommend setting up the whole toolchain in this fashion.
 
 ## Getting help
 

--- a/docs/self-managed/tasklist-deployment/install-and-start.md
+++ b/docs/self-managed/tasklist-deployment/install-and-start.md
@@ -4,4 +4,4 @@ title: Installation
 description: "Let's get started with Tasklist by installing and running with these simple methods."
 ---
 
-Please refer to the [Installation Guide](/docs/self-managed/platform-deployment/) for details on how to install Tasklist.
+Please refer to the [Installation Guide](/docs/self-managed/platform-deployment/platform-8-deployment) for details on how to install Tasklist.

--- a/docs/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -1,5 +1,5 @@
 ---
-id: authentication
+id: tasklist-authentication
 title: Authentication
 description: "Let's take a closer look at the authentication methods of Tasklist."
 ---

--- a/docs/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -1,5 +1,5 @@
 ---
-id: configuration
+id: tasklist-configuration
 title: Configuration
 ---
 
@@ -8,12 +8,26 @@ Tasklist is a Spring Boot application. This means all provided ways to [configur
 By default, the configuration for Tasklist is stored in a YAML file `application.yml`. All Tasklist-related settings are prefixed with `camunda.tasklist`. The following components are configurable:
 
 - [Webserver](#webserver)
-- [Elasticsearch connection](#elasticsearch)
-- [Zeebe Broker connection](#zeebe-broker-connection)
+- [Elasticsearch](#elasticsearch)
+  - [Settings to connect](#settings-to-connect)
+    - [Settings to connect to a secured Elasticsearch instance](#settings-to-connect-to-a-secured-elasticsearch-instance)
+  - [Settings for shards and replicas](#settings-for-shards-and-replicas)
+  - [A snippet from application.yml](#a-snippet-from-applicationyml)
+- [Zeebe broker connection](#zeebe-broker-connection)
+  - [Settings to connect](#settings-to-connect-1)
+  - [A snippet from application.yml](#a-snippet-from-applicationyml-1)
 - [Zeebe Elasticsearch exporter](#zeebe-elasticsearch-exporter)
-- [Authentication](authentication.md)
+  - [Settings to connect and import](#settings-to-connect-and-import)
+  - [A snippet from application.yml](#a-snippet-from-applicationyml-2)
 - [Monitoring and health probes](#monitoring-and-health-probes)
-- [Logging configuration](#logging)
+  - [Example snippets to use Tasklist probes in Kubernetes](#example-snippets-to-use-tasklist-probes-in-kubernetes)
+    - [Readiness probe as yaml config](#readiness-probe-as-yaml-config)
+    - [Liveness probe as yaml config](#liveness-probe-as-yaml-config)
+- [Logging](#logging)
+  - [JSON logging configuration](#json-logging-configuration)
+  - [Change logging level at runtime](#change-logging-level-at-runtime)
+    - [Set all Tasklist loggers to DEBUG](#set-all-tasklist-loggers-to-debug)
+- [An example of application.yml file](#an-example-of-applicationyml-file)
 
 ## Webserver
 

--- a/docs/self-managed/troubleshooting/log-levels.md
+++ b/docs/self-managed/troubleshooting/log-levels.md
@@ -22,4 +22,4 @@ Enable logging for each component of Camunda Platform 8 using the following inst
 
 - [Zeebe](../zeebe-deployment/configuration/logging.md)
 - [Operate](../operate-deployment/operate-configuration.md/#logging)
-- [Tasklist](../tasklist-deployment/configuration.md/#logging)
+- [Tasklist](../tasklist-deployment/tasklist-configuration.md/#logging)

--- a/docs/self-managed/troubleshooting/log-levels.md
+++ b/docs/self-managed/troubleshooting/log-levels.md
@@ -21,5 +21,5 @@ Camunda Platform 8 uses the following log levels:
 Enable logging for each component of Camunda Platform 8 using the following instructions:
 
 - [Zeebe](../zeebe-deployment/configuration/logging.md)
-- [Operate](../operate-deployment/configuration.md/#logging)
+- [Operate](../operate-deployment/operate-configuration.md/#logging)
 - [Tasklist](../tasklist-deployment/configuration.md/#logging)

--- a/docs/self-managed/zeebe-deployment/operations/zeebe-in-production.md
+++ b/docs/self-managed/zeebe-deployment/operations/zeebe-in-production.md
@@ -1,5 +1,5 @@
 ---
-id: index
+id: zeebe-in-production
 title: "Operating Zeebe in Production"
 sidebar_label: "Overview"
 keywords: ["backpressure", "back-pressure", "back pressure"]

--- a/docs/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/docs/self-managed/zeebe-deployment/zeebe-installation.md
@@ -4,7 +4,7 @@ title: "Installation"
 sidebar_label: "Overview"
 ---
 
-Please refer to the [Installation Guide](/docs/self-managed/platform-deployment/) for details on how to install Zeebe in a private cloud or on your own hardware.
+Please refer to the [Installation Guide](/docs/self-managed/platform-deployment/platform-8-deployment) for details on how to install Zeebe in a private cloud or on your own hardware.
 
 Within this section you will find detailed information about:
 

--- a/docs/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/docs/self-managed/zeebe-deployment/zeebe-installation.md
@@ -1,5 +1,5 @@
 ---
-id: index
+id: zeebe-installation
 title: "Installation"
 sidebar_label: "Overview"
 ---
@@ -10,7 +10,7 @@ Within this section you will find detailed information about:
 
 - [Configuration](configuration/configuration.md) - Explains the configuration options. These configuration options apply to both environments, but not to Camunda Platform 8. In Camunda Platform 8, the configuration is provided for you.
 - [Security](security/security.md) - Discusses the security aspects of running Zeebe and how to use them.
-- [Operation](operations/index.md) - Outlines topics that become relevant when you want to operate Zeebe in production.
+- [Operation](operations/zeebe-in-production.md) - Outlines topics that become relevant when you want to operate Zeebe in production.
 
 :::note
 New to BPMN and want to learn more before moving forward? [Visit our Get Started Guides](/docs/guides/getting-started/) to learn about BPMN and orchestration.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,7 +76,7 @@ module.exports = {
         },
         {
           type: "doc",
-          docId: "self-managed/overview",
+          docId: "self-managed/about-self-managed",
           label: "Self-Managed",
           position: "left",
         },

--- a/sidebars.js
+++ b/sidebars.js
@@ -463,7 +463,7 @@ module.exports = {
     "reference/dependencies",
   ],
   "Self-Managed": [
-    "self-managed/overview",
+    "self-managed/about-self-managed",
     {
       Installation: [
         "self-managed/platform-deployment/platform-8-deployment",
@@ -495,7 +495,7 @@ module.exports = {
     },
     {
       Zeebe: [
-        "self-managed/zeebe-deployment/index",
+        "self-managed/zeebe-deployment/zeebe-installation",
         {
           Configuration: [
             "self-managed/zeebe-deployment/configuration/configuration",
@@ -516,7 +516,7 @@ module.exports = {
         },
         {
           Operation: [
-            "self-managed/zeebe-deployment/operations/index",
+            "self-managed/zeebe-deployment/operations/zeebe-in-production",
             "self-managed/zeebe-deployment/operations/resource-planning",
             "self-managed/zeebe-deployment/operations/network-ports",
             "self-managed/zeebe-deployment/operations/setting-up-a-cluster",

--- a/sidebars.js
+++ b/sidebars.js
@@ -532,11 +532,11 @@ module.exports = {
       ],
       Operate: [
         "self-managed/operate-deployment/install-and-start",
-        "self-managed/operate-deployment/configuration",
+        "self-managed/operate-deployment/operate-configuration",
         "self-managed/operate-deployment/data-retention",
         "self-managed/operate-deployment/schema-and-migration",
         "self-managed/operate-deployment/importer-and-archiver",
-        "self-managed/operate-deployment/authentication",
+        "self-managed/operate-deployment/operate-authentication",
         "self-managed/operate-deployment/usage-metrics",
       ],
       Tasklist: [
@@ -618,7 +618,7 @@ module.exports = {
       ],
       Identity: [
         "self-managed/identity/what-is-identity",
-        "self-managed/identity/getting-started/index",
+        "self-managed/identity/getting-started/install-identity",
         {
           "User guide": [
             "self-managed/identity/user-guide/adding-an-application",
@@ -639,7 +639,7 @@ module.exports = {
             "self-managed/identity/deployment/application-monitoring",
           ],
           Troubleshooting: [
-            "self-managed/identity/troubleshooting/index",
+            "self-managed/identity/troubleshooting/troubleshoot-identity",
             "self-managed/identity/troubleshooting/common-problems",
           ],
         },

--- a/sidebars.js
+++ b/sidebars.js
@@ -466,7 +466,7 @@ module.exports = {
     "self-managed/overview",
     {
       Installation: [
-        "self-managed/platform-deployment/index",
+        "self-managed/platform-deployment/platform-8-deployment",
         {
           Kubernetes: [
             "self-managed/platform-deployment/kubernetes",
@@ -541,8 +541,8 @@ module.exports = {
       ],
       Tasklist: [
         "self-managed/tasklist-deployment/install-and-start",
-        "self-managed/tasklist-deployment/configuration",
-        "self-managed/tasklist-deployment/authentication",
+        "self-managed/tasklist-deployment/tasklist-configuration",
+        "self-managed/tasklist-deployment/tasklist-authentication",
         "self-managed/tasklist-deployment/usage-metrics",
       ],
       Optimize: [

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -41,7 +41,7 @@ const features2 = [
   {
     title: "Self-Managed",
     imageUrl: "img/self-managed.png",
-    url: "https://docs.camunda.io/docs/self-managed/overview/",
+    url: "https://docs.camunda.io/docs/self-managed/about-self-managed/",
     description: (
       <>
         A self-hosted Camunda Platform 8 alternative, offering everything you

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -8,6 +8,7 @@ Options -Indexes -MultiViews
 
 # Redirect pages - https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule
 
+RewriteRule ^docs/self-managed/tasklist-deployment/configuration/(.*)$ /docs/self-managed/tasklist-deployment/tasklist-configuration/$1 [R=301,L]
 RewriteRule ^docs/self-managed/tasklist-deployment/authentication/(.*)$ /docs/self-managed/tasklist-deployment/tasklist-authentication/$1 [R=301,L]
 
 RewriteRule ^docs/self-managed/platform-deployment/?$ /docs/self-managed/platform-deployment/platform-8-deployment/ [R=301,L]

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -8,6 +8,12 @@ Options -Indexes -MultiViews
 
 # Redirect pages - https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule
 
+RewriteRule ^docs/self-managed/operate-deployment/configuration/(.*)$ /docs/self-managed/operate-deployment/operate-configuration/$1 [R=301,L]
+RewriteRule ^docs/self-managed/operate-deployment/authentication/(.*)$ /docs/self-managed/operate-deployment/operate-authentication/$1 [R=301,L]
+
+RewriteRule ^docs/self-managed/identity/troubleshooting/?$ /docs/self-managed/identity/troubleshooting/troubleshoot-identity/ [R=301,L]
+RewriteRule ^docs/self-managed/identity/getting-started/?$ /docs/self-managed/identity/getting-started/install-identity/ [R=301,L]
+
 RewriteRule ^docs/components/overview/(.*)$ /docs/components/components-overview/$1 [R=301,L]
 RewriteRule ^docs/components/overview$ /docs/components/components-overview/ [R=301,L]
 

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -8,6 +8,10 @@ Options -Indexes -MultiViews
 
 # Redirect pages - https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule
 
+RewriteRule ^docs/self-managed/tasklist-deployment/authentication/(.*)$ /docs/self-managed/tasklist-deployment/tasklist-authentication/$1 [R=301,L]
+
+RewriteRule ^docs/self-managed/platform-deployment/?$ /docs/self-managed/platform-deployment/platform-8-deployment/ [R=301,L]
+
 RewriteRule ^docs/self-managed/operate-deployment/configuration/(.*)$ /docs/self-managed/operate-deployment/operate-configuration/$1 [R=301,L]
 RewriteRule ^docs/self-managed/operate-deployment/authentication/(.*)$ /docs/self-managed/operate-deployment/operate-authentication/$1 [R=301,L]
 

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -8,6 +8,12 @@ Options -Indexes -MultiViews
 
 # Redirect pages - https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule
 
+RewriteRule ^docs/self-managed/overview/(.*)$ /docs/self-managed/about-self-managed/$1 [R=301,L]
+RewriteRule ^docs/self-managed/overview$ /docs/self-managed/about-self-managed/ [R=301,L]
+
+RewriteRule ^docs/self-managed/zeebe-deployment/?$ /docs/self-managed/zeebe-deployment/zeebe-installation/ [R=301,L]
+RewriteRule ^docs/self-managed/zeebe-deployment/operations/?$ /docs/self-managed/zeebe-deployment/operations/zeebe-in-production/ [R=301,L]
+
 RewriteRule ^docs/self-managed/tasklist-deployment/configuration/(.*)$ /docs/self-managed/tasklist-deployment/tasklist-configuration/$1 [R=301,L]
 RewriteRule ^docs/self-managed/tasklist-deployment/authentication/(.*)$ /docs/self-managed/tasklist-deployment/tasklist-authentication/$1 [R=301,L]
 

--- a/versioned_docs/version-1.3/components/best-practices/architecture/deciding-about-your-stack.md
+++ b/versioned_docs/version-1.3/components/best-practices/architecture/deciding-about-your-stack.md
@@ -72,7 +72,7 @@ You can develop process solutions as decribed with Java above also in any other 
 
 ### Running Camunda Cloud self-managed
 
-You can also run Camunda Cloud self-managed on your own Kubernetes cluster. Details can be found in the [docs](/docs/self-managed/overview).
+You can also run Camunda Cloud self-managed on your own Kubernetes cluster. Details can be found in the [docs](/docs/self-managed/about-self-managed).
 
 While there [exists a Docker Compose configuration](/self-managed/zeebe-deployment/docker/install.md) to run Camunda Cload locally, this is not meant to be used for production, but rather to quickly startup compenents on a developer machine to be able to play around.
 

--- a/versioned_docs/version-1.3/components/best-practices/operations/operating-camunda-c7.md
+++ b/versioned_docs/version-1.3/components/best-practices/operations/operating-camunda-c7.md
@@ -12,7 +12,7 @@ tags:
 To successfully operate Camunda Platform 7.x, you need to take into account operation requirements when modeling business processes. Use your existing tools and infrastructure for technical monitoring and alarming. When appropriate, use Camunda Cockpit and consider extending it with plugins instead of writing your own tooling.
 
 :::caution Camunda Platform 7 only
-This best practice targets Camunda Platform 7.x only! The Camunda Cloud stacks differs and operating it is discussed in [Camunda Cloud Self-Managed](/docs/self-managed/overview/).
+This best practice targets Camunda Platform 7.x only! The Camunda Cloud stacks differs and operating it is discussed in [Camunda Cloud Self-Managed](/docs/self-managed/about-self-managed/).
 :::
 
 ## Installing Camunda Platform 7.x


### PR DESCRIPTION
According to https://github.com/orgs/camunda/projects/27/views/1, renaming files named `overview`, `index`, or other vague terms like `authentication` or `configuration` to clarify the file subject and ease analytics research. 