### PR TITLE
chore: Revert "debug(ci): enable debug flag for link checking (#1098)"

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -51,6 +51,6 @@ jobs:
         run: |
           curl -sL https://github.com/filiph/linkcheck/releases/download/2.0.20/linkcheck-2.0.20-linux-x64.tar.gz | tar xvzf - linkcheck/linkcheck --strip 1
           # Check links from production sitemap to ensure no publish links are broken
-          ./linkcheck -d -i sitemap.prod.txt
+          ./linkcheck -i sitemap.prod.txt
           # Check links from other products to ensure no links are broken
-          ./linkcheck -d -i product-links.prod.txt
+          ./linkcheck -i product-links.prod.txt

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -26,6 +26,6 @@ jobs:
         run: |
           curl -sL https://github.com/filiph/linkcheck/releases/download/2.0.20/linkcheck-2.0.20-linux-x64.tar.gz | tar xvzf - linkcheck/linkcheck --strip 1
           # Check links from production sitemap to ensure no publish links are broken
-          ./linkcheck -d -i sitemap.prod.txt
+          ./linkcheck -i sitemap.prod.txt
           # Check links from other products to ensure no links are broken
-          ./linkcheck -d -i product-links.prod.txt
+          ./linkcheck -i product-links.prod.txt


### PR DESCRIPTION
Closes #1103.

This reverts commit 8a04615714e51c2d0085ce2927290fdaade9be97, which introduced verbose logging for link-checking. It seems that the slow link-checking was either (a) temporary, or (b) resolved by #1097.