### PR TITLE
debug(ci): enable debug flag for link checking

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -51,6 +51,6 @@ jobs:
         run: |
           curl -sL https://github.com/filiph/linkcheck/releases/download/2.0.20/linkcheck-2.0.20-linux-x64.tar.gz | tar xvzf - linkcheck/linkcheck --strip 1
           # Check links from production sitemap to ensure no publish links are broken
-          ./linkcheck -i sitemap.prod.txt
+          ./linkcheck -d -i sitemap.prod.txt
           # Check links from other products to ensure no links are broken
-          ./linkcheck -i product-links.prod.txt
+          ./linkcheck -d -i product-links.prod.txt

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -26,6 +26,6 @@ jobs:
         run: |
           curl -sL https://github.com/filiph/linkcheck/releases/download/2.0.20/linkcheck-2.0.20-linux-x64.tar.gz | tar xvzf - linkcheck/linkcheck --strip 1
           # Check links from production sitemap to ensure no publish links are broken
-          ./linkcheck -i sitemap.prod.txt
+          ./linkcheck -d -i sitemap.prod.txt
           # Check links from other products to ensure no links are broken
-          ./linkcheck -i product-links.prod.txt
+          ./linkcheck -d -i product-links.prod.txt


### PR DESCRIPTION
We've been noticing that link-checking is suddenly sporadically taking a very very long time ([example 1](https://github.com/camunda/camunda-platform-docs/actions/runs/2746917140), [example 2](https://github.com/camunda/camunda-platform-docs/actions/runs/2751525426), [example 3](https://github.com/camunda/camunda-platform-docs/actions/runs/2752589151)), but we don't really know why. 

This PR adds [the debug flag](https://github.com/filiph/linkcheck/blob/master/lib/linkcheck.dart#L204) to our link-checking steps, with the hopes of gaining insight into why the link-checking is taking so long. 

I anticipate this change to be temporary, and we'll revert after gaining (or not gaining) insight. 

