### PR TITLE
Document serialization of complex variable values in Tasklist API

### DIFF
--- a/docs/apis-clients/tasklist-api/inputs/variable-input.mdx
+++ b/docs/apis-clients/tasklist-api/inputs/variable-input.mdx
@@ -16,4 +16,8 @@ type VariableInput {
 
 #### `name` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
 
+Name of the variable.
+
 #### `value` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+
+Value of the variable. Complex values, e.g. a list of objects, must be serialized as JSON.


### PR DESCRIPTION
[docs/apis-clients/tasklist-api/inputs/variable-input.mdx](https://github.com/camunda/csamunda-platform-docs/edit/main/docs/apis-clients/tasklist-api/inputs/variable-input.mdx) only defines `VariableInput#value` as a `String` but doesn't explain the format for complex variable values, e.g. a list of objects, which I believe should be JSON. 