### PR TITLE
change io.zeebe to io.camunda

### DIFF
--- a/versioned_docs/version-1.1/components/clients/java-client/index.md
+++ b/versioned_docs/version-1.1/components/clients/java-client/index.md
@@ -65,7 +65,7 @@ Let's go over this code snippet line by line:
 3. Create the client by passing in the address of the cluster we want to connect to and the credentials provider from the step above.
 4. Send a test request to verify the connection was established.
 
-See [io.camunda.zeebe.client.ZeebeClientBuilder](https://javadoc.io/doc/io.zeebe/zeebe-client-java/latest/io/zeebe/client/ZeebeClientBuilder.html) for a description of all available configuration properties.
+See [io.camunda.zeebe.client.ZeebeClientBuilder](https://javadoc.io/doc/io.camunda/zeebe-client-java/latest/io/zeebe/client/ZeebeClientBuilder.html) for a description of all available configuration properties.
 
 Another (more compact) option is to pass in the connection settings via environment variables:
 

--- a/versioned_docs/version-1.2/apis-clients/java-client/index.md
+++ b/versioned_docs/version-1.2/apis-clients/java-client/index.md
@@ -65,7 +65,7 @@ Let's go over this code snippet line by line:
 3. Create the client by passing in the address of the cluster we want to connect to and the credentials provider from the step above.
 4. Send a test request to verify the connection was established.
 
-See [io.camunda.zeebe.client.ZeebeClientBuilder](https://javadoc.io/doc/io.zeebe/zeebe-client-java/latest/io/zeebe/client/ZeebeClientBuilder.html) for a description of all available configuration properties.
+See [io.camunda.zeebe.client.ZeebeClientBuilder](https://javadoc.io/doc/io.camunda/zeebe-client-java/latest/io/zeebe/client/ZeebeClientBuilder.html) for a description of all available configuration properties.
 
 Another (more compact) option is to pass in the connection settings via environment variables:
 

--- a/versioned_docs/version-1.3/apis-clients/java-client/index.md
+++ b/versioned_docs/version-1.3/apis-clients/java-client/index.md
@@ -65,7 +65,7 @@ Let's go over this code snippet line by line:
 3. Create the client by passing in the address of the cluster we want to connect to and the credentials provider from the step above.
 4. Send a test request to verify the connection was established.
 
-See [io.camunda.zeebe.client.ZeebeClientBuilder](https://javadoc.io/doc/io.zeebe/zeebe-client-java/latest/io/zeebe/client/ZeebeClientBuilder.html) for a description of all available configuration properties.
+See [io.camunda.zeebe.client.ZeebeClientBuilder](https://javadoc.io/doc/io.camunda/zeebe-client-java/latest/io/zeebe/client/ZeebeClientBuilder.html) for a description of all available configuration properties.
 
 Another (more compact) option is to pass in the connection settings via environment variables:
 


### PR DESCRIPTION
## What is the purpose of the change

Based on https://github.com/camunda/camunda-platform-docs/issues/1009. Renaming `io.zeebe` to `io.camunda` we seemed to rename the text but not the actual link, causing the links to send users to old versions of the Javadocs.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
