### PR TITLE
Added migration guide from Cawemo

### DIFF
--- a/docs/guides/migrating-from-cawemo.md
+++ b/docs/guides/migrating-from-cawemo.md
@@ -1,0 +1,57 @@
+---
+id: migrating-from-cawemo
+title: Migrating Diagrams from Cawemo
+description: "Migrating Diagrams from Cawemo to Camunda Platform 8 Web Modeler"
+---
+
+## Migrating Diagrams from Cawemo to Camunda Platform 8 Web Modeler
+
+This guide steps through how to migrate BPMN diagrams created in Cawemo to Camunda Platform 8 Web Modeler.
+
+- You should consider migrating diagrams from Cawemo to Camunda Platform 8 Web Modeler if:
+- You want to continue working on your diagrams on the latest Camunda Platform.
+- You are exploring automating your processes.
+- You are in need of certain features that can only be found in Camunda Platform 8 (e.g. [BPMN message buffering](https://docs.camunda.io/docs/components/concepts/messages/#message-buffering), big [multi-instance constructs](https://docs.camunda.io/docs/components/modeler/bpmn/multi-instance/), the new Connectors framework, or the improved collaboration features in web modeler).
+
+## Prerequisites
+
+- Ensure you have a valid [Camunda Platform 8 account](https://docs.camunda.io/docs/guides/getting-started/), or sign up if you still need one.
+- A BPMN diagram in your Cawemo account.
+
+## Migrate your BPMN diagram
+
+Take the following steps to migrate your BPMN diagram in Cawemo to Camunda Platform 8 [Web Modeler](https://docs.camunda.io/docs/components/modeler/web-modeler/launch-cloud-modeler/):
+
+1. Log in to Cawemo.
+2. Click the **Project** folder on the **Home** page of the BPMN diagram you want to transfer.
+3. Click on the BPMN diagram you want to transfer.
+
+:::note
+If the BPMN file has been uploaded to Cawemo from Desktop Modeler for execution on Camunda Platform 7, the file cannot be uploaded to Web Modeler.
+:::
+
+4. Click **Download** or **export**
+5. Click **Download as BPMN 2.0 XML**.
+6. Log in to Camunda Platform 8.
+7. Click **Modeler** to open Web Modeler.
+8. Open the project you want to transfer your BPMN file to or create a new project by clicking **New project**.
+9. Click **New** > **Upload files**.
+10. Open the BPMN XML file downloaded from Cawemo.
+
+:::note
+While unsupported elements are imported in Web Modeler, they are not supported for deployment and will be highlighted in the error panel.
+:::
+
+## Additional resources
+
+Not all elements in Cawemo are supported in Camunda Platform 8 Web Modeler. Find details on BPMN coverage in Camunda Platform 8 in the [BPMN coverage documentation](https://docs.camunda.io/docs/components/modeler/bpmn/bpmn-coverage/). We are investing in supporting the elements currently available on Camunda Platform 7.
+
+## Next step
+
+Learn more about [migrating from Camunda 7 to Camunda 8](https://docs.camunda.io/docs/guides/migrating-from-camunda-platform-7/).
+
+## FAQ
+
+Questions: Why do I get the following error The following 1 file is invalid and can't be uploaded: “" when uploading my BPMN file?
+
+Answer: A BPMN file for execution on Camunda Platform 7 that has been created with the Desktop Modeler - or another BPM tool using BPMN to execute processes - has been uploaded to Cawemo. Find details in [Migrating from Camunda Platform 7 documentation under migration overview](https://docs.camunda.io/docs/guides/migrating-from-camunda-platform-7/#migration-overview) to solve the error.

--- a/versioned_docs/version-8.0/guides/migrating-from-cawemo.md
+++ b/versioned_docs/version-8.0/guides/migrating-from-cawemo.md
@@ -1,0 +1,57 @@
+---
+id: migrating-from-cawemo
+title: Migrating Diagrams from Cawemo
+description: "Migrating Diagrams from Cawemo to Camunda Platform 8 Web Modeler"
+---
+
+## Migrating Diagrams from Cawemo to Camunda Platform 8 Web Modeler
+
+This guide steps through how to migrate BPMN diagrams created in Cawemo to Camunda Platform 8 Web Modeler.
+
+- You should consider migrating diagrams from Cawemo to Camunda Platform 8 Web Modeler if:
+- You want to continue working on your diagrams on the latest Camunda Platform.
+- You are exploring automating your processes.
+- You are in need of certain features that can only be found in Camunda Platform 8 (e.g. [BPMN message buffering](https://docs.camunda.io/docs/components/concepts/messages/#message-buffering), big [multi-instance constructs](https://docs.camunda.io/docs/components/modeler/bpmn/multi-instance/), the new Connectors framework, or the improved collaboration features in web modeler).
+
+## Prerequisites
+
+- Ensure you have a valid [Camunda Platform 8 account](https://docs.camunda.io/docs/guides/getting-started/), or sign up if you still need one.
+- A BPMN diagram in your Cawemo account.
+
+## Migrate your BPMN diagram
+
+Take the following steps to migrate your BPMN diagram in Cawemo to Camunda Platform 8 [Web Modeler](https://docs.camunda.io/docs/components/modeler/web-modeler/launch-cloud-modeler/):
+
+1. Log in to Cawemo.
+2. Click the **Project** folder on the **Home** page of the BPMN diagram you want to transfer.
+3. Click on the BPMN diagram you want to transfer.
+
+:::note
+If the BPMN file has been uploaded to Cawemo from Desktop Modeler for execution on Camunda Platform 7, the file cannot be uploaded to Web Modeler.
+:::
+
+4. Click **Download** or **export**
+5. Click **Download as BPMN 2.0 XML**.
+6. Log in to Camunda Platform 8.
+7. Click **Modeler** to open Web Modeler.
+8. Open the project you want to transfer your BPMN file to or create a new project by clicking **New project**.
+9. Click **New** > **Upload files**.
+10. Open the BPMN XML file downloaded from Cawemo.
+
+:::note
+While unsupported elements are imported in Web Modeler, they are not supported for deployment and will be highlighted in the error panel.
+:::
+
+## Additional resources
+
+Not all elements in Cawemo are supported in Camunda Platform 8 Web Modeler. Find details on BPMN coverage in Camunda Platform 8 in the [BPMN coverage documentation](https://docs.camunda.io/docs/components/modeler/bpmn/bpmn-coverage/). We are investing in supporting the elements currently available on Camunda Platform 7.
+
+## Next step
+
+Learn more about [migrating from Camunda 7 to Camunda 8](https://docs.camunda.io/docs/guides/migrating-from-camunda-platform-7/).
+
+## FAQ
+
+Questions: Why do I get the following error The following 1 file is invalid and can't be uploaded: “" when uploading my BPMN file?
+
+Answer: A BPMN file for execution on Camunda Platform 7 that has been created with the Desktop Modeler - or another BPM tool using BPMN to execute processes - has been uploaded to Cawemo. Find details in [Migrating from Camunda Platform 7 documentation under migration overview](https://docs.camunda.io/docs/guides/migrating-from-camunda-platform-7/#migration-overview) to solve the error.

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -33,6 +33,7 @@
         "guides/update-guide/026-to-100"
       ]
     },
+    "guides/migrating-from-cawemo",
     "guides/migrating-from-camunda-platform-7"
   ],
   "Components": [


### PR DESCRIPTION
## What is the purpose of the change

As discussed in https://github.com/camunda/product-hub/issues/358, @Camundaan worked on a guide helping users to migrate from Cawemo to the C8 Web Modeler. 
This PR includes these changes in the versioned 8.0 and next docs. 

## Are there related marketing activities
no

## When should this change go live?
as soon as possible - but no rush! 

## PR Checklist
- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.

P.s. a technical writer review has already been conducted in the GDoc file which was used by @christinaausley and @Camundaan for collaboration purposes. 
