### PR TITLE
Updates correlationKey in sample xml

### DIFF
--- a/versioned_docs/version-8.0/components/modeler/bpmn/receive-tasks/receive-tasks.md
+++ b/versioned_docs/version-8.0/components/modeler/bpmn/receive-tasks/receive-tasks.md
@@ -43,7 +43,7 @@ A receive task with message definition:
 ```xml
 <bpmn:message id="Message_1iz5qtq" name="Money collected">
    <bpmn:extensionElements>
-     <zeebe:subscription correlationKey="orderId" />
+     <zeebe:subscription correlationKey="= orderId" />
    </bpmn:extensionElements>
 </bpmn:message>
 


### PR DESCRIPTION
I believe in the descriptions of this example above, you reference the variable orderId as the place that holds the correlationKey. However in this xml example, it appears that it is referencing a correlation key of the static value "orderId". I have updated the sample xml to reflect the reference to a variable instead. If I'm wrong, then I have a few question I need answered.

## What is the purpose of the change

This is clarifying/improving documentation (see comment above)

## Are there related marketing activities

None

## When should this change go live?

as soon as they are approved 

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ x ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
