### PR TITLE
Include link to Slack docs regarding message formatting

### DIFF
--- a/docs/components/integration-framework/connectors/out-of-the-box-connectors/slack.md
+++ b/docs/components/integration-framework/connectors/out-of-the-box-connectors/slack.md
@@ -30,6 +30,8 @@ The **Channel/User Name** and **Message** can either be given static values, or 
 
 ![slack connector compose](../img/connectors-slack-compose.png)
 
+This Slack [guide](https://api.slack.com/reference/surfaces/formatting#basics) can assist in formatting messages.
+
 ## Slack API response
 
 The **Slack connector** exposes the Slack API response as a [local variable](https://docs.camunda.io/docs/components/concepts/variables/#variable-scopes) called `response`.

--- a/docs/components/integration-framework/connectors/out-of-the-box-connectors/slack.md
+++ b/docs/components/integration-framework/connectors/out-of-the-box-connectors/slack.md
@@ -30,7 +30,9 @@ The **Channel/User Name** and **Message** can either be given static values, or 
 
 ![slack connector compose](../img/connectors-slack-compose.png)
 
-This Slack [guide](https://api.slack.com/reference/surfaces/formatting#basics) can assist in formatting messages.
+:::note
+Slack's [guidance on formatting](https://api.slack.com/reference/surfaces/formatting#basics) can assist in formatting messages.
+:::
 
 ## Slack API response
 

--- a/versioned_docs/version-8.0/components/integration-framework/connectors/out-of-the-box-connectors/slack.md
+++ b/versioned_docs/version-8.0/components/integration-framework/connectors/out-of-the-box-connectors/slack.md
@@ -30,6 +30,10 @@ The **Channel/User Name** and **Message** can either be given static values, or 
 
 ![slack connector compose](../img/connectors-slack-compose.png)
 
+:::note
+Slack's [guidance on formatting](https://api.slack.com/reference/surfaces/formatting#basics) can assist in formatting messages.
+:::
+
 ## Slack API response
 
 The **Slack connector** exposes the Slack API response as a [local variable](https://docs.camunda.io/docs/components/concepts/variables/#variable-scopes) called `response`.


### PR DESCRIPTION
I added a line right after the compose image directing users to Slack's documentation on how to format messages using markdown