### PR TITLE
Remove second H1 on the home page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -164,7 +164,7 @@ function Home() {
         )}
         <div className={clsx("hero hero--secondary", styles.heroBanner)}>
           <div className="container">
-            <h1 className="hero__title">Unsure where to begin?</h1>
+            <h2 className="hero__title">Unsure where to begin?</h2>
             <p className="hero__subtitle">Try one of our use case guides</p>
             <div className={styles.buttons}>
               <Link


### PR DESCRIPTION
## What is the purpose of the change

There are two H1's on the home page and I'm embarrassed I did this, but more embarrassed that Bing Webmaster Tools caught it before any of us did... OOPS! The second one was changed to H2. This will need to be live for us to recheck in Bing Webmaster Tools, but you can also see it in the updated HTML.

## Are there related marketing activities

No

## When should this change go live?

Whenever, but this may be impacting SEO so sooner rather than later would be good.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
