### PR TITLE
chore(es): remove support for Elasticsearch 7.10-7.12

### DIFF
--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -33,12 +33,12 @@ We highly recommend running Camunda Platform 8 Self-Managed in a Kubernetes envi
 Requirements for the components can be seen below:
 
 |                          | Java version | Other requirements                                     |
-| ------------------------ | ------------ | ------------------------------------------------------ |
+| ------------------------ | ------------ |--------------------------------------------------------|
 | Zeebe Broker and Gateway | OpenJDK 17+  | Elasticsearch 7.16.x(only if Elastic exporter is used) |
 | Operate                  | OpenJDK 11+  | Elasticsearch 7.16.x                                   |
 | Tasklist                 | OpenJDK 11+  | Elasticsearch 7.16.x                                   |
 | Identity                 | OpenJDK 17+  | Keycloak 16.1.1                                        |
-| Optimize                 | OpenJDK 11+  | Elasticsearch 7.10.x - 7.15.x, 7.16.2+, 7.17.x         |
+| Optimize                 | OpenJDK 11+  | Elasticsearch 7.13.x - 7.15.x, 7.16.2+, 7.17.x         |
 
 :::note Elasticsearch support
 [Elastic's Elasticsearch](https://www.elastic.co/elasticsearch/) is the only supported version of Elastic compatible with Camunda Platform 8.

--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -33,7 +33,7 @@ We highly recommend running Camunda Platform 8 Self-Managed in a Kubernetes envi
 Requirements for the components can be seen below:
 
 |                          | Java version | Other requirements                                     |
-| ------------------------ | ------------ |--------------------------------------------------------|
+| ------------------------ | ------------ | ------------------------------------------------------ |
 | Zeebe Broker and Gateway | OpenJDK 17+  | Elasticsearch 7.16.x(only if Elastic exporter is used) |
 | Operate                  | OpenJDK 11+  | Elasticsearch 7.16.x                                   |
 | Tasklist                 | OpenJDK 11+  | Elasticsearch 7.16.x                                   |

--- a/docs/self-managed/optimize-deployment/migration-update/3.9-preview-to-3.9.md
+++ b/docs/self-managed/optimize-deployment/migration-update/3.9-preview-to-3.9.md
@@ -1,0 +1,29 @@
+---
+id: 3.9-preview-1-to-3.9
+title: "Update notes (3.9-preview-x to 3.9.x)"
+---
+
+:::note Heads up!
+To update Optimize to version 3.9.x, perform the following steps: [Migration & Update Instructions](./instructions.md).
+:::
+
+The update to 3.9.x can be performed from any 3.8.x or any 3.9.0-preview release.
+
+Here you will find information about:
+
+- Limitations
+- Known issues
+- Changes in the supported environments
+- Any unexpected behavior of Optimize (for example, due to a new feature)
+- Changes in translation resources
+
+## Known issues
+
+No known issues at the moment.
+
+## Changes in supported environments
+
+Optimize now requires at least Elasticsearch `7.13.0`.
+See the [Supported Environments](./../../../reference/supported-environments.md) sections for the full range of supported versions.
+
+If you need to update your Elasticsearch cluster, refer to the general [Elasticsearch Update Guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html) on how to do that. Usually, the only thing you need to do is perform a [rolling update](https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html).


### PR DESCRIPTION
relates to OPT-6384

## What is the purpose of the change

Optimize will no longer support ES 7.10-7.12 from our 3.9.0 release. This change amends the supported environments accordingly and adds a note to our migration notes for people updating from a previous version.

## Are there related marketing activities

N/A

## When should this change go live?

With the next release (Optimize 3.9.0 / Cloud 8.1.0)

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
