### PR TITLE
chore(docs): remove beta flag from external variable API docs

### DIFF
--- a/docs/apis-clients/optimize-api/external-variable-ingestion.md
+++ b/docs/apis-clients/optimize-api/external-variable-ingestion.md
@@ -4,11 +4,6 @@ title: "External variable ingestion"
 description: "The REST API to ingest external variable data into Optimize."
 ---
 
-:::note Heads Up!
-The external variable ingestion API is a beta feature and will be subject
-to future changes.
-:::
-
 With the external variable ingestion API, variable data held in external systems can be ingested into Optimize directly,
 without the need for these variables to be present in your Camunda platform data. This can be useful when external
 business data, which is relevant for process analysis in Optimize, is to be associated with specific process instances.


### PR DESCRIPTION
relates to OPT-5974

## What is the purpose of the change

Feature is no longer in beta. Remove the flag

## Are there related marketing activities

N/A

## When should this change go live?

Next release

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
