### PR TITLE
Enable protobuf syntax highlighting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,7 +56,7 @@ module.exports = {
       isCloseable: false,
     },
     prism: {
-      additionalLanguages: ["java"],
+      additionalLanguages: ["java", "protobuf"],
     },
     navbar: {
       title: "Camunda Platform 8 Docs",


### PR DESCRIPTION
## What is the purpose of the change

_Briefly describe the change you are making, this helps the reviewer by providing an overview._
We have some protobuf codeblocks. Docusaurus does not enable syntax highlighting for these by default. This PR enables this.

Before:
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/5787702/192775925-83815028-63a3-425e-b604-ab078d1b5e3d.png">

After:
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/5787702/192775962-717975d1-d48a-4555-9170-7af51dc125b1.png">


## Are there related marketing activities

_Are there any marketing activities related to the related feature or component? If so, please briefly describe them._
N/A

## When should this change go live?

_Does this change need to be released before a certain date or milestone? If so, when?_
Whenever, it doesn't change any of the content, just makes it more readable.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
