### PR TITLE
docs: update documentation guidelines based on new versioning strategy

### DIFF
--- a/howtos/documentation-guidelines.md
+++ b/howtos/documentation-guidelines.md
@@ -13,15 +13,24 @@ In the spirit of "Always Progress", if you are confident you know what change ne
 - Name Markdown files according to the title. This makes it easier to find a file. Example: **Introduction to Camunda Platform 8** --> `introduction-to-camunda-platform-8.md`. Use the file name as internal document id to reference in `sidebars.js`.
 - Sub categories have to be placed in their own sub directories. Example: Guides/Getting Started can be found in `docs/guides/getting-started`.
 
+## Versions
+
+- The [`/versioned_docs/version-*` source folders][versioned-source] contain documentation for specific releases.
+- The [`/docs/` source folder][next-source] contains documentation for the "Next" release.
+- When edits apply to the current version _and beyond_, they must be made in both the [`/docs/` folder][next-source] and the most recent [`/versioned_docs/version-*` folder][versioned-source].
+
 ## Adding a new documentation page
 
 1. Select the corresponding directory.
-2. Add the document id to `sidebars.js`.
+2. Add the document id to the corresponding sidebars file:
+
+   - For the current release, the most recent [`/versioned_sidebars/version-*-sidebars.json`][versioned-sidebars]
+   - For the "Next" release, [`sidebars.js`][next-sidebars]
 
 ## Moving an existing page
 
 1. Identify the page, pages, or directory and relocate it in the file structure.
-2. Update `sidebars.js` to fit the new location.
+2. Update [`/versioned_sidebars/version-*-sidebars.json`][versioned-sidebars] and/or [`sidebars.js`][next-sidebars] to fit the new location.
 3. Add a redirect/rewrite rule to the top of `.htaccess`.
 
 The redirects/rewrite rules added to `.htaccess` will not work when running the documentation locally. You can use online tooling to help with this (e.g. https://htaccess.madewithlove.com/).
@@ -42,3 +51,8 @@ After the proposed change is finished open a GitHub PR and assign at least one r
 In case you don't know who to assign choose @menski and he will delegate.
 
 As a reviewer feel free to merge any PR which you feel comfortable with after your review. If you have questions, concerns, or feel that you are not the right person to review the PR please make this transparent to the PR author so they can clarify this.
+
+[versioned-source]: https://github.com/camunda/camunda-platform-docs/tree/main/versioned_docs
+[next-source]: https://github.com/camunda/camunda-platform-docs/tree/main/docs
+[versioned-sidebars]: https://github.com/camunda/camunda-platform-docs/tree/main/versioned_sidebars
+[next-sidebars]: https://github.com/camunda/camunda-platform-docs/blob/main/sidebars.js


### PR DESCRIPTION
Follow-up to #1118.

This PR updates our documentation guidelines to add clarity in regards to versioned documentation. 