### PR TITLE
chore (optimize/3.8.0): revert "remove vNext and optimize docs from sitemap"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -229,8 +229,6 @@ module.exports = {
           //cacheTime: 600 * 1000, // 600 sec - cache purge period
           changefreq: "weekly",
           priority: 0.5,
-          // this is temporary. Ignore these from the sitemap while we move a lot of things around.
-          ignorePatterns: ["/docs/next/**", "/optimize/**"],
         },
       },
     ],


### PR DESCRIPTION
Child of #1234 

This will be merged into #1234 before #1234 is merged into `main`.

## What is the purpose of the change

While building the `next` versions of the docs, we removed these folders from the sitemap to avoid a constantly changing (and usually incorrect) sitemap. 

This PR reverts that commit, adding the `docs/next` and `optimize/` folders back to the sitemap.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
