### PR TITLE
docs(identity): add reference to the webmodeler preset placeholder

### DIFF
--- a/docs/self-managed/identity/deployment/configuration-variables.md
+++ b/docs/self-managed/identity/deployment/configuration-variables.md
@@ -34,5 +34,7 @@ component for use within Identity, all that is required is to set two variables:
 | `KEYCLOAK_INIT_<COMPONENT>_ROOT_URL` | The root URL of where the component is hosted | No default    |
 
 :::note
-Identity supports the following values for the `<COMPONENT>` placeholder: `OPERATE`,`TASKLIST`, and `OPTIMIZE`.
+Identity supports the following values for the `<COMPONENT>` placeholder: `OPERATE`, `OPTIMIZE`, `TASKLIST`, and `WEBMODELER`.
+
+For the `WEBMODELER` value, only the `KEYCLOAK_INIT_<COMPONENT>_ROOT_URL` variable is required to be set.
 :::


### PR DESCRIPTION
## What is the purpose of the change

With the merging of https://github.com/camunda-cloud/identity/pull/956 - the Identity component is now able to initialise with a preset for the Web Modeler component. 

This PR updates the values described to the user.

## Are there related marketing activities

Not for this change specifically.

## When should this change go live?

The preset support for Web Modeler is in the 8.1.0-alpha5 release so this change is fine to go into the `next` version of docs, and eventually in the 8.1 release.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
