### PR TITLE
docs(identity): reference new base path variable in configuration options

### DIFF
--- a/docs/self-managed/identity/deployment/configuration-variables.md
+++ b/docs/self-managed/identity/deployment/configuration-variables.md
@@ -18,7 +18,7 @@ methods.
 | `IDENTITY_BASE_PATH`                 | Used to configure Identity to run on a subpath       |                                                     |
 
 :::note
-When setting the `IDENTITY_BASE_PATH` variable, a secure connection (HTTPS) is required to allow Identity to correctly handle requests
+When setting the `IDENTITY_BASE_PATH` variable, a secure connection (HTTPS) is required to allow Identity to correctly handle requests.
 :::
 
 ### Component configuration

--- a/docs/self-managed/identity/deployment/configuration-variables.md
+++ b/docs/self-managed/identity/deployment/configuration-variables.md
@@ -15,6 +15,11 @@ methods.
 | `IDENTITY_URL`                       | The URL of the Identity service                      | http://localhost:8080                               |
 | `KEYCLOAK_URL`                       | The URL of the Keycloak instance to use              | http://localhost:18080/auth                         |
 | `IDENTITY_AUTH_PROVIDER_BACKEND_URL` | Used to support container to container communication | http://localhost:18080/auth/realms/camunda-platform |
+| `IDENTITY_BASE_PATH`                 | Used to configure Identity to run on a subpath       |                                                     |
+
+:::note
+When setting the `IDENTITY_BASE_PATH` variable, a secure connection (HTTPS) is required to allow Identity to correctly handle requests
+:::
 
 ### Component configuration
 


### PR DESCRIPTION
Resolves https://github.com/camunda-cloud/identity/issues/938

This PR adds the new configuration variable in Identity that allows a user to configure Identity to run using a subpath, for example: `http://adomain.com/identity`.

I've elected to use a `:::note` block to suggest to the user a caveat which is in place when using a subpath, this caveat is that there is a requirement to either be on localhost or to have a connection which is HTTPS.

I had initially anticipated a user guide addition but at this time I don't feel it would add any great value to the Identity docs so I have left out that change.

This change has been available since 8.1.0-alpha3 so it does not need to be backported to the 8.0 docs :) 