### PR TITLE
feat: show correct versions in navbar based on which docs you're viewing

### DIFF
--- a/src/theme/NavbarItem/index.js
+++ b/src/theme/NavbarItem/index.js
@@ -1,0 +1,26 @@
+// Why is this swizzled?
+//   To render the correct versions in the version dropdown.
+//   If they're viewing optimize docs, we pass the optimize docs plugin ID to the version dropdown.
+// Swizzled from version 2.0.1.
+
+import React from "react";
+import { useLocation } from "@docusaurus/router";
+import NavbarItem from "@theme-original/NavbarItem";
+
+export default function NavbarItemWrapper(props) {
+  const { type } = props;
+  const { pathname } = useLocation();
+
+  const childProps = { ...props };
+  if (type === "docsVersionDropdown") {
+    if (/^\/optimize/.test(pathname)) {
+      childProps.docsPluginId = "optimize";
+    }
+  }
+
+  return (
+    <>
+      <NavbarItem {...childProps} />
+    </>
+  );
+}


### PR DESCRIPTION
Child of #1234 

My intention is to merge this into #1234 before #1234 is merged into `main`. 

I expect link-checking to fail on this PR, because the redirect rules for moved docs are not defined yet.

## What is the purpose of the change

Customizes the version selector in the top navigation so that it displays the correct versions based on which doc is being viewed. For Optimize docs, emits 3.8.0 and next....for all other docs, emits 8.0, next, and all the other c8 versions.

### What it looks like on an optimize page

<img width="830" alt="image" src="https://user-images.githubusercontent.com/1627089/188728985-9645ca73-b46e-4365-80ad-d15f55996162.png">

### What it looks like on any other page

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/1627089/188728528-15ebbe3c-0467-4328-b5e5-204c45b29730.png">

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
