### PR TITLE
[DO NOT MERGE] experiment: configure auto-formatting for all PRs question mark?

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -10,12 +10,34 @@ on:
   pull_request:
 
 jobs:
+  auto-format:
+    # For internal PRs, this will run on `push` events;
+    #   for external/forked PRs, it will run on `pull_request` events.
+    #   Ideally we'd have checked this condition when defining the triggers,
+    #   but that's not supported by GitHub actions.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        # with:
+        #   ref: ${{ github.head_ref }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm run format
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4.14.1
+        with:
+          commit_message: "chore(format): apply prettier changes"
+          # branch: ${{ github.head_ref }}
   build-docs:
     # For internal PRs, this will run on `push` events;
     #   for external/forked PRs, it will run on `pull_request` events.
     #   Ideally we'd have checked this condition when defining the triggers,
     #   but that's not supported by GitHub actions.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
+    needs: auto-format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -10,17 +10,17 @@ on:
   pull_request:
 
 jobs:
-  auto-format:
-    # For internal PRs, this will run on `push` events;
-    #   for external/forked PRs, it will run on `pull_request` events.
-    #   Ideally we'd have checked this condition when defining the triggers,
-    #   but that's not supported by GitHub actions.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
+  auto-format-forked:
+    # For forked PRs, only run on `pull_request`. This event re-fires when they push more commits.
+    # TODO: get rid of all this copy pasta.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        # with:
-        #   ref: ${{ github.head_ref }}
+        with:
+          # note that this value is different across these two auto-format jobs
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v1
         with:
           node-version: 16
@@ -30,7 +30,22 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4.14.1
         with:
           commit_message: "chore(format): apply prettier changes"
-          # branch: ${{ github.head_ref }}
+  auto-format-non-forked:
+    # For non-forked PRs, only run on `push`. This event re-fires when they push more commits.
+    # TODO: get rid of all this copy pasta.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm run format
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4.14.1
+        with:
+          commit_message: "chore(format): apply prettier changes"
   build-docs:
     # For internal PRs, this will run on `push` events;
     #   for external/forked PRs, it will run on `pull_request` events.


### PR DESCRIPTION
This PR is an experiment to see if the `GITHUB_TOKEN` associated with this repo has the permissions it needs in order to write commits to forks. 

More specifically, I wanted to find out if the options I recommended in #1104 are even feasible. 

It configures a job in the `build-docs` workflow named `auto-format`. This job runs `npm run format` against the branch, then commits any updates. I followed [this article](https://mskelton.medium.com/auto-formatting-code-using-prettier-and-github-actions-ed458f58b7df) as a guide. 

## Findings

No luck.

The `GITHUB_TOKEN` does **not** have write access when running in forks. (Actually, it has a confusing amount of access when running in forks --  [See this PR/comment](https://github.com/camunda/camunda-platform-docs/pull/1140#issuecomment-1213307313) for more details on what we do/do not have permissions to do against a forked repo.).

And we don't have access to the setting in this repo to grant it write access, which suggests it's disabled at the org level.