### PR TITLE
fix?: attempt to fix mixpanel events

### DIFF
--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -8,6 +8,7 @@ import Footer from "@theme-original/Footer";
 import { Auth0Provider, useAuth0 } from "@auth0/auth0-react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Head from "@docusaurus/Head";
+import mixpanel from "mixpanel-browser";
 
 export default function FooterWrapper(props) {
   return (

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -65,6 +65,8 @@ const MixpanelElement = () => {
             }
           } catch (_error) {
             // mixpanel is not initiated
+            // TODO: remove this logging after figuring out why mixpanel is broken
+            console.log("mixpanel is not initiated...", _error);
           }
           if (!mixpanelInitiated) {
             getAccessTokenSilently()
@@ -88,6 +90,8 @@ const MixpanelElement = () => {
               })
               .catch((_error) => {
                 // failed to silently authenticate user
+                // TODO: remove this logging after figuring out why mixpanel is broken
+                console.log("failed to authenticate user...", _error);
               });
           } else {
             // track event "docs"


### PR DESCRIPTION
## What is the purpose of the change

Mixpanel events haven't been sending since about the time that #1114 was published. This PR does two things: 

1. imports `mixpanel` because that line was removed in #1114 and shouldn't have been.
2. Adds some `console.log` statements for silently-caught errors, to help provide details when testing in production.

The big challenge with this is that the only way for us to test Mixpanel events is in production. (Maybe staging too? I'm not sure.) So in order to see if this fix works, we'll need to merge, and maybe also deploy to production. 

## When should this change go live?

Immediately, so that I can test it in production.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
