### PR TITLE
Add timer cycle with start time

### DIFF
--- a/docs/components/modeler/bpmn/timer-events/timer-events.md
+++ b/docs/components/modeler/bpmn/timer-events/timer-events.md
@@ -78,9 +78,12 @@ If the duration is zero or negative, the timer fires immediately.
 ### Time cycle
 
 A cycle defined as ISO 8601 repeating intervals format; it contains the duration and the number of repetitions. If the repetitions are not defined, the timer repeats infinitely until it is canceled.
+It's possible to define a start time. By doing this the timer triggers for the first time on the given start time. Afterwards it will follow the interval as usual.
 
 - `R5/PT10S`: Every 10 seconds, up to five times
 - `R/P1D`: Every day, infinitely
+- `R/2022-01-01T10:00:00+02:00[Europe/Berlin]/P1D`: Every day infinitely, starting from the 1st of January 2022 at 10 am
+- `R3/2022-04-027T17:20:00+02:00Z/P1D`: Every day up to three times, starting from the 27th of April 2022 at 5:20 pm
 
 ## Additional resources
 


### PR DESCRIPTION
Adds documentation about the timer cycle with start time. E.g. `R/2022-01-01T10:00:00+02:00[Europe/Berlin]/P1D`

closes #986