### PR TITLE
feat: add PRs to Documentation board in In Review column when review requested from Amara or Christina

### DIFF
--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -2,13 +2,12 @@ name: sync-board
 
 on:
   pull_request:
-    types:
-      - labeled
+    types: [review_requested]
 
 jobs:
   sync-board:
     # if: github....reviewer == "christina" or "amara"
-    if: contains(github.event.pull_request.labels.*.name, 'needs-docs-review')
+    # if: contains(github.event.pull_request.labels.*.name, 'needs-docs-review')
     runs-on: ubuntu-latest
     steps:
       - name: Dump GitHub context

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -61,30 +61,30 @@ jobs:
             }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectV2ItemById.item.id')"
 
             echo 'ITEM_ID='$item_id >> $GITHUB_ENV
-      # - name: Set fields
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
-      #   run: |
-      #     gh api graphql -f query='
-      #       mutation (
-      #         $project: ID!
-      #         $item: ID!
-      #         $status_field: ID!
-      #         $status_value: String!
-      #       ) {
-      #         set_status: updateProjectV2ItemFieldValue(input: {
-      #           projectId: $project
-      #           itemId: $item
-      #           fieldId: $status_field
-      #           value: {
-      #             singleSelectOptionId: $status_value
-      #             }
-      #         }) {
-      #           projectV2Item {
-      #             id
-      #             }
-      #         }
-      #       }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.IN_REVIEW_OPTION_ID }}
+      - name: Set fields
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              set_status: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: {
+                  singleSelectOptionId: $status_value
+                  }
+              }) {
+                projectV2Item {
+                  id
+                  }
+              }
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.IN_REVIEW_OPTION_ID }}
 
       # --silent
 

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -1,5 +1,7 @@
 name: sync-board
 
+# FYI secrets.ADD_TO_PROJECT_PAT is a personal access token belonging to @akeller.
+
 on:
   pull_request:
     types: [review_requested]

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -18,8 +18,44 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: needs-docs-review
           # label-operator: NOT
-      - uses: alex-page/github-project-automation-plus@v0.8.1 # Error: Could not find the column "👀 In review" or project "Documentation Board"
-        with: # - uses: alex-page/github-project-automation-plus@v0.8.1
-          project: Documentation
-          column: Review
-          repo-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          ORGANIZATION: camunda
+          PROJECT_NUMBER: 27
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectV2(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'IN_REVIEW_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="👀 In Review") |.id' project_data.json) >> $GITHUB_ENV
+      - name: See project data
+        run: |
+          echo "${{env.PROJECT_ID}}"
+          echo "${{env.STATUS_FIELD_ID}}"
+          echo "${{env.IN_REVIEW_OPTION_ID}}"
+
+      # - uses: alex-page/github-project-automation-plus@v0.8.1 # Error: Could not find the column "👀 In review" or project "Documentation Board"
+      #   with: # - uses: alex-page/github-project-automation-plus@v0.8.1
+      #     project: Documentation
+      #     column: Review
+      #     repo-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   sync-board:
     # if: github....reviewer == "christina" or "amara"
-    # if: ....label.name === "needs-docs-review"
+    if: contains(github.event.pull_request.labels.*.name, 'needs-docs-review’)
     runs-on: ubuntu-latest
     steps:
       - name: Dump GitHub context

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -8,16 +8,14 @@ on:
 jobs:
   sync-board:
     # if: github....reviewer == "christina" or "amara"
+    # if: ....label.name === "needs-docs-review"
     runs-on: ubuntu-latest
     steps:
+      - name: Dump GitHub context
+        id: github_context_step
+        run: echo '${{ toJSON(github.event) }}'
       # filter based on reviewer assigned?
       # move to board
-      - uses: actions/add-to-project@v0.3.0
-        with:
-          project-url: https://github.com/orgs/camunda/projects/27
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          labeled: needs-docs-review
-          # label-operator: NOT
       - name: Get project data
         env:
           GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
@@ -48,31 +46,45 @@ jobs:
           echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
           echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
           echo 'IN_REVIEW_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="👀 In Review") |.id' project_data.json) >> $GITHUB_ENV
-      - name: Set fields
+      - name: Add PR to project
         env:
           GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
           PR_ID: ${{ github.event.pull_request.node_id }}
         run: |
-          gh api graphql -f query='
-            mutation (
-              $project: ID!
-              $item: ID!
-              $status_field: ID!
-              $status_value: String!
-            ) {
-              set_status: updateProjectV2ItemFieldValue(input: {
-                projectId: $project
-                itemId: $item
-                fieldId: $status_field
-                value: { 
-                  singleSelectOptionId: $status_value
-                  }
-              }) {
-                projectV2Item {
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $pr:ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $pr}) {
+                item {
                   id
-                  }
+                }
               }
-            }' -f project=$PROJECT_ID -f item=$PR_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.IN_REVIEW_OPTION_ID }}
+            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectV2ItemById.item.id')"
+
+            echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+      # - name: Set fields
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      #   run: |
+      #     gh api graphql -f query='
+      #       mutation (
+      #         $project: ID!
+      #         $item: ID!
+      #         $status_field: ID!
+      #         $status_value: String!
+      #       ) {
+      #         set_status: updateProjectV2ItemFieldValue(input: {
+      #           projectId: $project
+      #           itemId: $item
+      #           fieldId: $status_field
+      #           value: {
+      #             singleSelectOptionId: $status_value
+      #             }
+      #         }) {
+      #           projectV2Item {
+      #             id
+      #             }
+      #         }
+      #       }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.IN_REVIEW_OPTION_ID }}
 
       # --silent
 

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -8,7 +8,7 @@ jobs:
   sync-board:
     # if: github....reviewer == "christina" or "amara"
     # if: contains(github.event.pull_request.labels.*.name, 'needs-docs-review')
-    if: github.event.pull_request.requested_reviewer.login == 'akeller' || github.event.pull_request.requested_reviewer.login == 'christinaausley'
+    if: github.event.requested_reviewer.login == 'akeller' || github.event.requested_reviewer.login == 'christinaausley'
     runs-on: ubuntu-latest
     steps:
       - name: Dump GitHub context

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -4,12 +4,9 @@ on:
   pull_request:
     types: [review_requested]
 
-env:
-  DOCS_REVIEWERS: ("akeller" "christinaausley")
-
 jobs:
   sync-board:
-    if: contains(env.DOCS_REVIEWERS, github.event.requested_reviewer.login)
+    if: github.event.requested_reviewer.login == 'akeller' || github.event.requested_reviewer.login == 'christinaausley'
     runs-on: ubuntu-latest
     steps:
       - name: Get project IDs for later steps

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   sync-board:
     # if: github....reviewer == "christina" or "amara"
-    if: contains(github.event.pull_request.labels.*.name, 'needs-docs-review’)
+    if: contains(github.event.pull_request.labels.*.name, 'needs-docs-review')
     runs-on: ubuntu-latest
     steps:
       - name: Dump GitHub context

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -18,3 +18,8 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: needs-docs-review
           # label-operator: NOT
+      - uses: alex-page/github-project-automation-plus@v0.8.1 # Error: Could not find the column "👀 In review" or project "Documentation Board"
+        with: # - uses: alex-page/github-project-automation-plus@v0.8.1
+          project: Documentation
+          column: Review
+          repo-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -48,11 +48,33 @@ jobs:
           echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
           echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
           echo 'IN_REVIEW_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="👀 In Review") |.id' project_data.json) >> $GITHUB_ENV
-      - name: See project data
+      - name: Set fields
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          PR_ID: ${{ github.event.pull_request.node_id }}
         run: |
-          echo "${{env.PROJECT_ID}}"
-          echo "${{env.STATUS_FIELD_ID}}"
-          echo "${{env.IN_REVIEW_OPTION_ID}}"
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              set_status: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: { 
+                  singleSelectOptionId: $status_value
+                  }
+              }) {
+                projectV2Item {
+                  id
+                  }
+              }
+            }' -f project=$PROJECT_ID -f item=$PR_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.IN_REVIEW_OPTION_ID }}
+
+      # --silent
 
       # - uses: alex-page/github-project-automation-plus@v0.8.1 # Error: Could not find the column "👀 In review" or project "Documentation Board"
       #   with: # - uses: alex-page/github-project-automation-plus@v0.8.1

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -8,6 +8,7 @@ jobs:
   sync-board:
     # if: github....reviewer == "christina" or "amara"
     # if: contains(github.event.pull_request.labels.*.name, 'needs-docs-review')
+    if: github.event.pull_request.requested_reviewer.login == 'akeller' || github.event.pull_request.requested_reviewer.login == 'christinaausley'
     runs-on: ubuntu-latest
     steps:
       - name: Dump GitHub context

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -4,19 +4,15 @@ on:
   pull_request:
     types: [review_requested]
 
+env:
+  DOCS_REVIEWERS: ("akeller" "christinaausley")
+
 jobs:
   sync-board:
-    # if: github....reviewer == "christina" or "amara"
-    # if: contains(github.event.pull_request.labels.*.name, 'needs-docs-review')
-    if: github.event.requested_reviewer.login == 'akeller' || github.event.requested_reviewer.login == 'christinaausley'
+    if: contains(env.DOCS_REVIEWERS, github.event.requested_reviewer.login)
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        id: github_context_step
-        run: echo '${{ toJSON(github.event) }}'
-      # filter based on reviewer assigned?
-      # move to board
-      - name: Get project data
+      - name: Get project IDs for later steps
         env:
           GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
           ORGANIZATION: camunda
@@ -61,7 +57,7 @@ jobs:
             }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectV2ItemById.item.id')"
 
             echo 'ITEM_ID='$item_id >> $GITHUB_ENV
-      - name: Set fields
+      - name: Set status field
         env:
           GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
         run: |
@@ -85,11 +81,3 @@ jobs:
                   }
               }
             }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.IN_REVIEW_OPTION_ID }}
-
-      # --silent
-
-      # - uses: alex-page/github-project-automation-plus@v0.8.1 # Error: Could not find the column "👀 In review" or project "Documentation Board"
-      #   with: # - uses: alex-page/github-project-automation-plus@v0.8.1
-      #     project: Documentation
-      #     column: Review
-      #     repo-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
A collaboration with @akeller.

Addresses #1154 

This PR rewrites the `sync-board` workflow to:

1. Listen for reviewers to be assigned to a PR.
2. If the assigned reviewer isn't @akeller or @christinaausley, stop.
3. Otherwise, add the PR to the Documentation Board project, and set its status to In Review.

[Here is an example of a successful workflow run](https://github.com/camunda/camunda-platform-docs/actions/runs/2891812456).

## Alternatives considered

1. We initially attempted to use existing actions to do this:
    * [https://github.com/actions/add-to-project](actions/add-to-project) was able to add the PR to the project, but it does not support also setting the Status field to In Review.
    * [https://github.com/alex-page/github-project-automation-plus](alex-page/github-project-automation-plus) is supposed to be capable of setting the Status field to In Review, but we were unable to get it to work. We aren't sure why -- it may have been an issue with the scopes assigned to the personal access token we were using, but it seemed like we should have been covered. 

2. Using labels to trigger the workflow instead of review request. We initially did this because the actions/add-to-project job operated based on labels instead of reviewers. Once we got to the point of writing all of the GraphQL ourselves, it was no longer necessary to trigger on labels. Since both options would use `jobs.if` conditions to target specific PRs, and `jobs.if` conditions leave noise in the Actions tab for all skipped jobs, we chose review assignment over labels because it would likely cause fewer "skipped" actions.

## Edge cases

If the sync-board job were to fail, it would leave a PR in red for a confusing reason. We want to avoid this if possible. Here is a list of edge cases that we considered, and the outcome of each:

- if the PR is already on the documentation board in In Review, [the job succeeds](https://github.com/camunda/camunda-platform-docs/actions/runs/2891957669) without any changes. 
- if the PR is already on the documentation board in a different status, [the job succeeds](https://github.com/camunda/camunda-platform-docs/actions/runs/2891944563), but the status gets updated back to In Review. This might lead to things moving when we don't want them to, but I'd like to see it be a problem before we try to fix it.
- if review is requested from both @akeller and @christinaausley at the same time, the job runs twice ([here](https://github.com/camunda/camunda-platform-docs/actions/runs/2891920262) and [here](https://github.com/camunda/camunda-platform-docs/actions/runs/2891920478)). Both runs succeed.
- if review is requested from multiple people at the same time, one of them a docs reviewer and one not, the run with the docs reviewer would successfully add the PR to the board. The other run would be skipped.

