### PR TITLE
fix: use lint-staged correctly (to decrease commit time)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "prettier": "2.7.1"
   },
   "lint-staged": {
-    "*.{css,js,json,MD,md,mdx,yaml,yml}": "npm run format"
+    "*.{css,js,json,MD,md,mdx,yaml,yml}": "prettier --write"
   }
 }


### PR DESCRIPTION
A Friday afternoon (my time) gift [for @tmetzke](https://github.com/camunda/camunda-platform-docs/issues/1104#issuecomment-1229865319): 

## What is the purpose of the change

Updates the pre-commit hook to run prettier against _only_ files that have changed, for much faster commits.

### How?

I was using lint-staged incorrectly! In a case of over-pursuing the DRY principle, I configured lint-staged to run `npm run format`, to avoid defining what "format" meant in two places. 

But the `format` script passes `.` as the path to prettier, resulting in the entire codebase being formatted even for a one line change. 

lint-staged passes a glob for the committed files to the configured command...this change takes advantage of that, and now the hook will only format the files being committed. 

### Before this change

![image](https://user-images.githubusercontent.com/1627089/188206408-1c1ba83c-08b4-4f7f-a63f-7d5d6d38c930.png)

### After this change

![image](https://user-images.githubusercontent.com/1627089/188206512-741de698-e5fd-465e-ae08-b84775f4663d.png)


## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
