### PR TITLE
Add OpenShift documentation

### DIFF
--- a/docs/self-managed/platform-deployment/kubernetes-helm.md
+++ b/docs/self-managed/platform-deployment/kubernetes-helm.md
@@ -86,6 +86,16 @@ elasticsearch-master-0                          0/1     Pending             0   
 elasticsearch-master-1                          0/1     Init:0/1            0          4s
 ```
 
+### Installing on OpenShift
+
+To install the Camunda Platform Helm chart in OpenShift, you will need to customize the values based on your desired security context constraints (SCC). By using the `anyuid` SCC, you can deploy the Helm chart as described above, as with any Kubernetes cluster, e.g.:
+
+```shell
+> helm install <RELEASE NAME> camunda/camunda-platform
+```
+
+If you wish to deploy with less permissive SCCs, such as `restricted`, or `nonroot`, then read the [OpenShift deployment](./openshift-helm.md) guide, which includes detailed instructions as well as a guide for troubleshooting common problems.
+
 ### Installing the Camunda Helm chart locally using KIND
 
 If you want to use [Kubernetes KIND](https://github.com/kubernetes-sigs/kind), add `-f camunda-platform-core-kind-values.yaml`. The file can be downloaded [here](https://github.com/camunda/camunda-platform-helm/blob/main/kind/camunda-platform-core-kind-values.yaml).

--- a/docs/self-managed/platform-deployment/kubernetes.md
+++ b/docs/self-managed/platform-deployment/kubernetes.md
@@ -38,10 +38,11 @@ To do do, you must have the following tools installed in your local environment:
 You can use your Kubernetes environment of choice, e.g.:
 
 - [Kubernetes KIND](https://github.com/kubernetes-sigs/kind), Minikube, and MicroK8s for local development
+- [OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift), an enterprise ready solution with a focus on security.
 - Remote cloud service for prod, like Google GKE, Azure AKS, Amazon EKS, etc.
 
 :::note
-Be aware that we only officially test the Google GKE environment.
+Be aware that we only officially test the Google GKE and OpenShift environments.
 :::
 
 Optional tools related to Camunda Platform 8:

--- a/docs/self-managed/platform-deployment/openshift-helm.md
+++ b/docs/self-managed/platform-deployment/openshift-helm.md
@@ -1,0 +1,198 @@
+---
+id: openshift-helm
+title: "Camunda Helm charts"
+---
+
+The `camunda-platform` Helm chart can be deployed to Openshift with a few modifications, primarily revolving around your desired security context constraints. You can find out more about this in our general [OpenShift deployment guide](./openshift.md).
+
+## Compatibility
+
+We test against the following Openshift versions, and guarantee compatibility with:
+
+| Openshift Version | Supported          |
+| ----------------- | ------------------ |
+| 4.10.x            | :white_check_mark: |
+
+Any version not explicitly marked in the table above is not tested, and we cannot guarantee compatibility.
+
+## Quick start
+
+You can find a quick start guide in the [Helm chart repository itself](https://github.com/camunda/camunda-platform-helm/tree/main/openshift).
+
+## Limitations
+
+The `Elasticsearch`, `Keycloak`, and `Postgresql` charts all specify default non-root users for security purposes. In order to deploy these charts through the `camunda-platform` chart, these default values must be removed. Unfortunately, due to a [longstanding bug in Helm](https://github.com/helm/helm/issues/9136) that affects all Helm versions from 3.2.0 and greater, this makes the installation of the chart (when deploying any of these sub-charts) more complex. Note that this is only an issue if you are deploying `Elasticsearch`, `Keycloak` (via `Identity`), or `Postgresql` (via `Keycloak`). If you are not deploying these, or not via the `camunda-platform` chart, or you are using a [permissive SCC](./openshift.md#permissive-scc).
+
+:::note
+This also affects installations done through the OpenShift console, as it still uses Helm under the hood.
+:::
+
+## Configuration
+
+As discussed in the [OpenShift deployment guide](./openshift.md), you will need to configure the pod and container security contexts based on your desired security context constraint (aka SCC).
+
+### Permissive SCC
+
+If you wish to use a permissive SCC, then you can install the charts as they are. Simply follow the [general Helm deployment guide](./kubernetes-helm.md).
+
+### Restrictive SCC
+
+If you wish to use more a restrictive SCC, then you will need to configure the following minimum set of values for the various applications. The recommendations outlined in the general [OpenShift deployment guide](./openshift.md) hold here as well. As the Camunda 8 applications do not define a pod or security context, follow these recommendations, or simply omit defining any.
+
+If you are deploying with a SCC where `RunAsUser` is `MustRunAsRange` (e.g. the default `restricted` SCC), and are deploying at least one of `Elasticsearch`, `Keycloak`, or `Postgresql`, then we will need to unset the default security context of these charts. If this does not apply to you, then you can stop here.
+
+How we will do this depends on which Helm version you use: 3.1.3 and lower, or 3.2.0 and greater (i.e. one affected by [this bug](https://github.com/helm/helm/issues/9136)). You can find out your Helm version by running the following:
+
+```shell
+$ helm version
+version.BuildInfo{Version:"v3.9.0", GitCommit:"7ceeda6c585217a19a1131663d8cd1f7d641b2a7", GitTreeState:"clean", GoVersion:"go1.17.5"}
+```
+
+#### Helm 3.1.3 or lower
+
+If you're running on Helm 3.0.0 up to 3.1.3, then you will need to add these values to your `values.yaml` file, or save them to a new file locally, e.g. `openshift.yaml`:
+
+:::note
+[These values are also available from the Helm chart repository](https://github.com/camunda/camunda-platform-helm/blob/main/openshift/values.yaml):
+:::
+
+```yaml
+# omit this section if elasticsearch.enabled is false
+elasticsearch:
+  securityContext:
+    runAsUser: null
+  sysctlInitContainer:
+    enabled: false
+  podSecurityContext:
+    fsGroup: null
+    runAsUser: null
+
+# omit this section if identity.enabled is false
+identity:
+  # omit this section if identity.keycloak.enabled is false
+  keycloak:
+    containerSecurityContext:
+      runAsUser: null
+    podSecurityContext:
+      fsGroup: null
+      runAsUser: null
+    postgresql:
+      # omit this section if identity.keycloak.postgresql.primary.enabled is false
+      primary:
+        containerSecurityContext:
+          runAsUser: null
+        podSecurityContext:
+          fsGroup: null
+          runAsUser: null
+      # omit this section if identity.keycloak.postgresql.readReplicas.enabled is false
+      readReplicas:
+        containerSecurityContext:
+          runAsUser: null
+        podSecurityContext:
+          fsGroup: null
+          runAsUser: null
+      # omit this section if identity.keycloak.postgresql.metrics.enabled is false
+      metrics:
+        containerSecurityContext:
+          runAsUser: null
+        podSecurityContext:
+          fsGroup: null
+          runAsUser: null
+```
+
+Then when installing the chart, simply run:
+
+```shell
+helm install <RELEASE NAME> camunda/camunda-platform --skip-crds -f openshift.yaml -f values.yaml
+```
+
+#### Helm 3.2.0 and greater
+
+If you must deploy using Helm 3.2.0 or greater, then you have two options. One is to use a SCC which defines the `RunAsUser` strategy to be at least `RunAsAny`. If that's not possible, then you will need to make use of [a post-renderer](https://helm.sh/docs/topics/advanced/#post-rendering). This workaround is also described in detail in the [Helm chart repository itself](https://github.com/camunda/camunda-platform-helm/tree/main/openshift#using-a-post-renderer).
+
+:::warning
+If using a post-renderer, you **must** use the post-renderer whenever you are upgrading your release, not only during the initial installation. If you do not, then the default values will be used again, which will prevent some services from starting.
+:::
+
+While you can use your preferred `post-renderer`, we provide [a simple one](https://github.com/camunda/camunda-platform-helm/blob/main/openshift/patch.sh) which requires only `bash` and `sed` to be available locally:
+
+```bash
+#!/bin/bash -eu
+# Expected usage is as an Helm post renderer.
+# Example usage:
+#   $ helm install my-release camunda/camunda-platform --post-renderer ./patch.sh
+#
+# This script is a Helm chart post-renderer for users on Helm 3.2.0 and greater. It allows removing default
+# values set in sub-charts/dependencies, something which should be possible but is currently not working.
+# See this issue for more: https://github.com/helm/helm/issues/9136
+#
+# The result of patching the rendered Helm templates is printed out to STDOUT. Any other logging from the
+# script is thus sent to STDERR.
+#
+# Note to contributors: this post-renderer is used in the integration tests, so make sure that it can be used
+# from any working directory.
+
+set -o pipefail
+
+# Perform two passes: once for single quotes, once for double quotes, as it's not specified that string values are
+# always output with single or double quotes
+sed -e "s/'@@null@@'/null/g" -e 's/"@@null@@"/null/g'
+```
+
+We will also need to use a custom values file where instead of using `null` as a value to unset default values, we will use a special marker value which will be removed by the post-renderer.
+
+Copy these values to your values file, or better, save them as a separate file, e.g. `openshift.yaml`:
+
+:::note
+[These values are also available from the Helm chart repository](https://github.com/camunda/camunda-platform-helm/blob/main/openshift/values-patch.yaml)
+:::
+
+```yaml
+# omit this section if elasticsearch.enabled is false
+elasticsearch:
+  securityContext:
+    runAsUser: "@@null@@"
+  sysctlInitContainer:
+    enabled: false
+  podSecurityContext:
+    fsGroup: "@@null@@"
+    runAsUser: "@@null@@"
+
+# omit this section if identity.enabled is false
+identity:
+  # omit this section if identity.keycloak.enabled is false
+  keycloak:
+    containerSecurityContext:
+      runAsUser: "@@null@@"
+    podSecurityContext:
+      fsGroup: "@@null@@"
+      runAsUser: "@@null@@"
+    postgresql:
+      # omit this section if identity.keycloak.postgresql.primary.enabled is false
+      primary:
+        containerSecurityContext:
+          runAsUser: "@@null@@"
+        podSecurityContext:
+          fsGroup: "@@null@@"
+          runAsUser: "@@null@@"
+      # omit this section if identity.keycloak.postgresql.readReplicas.enabled is false
+      readReplicas:
+        containerSecurityContext:
+          runAsUser: "@@null@@"
+        podSecurityContext:
+          fsGroup: "@@null@@"
+          runAsUser: "@@null@@"
+      # omit this section if identity.keycloak.postgresql.metrics.enabled is false
+      metrics:
+        containerSecurityContext:
+          runAsUser: "@@null@@"
+        podSecurityContext:
+          fsGroup: "@@null@@"
+          runAsUser: "@@null@@"
+```
+
+Now, when installing the charts, you can do so running:
+
+```shell
+helm install <RELEASE NAME> camunda/camunda-platform --skip-crds -f openshift.yaml -f values.yaml --post-renderer ./patch.sh
+```

--- a/docs/self-managed/platform-deployment/openshift.md
+++ b/docs/self-managed/platform-deployment/openshift.md
@@ -1,0 +1,71 @@
+---
+id: openshift
+title: "Overview"
+---
+
+A properly configured Camunda 8 platform can be deployed on OpenShift, depending primarily on the security context constraints (aka SCC) you wish to apply to it.
+
+:::note
+The recommended way to deploy Camunda 8 on OpenShift is to use the official Helm charts. These are regularly tested to ensure compatibility with a select set of OpenShift versions. You can find more [in the dedicated guide for it](./openshift-helm.md).
+:::
+
+## Configuration
+
+Generally, if you aren't using the Helm charts, you can deploy Camunda 8 to OpenShift by following the general [Kubernetes](./kubernetes.md) guide. Then, depending on the SCC you've selected, you will have to adapt the certain resources.
+
+### What is an SCC?
+
+Much like how roles control the permissions of users, SCCs are a way to control the permissions of the applications deployed, both at the pod and container level. It's generally recommended to deploy your application with the most restricted SCC possible. If you're not familiar with security context constraints, refer to the [OpenShift documentation](https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html).
+
+#### Permissive SCC
+
+Out of the box, if you will deploy Camunda 8 (and related infrastructure) with a permissive SCC, then there is nothing special for you to configure. Here, a permissive SCC refers to one where the strategy for `RunAsUser` is defined as `RunAsAny` (including root).
+
+#### Non-root SCC
+
+If you wish to deploy Camunda 8 but restrict the applications from running as root (e.g. the `nonroot` built-in SCC), then you will need to configure each pod and container to run as a non-root user. For example, when deploying Zeebe using a stateful set, you would add the following, replacing `1000` with the user ID you wish to use:
+
+```yaml
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1000
+      containers:
+        securityContext:
+          runAsUser: 1000
+```
+
+:::note
+As the container user in OpenShift is always part of the root group, it's not necessary to define an `fsGroup` for any Camunda 8 applications' pod security context.
+:::
+
+This is necessary for all Camunda 8 applications, as well as related ones (e.g. Keycloak, Postgresql, etc.). This is notably crucial for stateful applications which will write to persistent volumes, but it's also generally a good idea to set.
+
+#### Restrictive SCC
+
+The following is the most restrictive SCC you can use to deploy Camunda 8. Note that this is, in OpenShift 4.10, equivalent to the built-in `restricted` SCC (which is the default SCC).
+
+```yaml
+Allow Privileged: false
+Default Add Capabilities: <none>
+Required Drop Capabilities: KILL,MKNOD,SYS_CHROOT,SETUID,SETGID
+Allowed Capabilities: <none>
+Allowed Seccomp Profiles: <none>
+Allowed Volume Types: configMap,downwardAPI,emptyDir,persistentVolumeClaim,projected,secret
+Allow Host Network: false
+Allow Host Ports: false
+Allow Host PID: false
+Allow Host IPC: false
+Read Only Root Filesystem: false
+Run As User Strategy: MustRunAsRange
+SELinux Context Strategy: MustRunAs
+FSGroup Strategy: MustRunAs
+Supplemental Groups Strategy: RunAsAny
+```
+
+When using this, you must take care not to specify _any_ `runAsUser` or `fsGroup` in either the pod or container security context. Instead, let OpenShift assign arbitrary IDs.
+
+:::note
+Of course, if you are providing the ID ranges yourself, you can configure the `runAsUser` and `fsGroup` values yourself as well.
+:::

--- a/docs/self-managed/platform-deployment/platform-8-deployment.md
+++ b/docs/self-managed/platform-deployment/platform-8-deployment.md
@@ -27,6 +27,7 @@ For details on supported environments (e.g. Java or Elasticsearch versions), see
 You have the following options to run the above components in a self-managed fashion:
 
 - [**Kubernetes**](./kubernetes.md): We strongly recommend using Kubernetes to run Camunda Platform 8 in production. Using minikube, Kubernetes can also be an interesting environment to run Camunda Platform 8 locally on developer machines.
+- [**OpenShift**](./openshift.md): You can run Camunda Platform 8 on OpenShift in much the same way you would on a standard Kubernetes cluster, with some configuration based on your desired security context constraints.
 - [**Docker**](./docker.md): You can run the provided Docker images of the components, also in production. For your convenience, we provide a Docker Compose configuration to run Camunda Platform 8 on developer machines. Note that the Docker Compose configuration is **not** optimized for production usage, but for local development.
 - [**Local installation**](./local.md): You can run the Java applications on a local or virtual machine if it provides a supported Java Virtual Machine (JVM). This allows you to run Camunda on virtual machines or bare metal and offers a significant amount of flexibility. However, you will need to configure the details for the components to interact correctly yourself. We consider this a last resort. Note that Windows/Mac is **not** supported for production usage of Zeebe.
 
@@ -41,7 +42,7 @@ For production usage, we highly recommend using a real Kubernetes cluster and ou
 We support the following deployment options (the sequence expresses preference) for production:
 
 1. **SaaS**
-2. [**Helm**](./kubernetes-helm.md) on a real Kubernetes cluster (independent where this is hosted, for example GKE).
+2. [**Helm**](./kubernetes-helm.md) on a real Kubernetes cluster (independent where this is hosted, for example GKE), including [a dedicated guide to deploy with Helm on OpenShift](./openshift-helm.md).
 3. [**Docker**](./docker.md) images together with the [infrastructure as code (IaC) tool](https://en.wikipedia.org/wiki/Infrastructure_as_code) of your choice.
 4. [**Local installation**](./local.md) using the [infrastructure as code (IaC) tool](https://en.wikipedia.org/wiki/Infrastructure_as_code) of your choice.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -473,6 +473,10 @@ module.exports = {
             "self-managed/platform-deployment/kubernetes",
             "self-managed/platform-deployment/kubernetes-helm",
           ],
+          OpenShift: [
+            "self-managed/platform-deployment/openshift",
+            "self-managed/platform-deployment/openshift-helm",
+          ],
         },
         "self-managed/platform-deployment/docker",
         "self-managed/platform-deployment/local",


### PR DESCRIPTION
**Description**

This PR adds documentation for self-managed platform deployments on OpenShift. I followed the existing pattern of having a general Kubernetes guide (without Helm) and a specific Helm chart deployment guide.

Both guides have some overlap, I guess, but I think generally the information is useful. I'm happy to also merge them and focus on a single Helm specific guide, ignoring non-Helm deployments on OpenShift :shrug: 

I also didn't want to link too much to the values and other files in the repository, as I wanted the documentation here to be as self-contained as possible. I still linked to the repository as a quick-start for impatient users, while taking more time to explain here in these docs. Let me know what you think.