### PR TITLE
Document `zeebe:Property` Element Template Property

### DIFF
--- a/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -417,6 +417,16 @@ The `property` binding is supported both in Camunda Platform 7 and Cloud.
 | **Binding parameters**      |                                                     |
 | **Mapping result**          | `<zeebe:taskDefinition type="[userInput]" />`       |
 
+##### `zeebe:property`
+
+| **Binding `type`**          | `zeebe:property`                                      |
+| --------------------------- | ----------------------------------------------------- |
+| **Valid property `type`'s** | `String`<br />`Text`<br />`Hidden`<br />`Dropdown`    |
+| **Binding parameters**      | `name`: the name of the property                      |
+| **Mapping result**          | `<zeebe:property name="[name]" value="[userInput] />` |
+
+The `zeebe:property` binding allows you to set any arbitrary property for an outside system. It does not impact execution of the Zeebe engine.
+
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Related to https://github.com/bpmn-io/internal-docs/issues/636

## What is the purpose of the change

_Briefly describe the change you are making, this helps the reviewer by providing an overview._

Documenting the new `zeebe:Property` element template property supported as of Camunda Modeler 5.3.

Product Hub: https://github.com/camunda/product-hub/issues/335

## Are there related marketing activities

_Are there any marketing activities related to the related feature or component? If so, please briefly describe them._

No.

## When should this change go live?

_Does this change need to be released before a certain date or milestone? If so, when?_

Will be supported across the entire stack once Camunda 8.1 is released.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
