### PR TITLE
Fix: reword the official support of Helm charts

### DIFF
--- a/docs/self-managed/platform-deployment/kubernetes.md
+++ b/docs/self-managed/platform-deployment/kubernetes.md
@@ -42,7 +42,7 @@ You can use your Kubernetes environment of choice, e.g.:
 - Remote cloud service for prod, like Google GKE, Azure AKS, Amazon EKS, etc.
 
 :::note
-Be aware that we only officially test the Google GKE and OpenShift environments.
+Be aware that we only officially test the stock Kubernetes and OpenShift environments.
 :::
 
 Optional tools related to Camunda Platform 8:

--- a/versioned_docs/version-1.3/self-managed/zeebe-deployment/kubernetes/index.md
+++ b/versioned_docs/version-1.3/self-managed/zeebe-deployment/kubernetes/index.md
@@ -56,8 +56,8 @@ You also need a Kubernetes cluster. You have several options:
 - Remote: Google GKE, Azure AKS, Amazon EKS, etc.
 
 :::note
-Be aware that we only officially support the GKE environment.
-Feel free to try different trials from cloud providers to create a Kubernetes cluster to test Camunda Cloud Self-Managed in your cloud.
+Be aware that we only officially test the stock Kubernetes and OpenShift environments.
+However, feel free to try different trials from cloud providers to create a Kubernetes cluster to test Camunda Cloud Self-Managed in your cloud.
 :::
 
 Optional tools related to Camunda Cloud:

--- a/versioned_docs/version-8.0/self-managed/platform-deployment/kubernetes.md
+++ b/versioned_docs/version-8.0/self-managed/platform-deployment/kubernetes.md
@@ -42,7 +42,7 @@ You can use your Kubernetes environment of choice, e.g.:
 - Remote cloud service for prod, like Google GKE, Azure AKS, Amazon EKS, etc.
 
 :::note
-Be aware that we only officially test the Google GKE and OpenShift environments.
+Be aware that we only officially test the stock Kubernetes and OpenShift environments.
 :::
 
 Optional tools related to Camunda Platform 8:


### PR DESCRIPTION
The wording of the official support platforms is not correct. There is no support for any other cloud platform, only stock K8s and OpenShift.