### PR TITLE
chore: remove vNext and optimize docs from sitemap temporarily

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -216,6 +216,8 @@ module.exports = {
           //cacheTime: 600 * 1000, // 600 sec - cache purge period
           changefreq: "weekly",
           priority: 0.5,
+          // this is temporary. Ignore these from the sitemap while we move a lot of things around.
+          ignorePatterns: ["/docs/next/**", "/optimize/**"],
         },
       },
     ],


### PR DESCRIPTION
Related to #1116 

## What is the purpose of the change

This PR removes the "next" version & the Optimize docs from the sitemap, temporarily. This is in preparation for moving a bunch of files around, iteratively, for #1116. 

### Why?

1. I'm not sure what effect having a bunch of files disappearing & moving from the sitemap will have for SEO
2. I think link-checking will break once I start submitting PRs that move docs from the `docs` instance to the `optimize` instance. Removing the entire next version from the sitemap would prevent link-checking from happening on these files that are being moved.

## Proof that it removes things

Here's a screenshot of me searching a generated sitemap for `/next/` -- with zero results. Note that it's pointless to include a search for the optimize documentation, because there is no optimize docs instance in this branch yet. 

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/1627089/186254185-28d59465-f4de-47f5-8c74-e31b83f83dd9.png">

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
