### PR TITLE
style: update cookie consent styling

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -79,34 +79,52 @@ body {
 }
 
 /* Osano Styles  */
-
-.osano-cm-widget svg {
-  display: none;
-}
-.osano-cm-widget svg {
+.osano-cm-widget {
   display: none;
 }
 .osano-cm-widget:focus,
 .osano-cm-widget:hover {
   opacity: 1;
   transform: none;
-  transition: all 0.3s ease;
 }
 .osano-cm-widget:active {
   transform: translateY(1px);
-  transition: all 0.3s ease;
-}
-.osano-cm-link {
-  color: #002f66 !important;
-}
-.osano-cm-close {
-  background: transparent !important;
 }
 div.osano-cm-info__info-views.osano-cm-info-views.osano-cm-info-views--position_0
   > div
   > ul
   > li:last-of-type {
   display: none;
+}
+.osano-cm-button--type_accept {
+  border-radius: 30px;
+  border: 1px solid #000000;
+}
+.osano-cm-button--type_deny {
+  border-radius: 30px;
+}
+.osano-cm-button--type_save {
+  color: #434343;
+  background-color: #f7f7f7;
+  border-radius: 30px;
+  border: 1px solid #434343;
+}
+.osano-cm-button--type_denyAll {
+  color: #434343;
+  background-color: #f7f7f7;
+  border-radius: 30px;
+  border: 1px solid #434343;
+}
+.osano-cm-button--type_deny:hover {
+  color: #434343;
+}
+.osano-cm-button--type_denyAll:hover {
+  color: #434343;
+  background-color: #e6e6e6;
+}
+.osano-cm-button--type_save:hover {
+  color: #434343;
+  background-color: #e6e6e6;
 }
 
 /* style SVG images of the BPMN coverage page */


### PR DESCRIPTION
This PR updates the styling of our Osano cookie-consent popup to match exactly the code given to us by marketing.

It changes the styling in a couple subtle ways, enumerated below this image (which shows the updated version on the left, and the original on the right): 

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/1627089/183987428-c93379d1-cf25-48bc-8508-16e756e2adf1.png">

1. A different color for the Privacy Policy link
2. Rounded corners on the Accept/Deny buttons

