### PR TITLE
fix(ootb connectors): order connectors alphabetically

### DIFF
--- a/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -7,8 +7,8 @@ description: Take a closer look at the Connectors available in Camunda Platform 
 This section gives an overview of the **out-of-the-box Connectors** available in Camunda Platform 8:
 
 - [Amazon SQS Connector](aws-sqs.md) - Send messages to Amazon [Simple Queue Service](https://aws.amazon.com/sqs/) from your BPMN process.
-- [Google Drive Connector](googledrive.md) - Create folders or files from a [Google Drive](https://www.google.com/drive/) template from your BPMN process.
 - [AWS Lambda Connector](aws-lambda.md) - Invoke [AWS Lambda Functions](https://aws.amazon.com/lambda/) from your BPMN process.
+- [Google Drive Connector](googledrive.md) - Create folders or files from a [Google Drive](https://www.google.com/drive/) template from your BPMN process.
 - [REST Connector](rest.md) - Make a request to a REST API and use the response in the next steps of your process.
 - [SendGrid Connector](sendgrid.md) - Quickly send emails from your BPMN processes.
 - [Slack Connector](slack.md) - Send messages to channels or users in your [Slack](https://slack.com) workspace from your BPMN process.


### PR DESCRIPTION
## What is the purpose of the change

This change orders available OOTB connectors in alphabetical order.

## Are there related marketing activities

No

## When should this change go live?

This change is purely cosmetic, thus no specific date. Can go in `Next`.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
