### PR TITLE
Document job retry backoff

### DIFF
--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -392,9 +392,10 @@ Returned if:
 
 ### `FailJob` RPC
 
-Marks the job as failed; if the retries argument is positive, the job is immediately
-activatable again, and a worker could try again to process it. If it is zero or negative,
-an incident is raised, tagged with the given errorMessage, and the job is not activatable until the incident is resolved.
+Marks the job as failed. If the retries argument is positive and no retry back off is set, the job is immediately
+activatable again. If the retry back off is positive the job becomes activatable once the back off timeout has passed.
+If the retries argument is zero or negative, an incident is raised, tagged with the given errorMessage, and the job is
+not activatable until the incident is resolved.
 
 #### Input: `FailJobRequest`
 
@@ -408,6 +409,8 @@ message FailJobRequest {
   // this is particularly useful if a job runs out of retries and an incident is raised,
   // as it this message can help explain why an incident was raised
   string errorMessage = 3;
+  // the backoff timeout (in ms) for the next retry
+  int64 retryBackOff = 4;
 }
 ```
 

--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -67,6 +67,11 @@ After working on an activated job, a job worker informs Camunda Platform 8 that 
   - If `remaining retries` is greather than zero, the job is retried and reassigned.
   - If `remaining retries` is zero or negative, an incident is raised and the job is not retried until the incident is resolved.
 
+When failing a job it is possible to specify a `retry back off`. This back off allows waiting for a specified amount of time before retrying the job.
+This could be useful when a job worker communicates with an external system. If the external system is down, immediately retrying the job will not work.
+This will result in an incident when the retries run out. Using the `retry back off` will delay the retry. This allows the external system some time to recover.
+If no `retry back off` the job is immediately retried.
+
 ## Timeouts
 
 If the job is not completed or failed within the configured job activation timeout, Zeebe reassigns the job to another job worker. This does not affect the number of `remaining retries`.

--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -64,7 +64,7 @@ After working on an activated job, a job worker informs Camunda Platform 8 that 
 
 - When the job worker completes its work, it sends a `complete job` command along with any variables, which in turn is merged into the process instance. This is how the job worker exposes the results of its work.
 - If the job worker can not successfully complete its work, it sends a `fail job` command. Fail job commands include the number of remaining retries, which is set by the job worker.
-  - If `remaining retries` is greather than zero, the job is retried and reassigned.
+  - If `remaining retries` is greater than zero, the job is retried and reassigned.
   - If `remaining retries` is zero or negative, an incident is raised and the job is not retried until the incident is resolved.
 
 When failing a job it is possible to specify a `retry back off`. This back off allows waiting for a specified amount of time before retrying the job.


### PR DESCRIPTION
## What is the purpose of the change

Documents the Job retry backoff mechanism.

closes #964 

## Are there related marketing activities

N/A

## When should this change go live?

8.1.0 release.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
