### PR TITLE
docs(feel): Update the FEEL docs to 1.15

### DIFF
--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-boolean.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-boolean.md
@@ -11,7 +11,7 @@ description: "This document outlines current boolean functions and a few example
 - result: boolean
 
 ```js
-not(true);
+not(true)
 // false
 ```
 

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-boolean.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-boolean.md
@@ -10,7 +10,7 @@ description: "This document outlines current boolean functions and a few example
   - `negand`: boolean
 - result: boolean
 
-```js
+```feel
 not(true)
 // false
 ```
@@ -25,7 +25,7 @@ The function can be used to check if a variable or a context entry (e.g. a prope
   - `value`: any
 - result: boolean
 
-```js
+```feel
 is defined(1)
 // true
 

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-context.md
@@ -13,7 +13,7 @@ Returns the value of the context entry with the given key.
   - `key`: string
 - result: any
 
-```js
+```feel
 get value({foo: 123}, "foo")
 // 123
 ```
@@ -26,7 +26,7 @@ Returns the entries of the context as a list of key-value-pairs.
   - `context`: context
 - result: list of context which contains two entries for "key" and "value"
 
-```js
+```feel
 get entries({foo: 123})
 // [{key: "foo", value: 123}]
 ```
@@ -43,7 +43,7 @@ Returns `null` if the value is not defined.
   - `value`: any
 - result: context
 
-```js
+```feel
 put({x:1}, "y", 2)
 // {x:1, y:2}
 ```
@@ -58,7 +58,7 @@ Returns `null` if one of the values is not a context.
   - `contexts`: contexts as varargs
 - result: context
 
-```js
+```feel
 put all({x:1}, {y:2})
 // {x:1, y:2}
 ```

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-context.md
@@ -44,7 +44,7 @@ Returns `null` if the value is not defined.
 - result: context
 
 ```js
-put({ x: 1 }, "y", 2);
+put({x:1}, "y", 2)
 // {x:1, y:2}
 ```
 

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
@@ -13,7 +13,7 @@ Convert a value into a different type.
   - or `year`, `month`, `day`: number
 - result: date
 
-```js
+```feel
 date(birthday)
 // date("2018-04-29")
 
@@ -32,7 +32,7 @@ date(2012, 12, 25)
     - (optional) `offset`: day-time-duration
 - result: time
 
-```js
+```feel
 time(lunchTime)
 // time("12:00:00")
 
@@ -54,7 +54,7 @@ time(14, 30, 0, duration("PT1H"))
   - or `from`: string
 - result: date-time
 
-```js
+```feel
 date and time(date("2012-12-24"),time("T23:59:00"))
 // date and time("2012-12-24T23:59:00")
 
@@ -71,7 +71,7 @@ date and time(birthday)
   - `from`: string
 - result: day-time-duration or year-month-duration
 
-```js
+```feel
 duration(weekDays)
 // duration("P5D")
 
@@ -86,7 +86,7 @@ duration(age)
   - `to`: date
 - result: year-month-duration
 
-```js
+```feel
 years and months duration(date("2011-12-22"), date("2013-08-24"))
 // duration("P1Y8M")
 ```
@@ -97,8 +97,8 @@ years and months duration(date("2011-12-22"), date("2013-08-24"))
   - `from`: string
 - result: number
 
-```js
-number("1500.5") 
+```feel
+number("1500.5")
 // 1500.5
 ```
 
@@ -108,8 +108,8 @@ number("1500.5")
   - `from`: any
 - result: string
 
-```js
-string(1.1) 
+```feel
+string(1.1)
 // "1.1"
 
 string(date("2012-12-25"))
@@ -130,7 +130,7 @@ Returns `null` if one of the entries is not a context or if a context doesn't co
   - `entries`: list of contexts
 - result: context
 
-```js
+```feel
 context([{"key":"a", "value":1}, {"key":"b", "value":2}])
 // {a:1, b:2}
 ```

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
@@ -72,10 +72,10 @@ date and time(birthday)
 - result: day-time-duration or year-month-duration
 
 ```js
-duration(weekDays);
+duration(weekDays)
 // duration("P5D")
 
-duration(age);
+duration(age)
 // duration("P32Y")
 ```
 
@@ -98,7 +98,7 @@ years and months duration(date("2011-12-22"), date("2013-08-24"))
 - result: number
 
 ```js
-number("1500.5");
+number("1500.5") 
 // 1500.5
 ```
 
@@ -109,10 +109,10 @@ number("1500.5");
 - result: string
 
 ```js
-string(1.1);
+string(1.1) 
 // "1.1"
 
-string(date("2012-12-25"));
+string(date("2012-12-25"))
 // "2012-12-25"
 ```
 
@@ -131,9 +131,6 @@ Returns `null` if one of the entries is not a context or if a context doesn't co
 - result: context
 
 ```js
-context([
-  { key: "a", value: 1 },
-  { key: "b", value: 2 },
-]);
+context([{"key":"a", "value":1}, {"key":"b", "value":2}])
 // {a:1, b:2}
 ```

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-introduction.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-introduction.md
@@ -9,7 +9,7 @@ FEEL includes many built-in functions. These functions can be invoked
 in [expressions](../language-guide/feel-expressions-introduction.md)
 and [unary-tests](../language-guide/feel-unary-tests.md).
 
-```js
+```feel
 contains("me@camunda.com", ".com")
 // invoke function with positional arguments
 

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-list.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-list.md
@@ -23,7 +23,7 @@ list contains([1,2,3], 2)
 - result: number
 
 ```js
-count([1, 2, 3]);
+count([1,2,3]) 
 // 3
 ```
 
@@ -35,10 +35,10 @@ count([1, 2, 3]);
 - result: number
 
 ```js
-min([1, 2, 3]);
+min([1,2,3]) 
 // 1
 
-min(1, 2, 3);
+min(1,2,3) 
 // 1
 ```
 
@@ -50,10 +50,10 @@ min(1, 2, 3);
 - result: number
 
 ```js
-min([1, 2, 3]);
+min([1,2,3]) 
 // 3
 
-min(1, 2, 3);
+min(1,2,3) 
 // 3
 ```
 
@@ -65,10 +65,10 @@ min(1, 2, 3);
 - result: number
 
 ```js
-min([1, 2, 3]);
+min([1,2,3]) 
 // 6
 
-min(1, 2, 3);
+min(1,2,3) 
 // 6
 ```
 
@@ -80,10 +80,10 @@ min(1, 2, 3);
 - result: number
 
 ```js
-product([2, 3, 4]);
+product([2, 3, 4])
 // 24
 
-product(2, 3, 4);
+product(2, 3, 4)
 // 24
 ```
 
@@ -97,10 +97,10 @@ Returns the arithmetic mean (i.e. average).
 - result: number
 
 ```js
-mean([1, 2, 3]);
+mean([1,2,3])
 // 2
 
-mean(1, 2, 3);
+mean(1,2,3)
 // 2
 ```
 
@@ -114,10 +114,10 @@ Returns the median element of the list of numbers.
 - result: number
 
 ```js
-median(8, 2, 5, 3, 4);
+median(8, 2, 5, 3, 4)
 // 4
 
-median([6, 1, 2, 3]);
+median([6, 1, 2, 3]) 
 // 2.5
 ```
 
@@ -131,10 +131,10 @@ Returns the standard deviation.
 - result: number
 
 ```js
-stddev(2, 4, 7, 5);
+stddev(2, 4, 7, 5)
 // 2.0816659994661326
 
-stddev([2, 4, 7, 5]);
+stddev([2, 4, 7, 5])
 // 2.0816659994661326
 ```
 
@@ -148,10 +148,10 @@ Returns the mode of the list of numbers.
 - result: list of numbers
 
 ```js
-mode(6, 3, 9, 6, 6);
+mode(6, 3, 9, 6, 6) 
 // [6]
 
-mode([6, 1, 9, 6, 1]);
+mode([6, 1, 9, 6, 1]) 
 // [1, 6]
 ```
 
@@ -163,10 +163,10 @@ mode([6, 1, 9, 6, 1]);
 - result: boolean
 
 ```js
-and([true, false]);
+and([true,false])
 // false
 
-and(false, null, true);
+and(false,null,true)
 // false
 ```
 
@@ -178,10 +178,10 @@ and(false, null, true);
 - result: boolean
 
 ```js
-or([false, true]);
+or([false,true])
 // true
 
-or(false, null, true);
+or(false,null,true)
 // true
 ```
 
@@ -194,10 +194,10 @@ or(false, null, true);
 - result: list
 
 ```js
-sublist([1, 2, 3], 2);
+sublist([1,2,3], 2)
 // [2,3]
 
-sublist([1, 2, 3], 1, 2);
+sublist([1,2,3], 1, 2)
 // [1,2]
 ```
 
@@ -209,7 +209,7 @@ sublist([1, 2, 3], 1, 2);
 - result: list
 
 ```js
-append([1], 2, 3);
+append([1], 2, 3)
 // [1,2,3]
 ```
 
@@ -220,10 +220,10 @@ append([1], 2, 3);
 - result: list
 
 ```js
-concatenate([1, 2], [3]);
+concatenate([1,2],[3]) 
 // [1,2,3]
 
-concatenate([1], [2], [3]);
+concatenate([1],[2],[3])
 // [1,2,3]
 ```
 
@@ -236,7 +236,7 @@ concatenate([1], [2], [3]);
 - result: list
 
 ```js
-insert before([1,3],1,2)
+insert before([1,3],1,2) 
 // [1,2,3]
 ```
 
@@ -248,7 +248,7 @@ insert before([1,3],1,2)
 - result: list
 
 ```js
-remove([1, 2, 3], 2);
+remove([1,2,3], 2) 
 // [1,3]
 ```
 
@@ -259,7 +259,7 @@ remove([1, 2, 3], 2);
 - result: list
 
 ```js
-reverse([1, 2, 3]);
+reverse([1,2,3]) 
 // [3,2,1]
 ```
 
@@ -271,7 +271,7 @@ reverse([1, 2, 3]);
 - result: list of numbers
 
 ```js
-index of([1,2,3,2],2)
+index of([1,2,3,2],2) 
 // [2,4]
 ```
 
@@ -282,7 +282,7 @@ index of([1,2,3,2],2)
 - result: list
 
 ```js
-union([1, 2], [2, 3]);
+union([1,2],[2,3])
 // [1,2,3]
 ```
 
@@ -304,7 +304,7 @@ distinct values([1,2,3,2,1])
 - result: list
 
 ```js
-flatten([[1, 2], [[3]], 4]);
+flatten([[1,2],[[3]], 4])
 // [1,2,3,4]
 ```
 

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-list.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-list.md
@@ -11,7 +11,7 @@ description: "This document outlines built-in list functions and examples."
   - `element`: any
 - result: boolean
 
-```js
+```feel
 list contains([1,2,3], 2)
 // true
 ```
@@ -22,8 +22,8 @@ list contains([1,2,3], 2)
   - `list`: list
 - result: number
 
-```js
-count([1,2,3]) 
+```feel
+count([1,2,3])
 // 3
 ```
 
@@ -34,11 +34,11 @@ count([1,2,3])
   - or numbers as varargs
 - result: number
 
-```js
-min([1,2,3]) 
+```feel
+min([1,2,3])
 // 1
 
-min(1,2,3) 
+min(1,2,3)
 // 1
 ```
 
@@ -49,11 +49,11 @@ min(1,2,3)
   - or numbers as varargs
 - result: number
 
-```js
-min([1,2,3]) 
+```feel
+min([1,2,3])
 // 3
 
-min(1,2,3) 
+min(1,2,3)
 // 3
 ```
 
@@ -64,11 +64,11 @@ min(1,2,3)
   - or numbers as varargs
 - result: number
 
-```js
-min([1,2,3]) 
+```feel
+min([1,2,3])
 // 6
 
-min(1,2,3) 
+min(1,2,3)
 // 6
 ```
 
@@ -79,7 +79,7 @@ min(1,2,3)
   - or numbers as varargs
 - result: number
 
-```js
+```feel
 product([2, 3, 4])
 // 24
 
@@ -96,7 +96,7 @@ Returns the arithmetic mean (i.e. average).
   - or numbers as varargs
 - result: number
 
-```js
+```feel
 mean([1,2,3])
 // 2
 
@@ -113,11 +113,11 @@ Returns the median element of the list of numbers.
   - or numbers as varargs
 - result: number
 
-```js
+```feel
 median(8, 2, 5, 3, 4)
 // 4
 
-median([6, 1, 2, 3]) 
+median([6, 1, 2, 3])
 // 2.5
 ```
 
@@ -130,7 +130,7 @@ Returns the standard deviation.
   - or numbers as varargs
 - result: number
 
-```js
+```feel
 stddev(2, 4, 7, 5)
 // 2.0816659994661326
 
@@ -147,11 +147,11 @@ Returns the mode of the list of numbers.
   - or numbers as varargs
 - result: list of numbers
 
-```js
-mode(6, 3, 9, 6, 6) 
+```feel
+mode(6, 3, 9, 6, 6)
 // [6]
 
-mode([6, 1, 9, 6, 1]) 
+mode([6, 1, 9, 6, 1])
 // [1, 6]
 ```
 
@@ -162,7 +162,7 @@ mode([6, 1, 9, 6, 1])
   - or booleans as varargs
 - result: boolean
 
-```js
+```feel
 and([true,false])
 // false
 
@@ -177,7 +177,7 @@ and(false,null,true)
   - or booleans as varargs
 - result: boolean
 
-```js
+```feel
 or([false,true])
 // true
 
@@ -193,7 +193,7 @@ or(false,null,true)
   - (optional) `length`: number
 - result: list
 
-```js
+```feel
 sublist([1,2,3], 2)
 // [2,3]
 
@@ -208,7 +208,7 @@ sublist([1,2,3], 1, 2)
   - `items`: elements as varargs
 - result: list
 
-```js
+```feel
 append([1], 2, 3)
 // [1,2,3]
 ```
@@ -219,8 +219,8 @@ append([1], 2, 3)
   - `lists`: lists as varargs
 - result: list
 
-```js
-concatenate([1,2],[3]) 
+```feel
+concatenate([1,2],[3])
 // [1,2,3]
 
 concatenate([1],[2],[3])
@@ -235,8 +235,8 @@ concatenate([1],[2],[3])
   - `newItem`: any
 - result: list
 
-```js
-insert before([1,3],1,2) 
+```feel
+insert before([1,3],1,2)
 // [1,2,3]
 ```
 
@@ -247,8 +247,8 @@ insert before([1,3],1,2)
   - `position`: number
 - result: list
 
-```js
-remove([1,2,3], 2) 
+```feel
+remove([1,2,3], 2)
 // [1,3]
 ```
 
@@ -258,8 +258,8 @@ remove([1,2,3], 2)
   - `list`: list
 - result: list
 
-```js
-reverse([1,2,3]) 
+```feel
+reverse([1,2,3])
 // [3,2,1]
 ```
 
@@ -270,8 +270,8 @@ reverse([1,2,3])
   - `match`: any
 - result: list of numbers
 
-```js
-index of([1,2,3,2],2) 
+```feel
+index of([1,2,3,2],2)
 // [2,4]
 ```
 
@@ -281,7 +281,7 @@ index of([1,2,3,2],2)
   - `lists`: lists as varargs
 - result: list
 
-```js
+```feel
 union([1,2],[2,3])
 // [1,2,3]
 ```
@@ -292,7 +292,7 @@ union([1,2],[2,3])
   - `list`: list
 - result: list
 
-```js
+```feel
 distinct values([1,2,3,2,1])
 // [1,2,3]
 ```
@@ -303,7 +303,7 @@ distinct values([1,2,3,2,1])
   - `list`: list
 - result: list
 
-```js
+```feel
 flatten([[1,2],[[3]], 4])
 // [1,2,3,4]
 ```
@@ -315,7 +315,7 @@ flatten([[1,2],[[3]], 4])
   - `precedes`: function with two arguments and boolean result
 - result: list
 
-```js
+```feel
 sort(list: [3,1,4,5,2], precedes: function(x,y) x < y)
 // [1,2,3,4,5]
 ```
@@ -338,7 +338,7 @@ neither a string nor `null`, the function returns `null` instead of a string.
     string)
 - Result: The joined list as a string
 
-```js
+```feel
 string join(["a","b","c"])
 // "abc"
 string join(["a"], "X")

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-numeric.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-numeric.md
@@ -15,13 +15,13 @@ Round the given number at the given scale using the given rounding mode. If no r
 - result: number
 
 ```js
-decimal(1 / 3, 2);
+decimal(1/3, 2)
 // .33
 
-decimal(1.5, 0);
+decimal(1.5, 0) 
 // 2
 
-decimal(2.5, 0, "half_up");
+decimal(2.5, 0, "half_up")
 // 3
 ```
 
@@ -32,38 +32,142 @@ decimal(2.5, 0, "half_up");
 - result: number
 
 ```js
-floor(1.5);
+floor(1.5)
 // 1
 
-floor(-1.5);
+floor(-1.5)
 // -2
+
+floor(-1.56, 1)
+// -1.6
 ```
 
 ## ceiling()
 
+Round the given number at the given scale using the ceiling rounding mode.
+
 - parameters:
   - `n`: number
+    -(optional) `scale`: number (default: `0`)
 - result: number
 
 ```js
-ceiling(1.5);
+ceiling(1.5)
 // 2
 
-floor(-1.5);
+ceiling(-1.5)
 // -1
+
+ceiling(-1.56, 1)
+// -1.5
+```
+
+## round up()
+
+Round the given number at the given scale using the round-up rounding mode.
+
+- parameters:
+  - `n`: number
+  - (optional) `scale`: number (default: `0`)
+- result: number
+
+```js
+round up(5.5)
+// 6
+
+round up(-5.5)
+// -6
+
+round up(1.121, 2)
+// 1.13
+
+round up(-1.126, 2)
+// -1.13
+```
+
+## round down()
+
+Round the given number at the given scale using the round-down rounding mode.
+
+- parameters:
+  - `n`: number
+  - (optional) `scale`: number (default: `0`)
+- result: number
+
+```js
+round down(5.5)
+// 5
+
+round down (-5.5)
+// -5
+
+round down (1.121, 2)
+// 1.12
+
+round down (-1.126, 2)
+// -1.12
+```
+
+## round half up()
+
+Round the given number at the given scale using the round-half-up rounding mode.
+
+- parameters:
+  - `n`: number
+  - (optional) `scale`: number (default: `0`)
+- result: number
+
+```js
+round half up(5.5)
+// 6
+
+round half up(-5.5)
+// -6
+
+round half up(1.121, 2)
+// 1.12
+
+round half up(-1.126, 2)
+// -1.13
+```
+
+## round half down()
+
+Round the given number at the given scale using the round-half-down rounding mode.
+
+-parameters:
+
+- `n`: number
+  -(optional) `scale`: number (default: `0`)
+- result: number
+
+```js
+round half down (5.5)
+// 5
+
+round half down (-5.5)
+// -5
+
+round half down (1.121, 2)
+// 1.12
+
+round half down (-1.126, 2)
+// -1.13
 ```
 
 ## abs()
+
+Returns the absolute value of the given numeric value.
 
 - parameters:
   - `number`: number
 - result: number
 
 ```js
-abs(10);
+abs(10)
 // 10
 
-abs(-10);
+abs(-10)
 // 10
 ```
 
@@ -77,7 +181,7 @@ Returns the remainder of the division of dividend by divisor.
 - result: number
 
 ```js
-modulo(12, 5);
+modulo(12, 5)
 // 2
 ```
 
@@ -90,7 +194,7 @@ Returns the square root.
 - result: number
 
 ```js
-sqrt(16);
+sqrt(16)
 // 4
 ```
 
@@ -103,7 +207,7 @@ Returns the natural logarithm (base e) of the number.
 - result: number
 
 ```js
-log(10);
+log(10)
 // 2.302585092994046
 ```
 
@@ -116,28 +220,38 @@ Returns the Euler’s number e raised to the power of number .
 - result: number
 
 ```js
-exp(5);
+exp(5)
 // 148.4131591025766
 ```
 
 ## odd()
 
+Returns `true` if the given numeric value is odd. Otherwise, it returns `false`.
+
 - parameters:
   - `number`: number
 - result: boolean
 
 ```js
-odd(5);
+odd(5)
 // true
+
+odd(2)
+// false
 ```
 
 ## even()
 
+Returns `true` if the given numeric value is even. Otherwise, it returns `false`.
+
 - parameters:
   - `number`: number
 - result: boolean
 
 ```js
-odd(5);
+even(5)
 // false
+
+even(2)
+// true
 ```

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-numeric.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-numeric.md
@@ -14,11 +14,11 @@ Round the given number at the given scale using the given rounding mode. If no r
   - (optional) `mode`: string - one of `UP, DOWN, CEILING, FLOOR, HALF_UP, HALF_DOWN, HALF_EVEN, UNNECESSARY` (default: `HALF_EVEN`)
 - result: number
 
-```js
+```feel
 decimal(1/3, 2)
 // .33
 
-decimal(1.5, 0) 
+decimal(1.5, 0)
 // 2
 
 decimal(2.5, 0, "half_up")
@@ -31,7 +31,7 @@ decimal(2.5, 0, "half_up")
   - `n`: number
 - result: number
 
-```js
+```feel
 floor(1.5)
 // 1
 
@@ -51,7 +51,7 @@ Round the given number at the given scale using the ceiling rounding mode.
     -(optional) `scale`: number (default: `0`)
 - result: number
 
-```js
+```feel
 ceiling(1.5)
 // 2
 
@@ -71,7 +71,7 @@ Round the given number at the given scale using the round-up rounding mode.
   - (optional) `scale`: number (default: `0`)
 - result: number
 
-```js
+```feel
 round up(5.5)
 // 6
 
@@ -94,7 +94,7 @@ Round the given number at the given scale using the round-down rounding mode.
   - (optional) `scale`: number (default: `0`)
 - result: number
 
-```js
+```feel
 round down(5.5)
 // 5
 
@@ -117,7 +117,7 @@ Round the given number at the given scale using the round-half-up rounding mode.
   - (optional) `scale`: number (default: `0`)
 - result: number
 
-```js
+```feel
 round half up(5.5)
 // 6
 
@@ -141,7 +141,7 @@ Round the given number at the given scale using the round-half-down rounding mod
   -(optional) `scale`: number (default: `0`)
 - result: number
 
-```js
+```feel
 round half down (5.5)
 // 5
 
@@ -163,7 +163,7 @@ Returns the absolute value of the given numeric value.
   - `number`: number
 - result: number
 
-```js
+```feel
 abs(10)
 // 10
 
@@ -180,7 +180,7 @@ Returns the remainder of the division of dividend by divisor.
   - `divisor`: number
 - result: number
 
-```js
+```feel
 modulo(12, 5)
 // 2
 ```
@@ -193,7 +193,7 @@ Returns the square root.
   - `number`: number
 - result: number
 
-```js
+```feel
 sqrt(16)
 // 4
 ```
@@ -206,7 +206,7 @@ Returns the natural logarithm (base e) of the number.
   - `number`: number
 - result: number
 
-```js
+```feel
 log(10)
 // 2.302585092994046
 ```
@@ -219,7 +219,7 @@ Returns the Euler’s number e raised to the power of number .
   - `number`: number
 - result: number
 
-```js
+```feel
 exp(5)
 // 148.4131591025766
 ```
@@ -232,7 +232,7 @@ Returns `true` if the given numeric value is odd. Otherwise, it returns `false`.
   - `number`: number
 - result: boolean
 
-```js
+```feel
 odd(5)
 // true
 
@@ -248,7 +248,7 @@ Returns `true` if the given numeric value is even. Otherwise, it returns `false`
   - `number`: number
 - result: boolean
 
-```js
+```feel
 even(5)
 // false
 

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-range.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-range.md
@@ -28,7 +28,7 @@ A scalar value must be of the following type:
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 before(1, 10)
 // true
 
@@ -57,7 +57,7 @@ before([1..5),[5..10])
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 after(10, 1)
 // true
 
@@ -84,7 +84,7 @@ before([5..10], [1..5))
   - `range2`: range
 - result: boolean
 
-```js
+```feel
 meets([1..5], [5..10])
 // true
 
@@ -106,7 +106,7 @@ meets([1..5], (5..8])
   - `range2`: range
 - result: boolean
 
-```js
+```feel
 met by([5..10], [1..5])
 // true
 
@@ -130,7 +130,7 @@ met by([5..10], [1..5))
   - `range2`: range
 - result: boolean
 
-```js
+```feel
 overlaps([5..10], [1..6])
 // true
 
@@ -154,7 +154,7 @@ overlaps([4..10], [1..5))
   - `range2`: range
 - result: boolean
 
-```js
+```feel
 overlaps before([1..5], [4..10])
 // true
 
@@ -178,7 +178,7 @@ overlaps before([1..5), [5..10])
   - `range2`: range
 - result: boolean
 
-```js
+```feel
 overlaps after([4..10], [1..5])
 // true
 
@@ -202,7 +202,7 @@ overlaps after([4..10], [1..5))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 finishes(5, [1..5])
 // true
 
@@ -226,7 +226,7 @@ finishes([5..10], [1..10))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 finishes by([5..10], 10)
 // true
 
@@ -250,7 +250,7 @@ finishes by([5..10], (1..10))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 includes([5..10], 6)
 // true
 
@@ -274,7 +274,7 @@ includes([1..10], [1..5))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 during(5, [1..10])
 // true
 
@@ -298,7 +298,7 @@ during((1..5], (1..10])
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 starts(1, [1..5])
 // true
 
@@ -322,7 +322,7 @@ starts((1..10), (1..10))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 started by([1..10], 1)
 // true
 
@@ -346,7 +346,7 @@ started by([1..10], [1..10))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 coincides(5, 5)
 // true
 

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-string.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-string.md
@@ -12,11 +12,11 @@ description: "This document outlines built-in string functions and examples."
   - (optional) `length`: number
 - result: string
 
-```js
-substring("foobar",3) 
+```feel
+substring("foobar",3)
 // "obar"
 
-substring("foobar",3,3) 
+substring("foobar",3,3)
 // "oba"
 ```
 
@@ -26,8 +26,8 @@ substring("foobar",3,3)
   - `string`: string
 - result: number
 
-```js
-string length("foo") 
+```feel
+string length("foo")
 // 3
 ```
 
@@ -37,7 +37,7 @@ string length("foo")
   - `string`: string
 - result: string
 
-```js
+```feel
 upper case("aBc4")
 // "ABC4"
 ```
@@ -48,7 +48,7 @@ upper case("aBc4")
   - `string`: string
 - result: string
 
-```js
+```feel
 lower case("aBc4")
 // "abc4"
 ```
@@ -60,7 +60,7 @@ lower case("aBc4")
   - `match`: string
 - result: string
 
-```js
+```feel
 substring before("foobar", "bar")
 // "foo"
 ```
@@ -72,7 +72,7 @@ substring before("foobar", "bar")
   - `match`: string
 - result: string
 
-```js
+```feel
 substring after("foobar", "ob")
 // "ar"
 ```
@@ -84,8 +84,8 @@ substring after("foobar", "ob")
   - `match`: string
 - result: boolean
 
-```js
-contains("foobar", "of") 
+```feel
+contains("foobar", "of")
 // false
 ```
 
@@ -96,7 +96,7 @@ contains("foobar", "of")
   - `match`: string
 - result: boolean
 
-```js
+```feel
 starts with("foobar", "fo")
 // true
 ```
@@ -108,7 +108,7 @@ starts with("foobar", "fo")
   - `match`: string
 - result: boolean
 
-```js
+```feel
 ends with("foobar", "r")
 // true
 ```
@@ -120,8 +120,8 @@ ends with("foobar", "r")
   - `pattern`: string (regular expression)
 - result: boolean
 
-```js
-matches("foobar", "^fo*bar") 
+```feel
+matches("foobar", "^fo*bar")
 // true
 ```
 
@@ -134,7 +134,7 @@ matches("foobar", "^fo*bar")
   - (optional) `flags`: string ("s", "m", "i", "x")
 - result: string
 
-```js
+```feel
 replace("abcd", "(ab)|(a)", "[1=$1][2=$2]")
 // "[1=ab][2=]cd"
 
@@ -149,8 +149,8 @@ replace("0123456789", "(\d{3})(\d{3})(\d{4})", "($1) $2-$3")
   - `delimiter`: string (regular expression)
 - result: list of strings
 
-```js
-split("John Doe", "\s" ) 
+```feel
+split("John Doe", "\s" )
 // ["John", "Doe"]
 
 split("a;b;c;;", ";")
@@ -167,7 +167,7 @@ match.
   - `pattern`: string (regular expression)
 - result: list of strings
 
-```js
+```feel
 extract("references are 1234, 1256, 1378", "12[0-9]*")
 // ["1234","1256"]
 ```

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-string.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-string.md
@@ -13,10 +13,10 @@ description: "This document outlines built-in string functions and examples."
 - result: string
 
 ```js
-substring("foobar", 3);
+substring("foobar",3) 
 // "obar"
 
-substring("foobar", 3, 3);
+substring("foobar",3,3) 
 // "oba"
 ```
 
@@ -27,7 +27,7 @@ substring("foobar", 3, 3);
 - result: number
 
 ```js
-string length("foo")
+string length("foo") 
 // 3
 ```
 
@@ -85,7 +85,7 @@ substring after("foobar", "ob")
 - result: boolean
 
 ```js
-contains("foobar", "of");
+contains("foobar", "of") 
 // false
 ```
 
@@ -121,7 +121,7 @@ ends with("foobar", "r")
 - result: boolean
 
 ```js
-matches("foobar", "^fo*bar");
+matches("foobar", "^fo*bar") 
 // true
 ```
 
@@ -135,10 +135,10 @@ matches("foobar", "^fo*bar");
 - result: string
 
 ```js
-replace("abcd", "(ab)|(a)", "[1=$1][2=$2]");
+replace("abcd", "(ab)|(a)", "[1=$1][2=$2]")
 // "[1=ab][2=]cd"
 
-replace("0123456789", "(d{3})(d{3})(d{4})", "($1) $2-$3");
+replace("0123456789", "(\d{3})(\d{3})(\d{4})", "($1) $2-$3")
 // "(012) 345-6789"
 ```
 
@@ -150,10 +150,10 @@ replace("0123456789", "(d{3})(d{3})(d{4})", "($1) $2-$3");
 - result: list of strings
 
 ```js
-split("John Doe", "s");
+split("John Doe", "\s" ) 
 // ["John", "Doe"]
 
-split("a;b;c;;", ";");
+split("a;b;c;;", ";")
 // ["a", "b", "c", "", ""]
 ```
 
@@ -168,6 +168,6 @@ match.
 - result: list of strings
 
 ```js
-extract("references are 1234, 1256, 1378", "12[0-9]*");
+extract("references are 1234, 1256, 1378", "12[0-9]*")
 // ["1234","1256"]
 ```

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-temporal.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-temporal.md
@@ -12,7 +12,7 @@ Returns the current date and time including the timezone.
 - result: date-time with timezone
 
 ```js
-now();
+now()
 // date and time("2020-07-31T14:27:30@Europe/Berlin")
 ```
 
@@ -24,7 +24,7 @@ Returns the current date.
 - result: date
 
 ```js
-today();
+today()
 // date("2020-07-31")
 ```
 
@@ -89,12 +89,12 @@ Returns the absolute value of a given duration.
 - result: duration
 
 ```js
-abs(duration("-PT5H"));
+abs(duration("-PT5H"))
 // "duration("PT5H")"
 
-abs(duration("PT5H"));
+abs(duration("PT5H"))
 // "duration("PT5H")"
 
-abs(duration("-P2M"));
+abs(duration("-P2M"))
 // duration("P2M")
 ```

--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-temporal.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-temporal.md
@@ -11,7 +11,7 @@ Returns the current date and time including the timezone.
 - parameters: no
 - result: date-time with timezone
 
-```js
+```feel
 now()
 // date and time("2020-07-31T14:27:30@Europe/Berlin")
 ```
@@ -23,7 +23,7 @@ Returns the current date.
 - parameters: no
 - result: date
 
-```js
+```feel
 today()
 // date("2020-07-31")
 ```
@@ -36,7 +36,7 @@ Returns the day of the week according to the Gregorian calendar. Note that it al
   - `date`: date/date-time
 - result: string
 
-```js
+```feel
 day of week(date("2019-09-17"))
 // "Tuesday"
 ```
@@ -49,7 +49,7 @@ Returns the Gregorian number of the day within the year.
   - `date`: date/date-time
 - result: number
 
-```js
+```feel
 day of year(date("2019-09-17"))
 // 260
 ```
@@ -62,7 +62,7 @@ Returns the Gregorian number of the week within the year, according to ISO 8601.
   - `date`: date/date-time
 - result: number
 
-```js
+```feel
 week of year(date("2019-09-17"))
 // 38
 ```
@@ -75,7 +75,7 @@ Returns the month of the week according to the Gregorian calendar. Note that it 
   - `date`: date/date-time
 - result: string
 
-```js
+```feel
 month of year(date("2019-09-17"))
 // "September"
 ```
@@ -88,7 +88,7 @@ Returns the absolute value of a given duration.
   - `n`: days-time-duration/years-months-duration
 - result: duration
 
-```js
+```feel
 abs(duration("-PT5H"))
 // "duration("PT5H")"
 

--- a/docs/components/modeler/feel/language-guide/feel-boolean-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-boolean-expressions.md
@@ -9,9 +9,9 @@ description: "This document outlines boolean expressions and examples."
 Creates a new boolean value.
 
 ```js
-true;
+true
 
-false;
+false
 ```
 
 ### Comparison

--- a/docs/components/modeler/feel/language-guide/feel-boolean-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-boolean-expressions.md
@@ -8,7 +8,7 @@ description: "This document outlines boolean expressions and examples."
 
 Creates a new boolean value.
 
-```js
+```feel
 true
 
 false
@@ -69,7 +69,7 @@ Two values of the same type can be compared using the following operators:
 
 </table>
 
-```js
+```feel
 5 = 5
 // true
 
@@ -109,7 +109,7 @@ value is `null` or the variable doesn't exist.
 Comparing a context entry with `null` results in `true` if the value of the entry is `null` or if
 the context doesn't contain an entry with this key.
 
-```js
+```feel
 null = null
 // true
 
@@ -130,7 +130,7 @@ function [is defined()](../builtin-functions/feel-built-in-functions-boolean.md#
 used to differentiate between a value that is `null` and a variable or context entry that doesn't
 exist.
 
-```js
+```feel
 is defined(null)
 // true
 
@@ -151,7 +151,7 @@ Combines multiple boolean values following the ternary logic.
 - The result is `false` if one value is `false`.
 - Otherwise, the result is `null` (i.e. if a value is not a boolean.)
 
-```js
+```feel
 true and true
 // true
 
@@ -179,7 +179,7 @@ Combines multiple boolean values following the ternary logic.
 - The result is `false` if all values are `false`.
 - Otherwise, the result is `null` (i.e. if a value is not a boolean.)
 
-```js
+```feel
 true or false
 // true
 
@@ -218,7 +218,7 @@ Checks if the value is of the given type. Available type names:
 
 Use the type `Any` to check if the value is not `null`.
 
-```js
+```feel
 1 instance of number
 // true
 
@@ -236,7 +236,7 @@ null instance of Any
 
 Evaluates a [unary-tests](/docs/components/modeler/feel/language-guide/feel-unary-tests) with the given value. The keyword `in` separates the value from the unary-tests.
 
-```js
+```feel
 5 in (3..7)
 // true
 

--- a/docs/components/modeler/feel/language-guide/feel-context-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-context-expressions.md
@@ -9,7 +9,7 @@ description: "This document outlines context expressions and examples."
 Creates a new context with the given entries. Each entry has a key and a value. The key is either a
 name or a string. The value can be any type.
 
-```js
+```feel
 {
   a: 1,
   b: 2
@@ -25,7 +25,7 @@ name or a string. The value can be any type.
 
 Inside the context, the previous entries can be accessed.
 
-```js
+```feel
 {
   a: 2,
   b: a * 2
@@ -35,7 +35,7 @@ Inside the context, the previous entries can be accessed.
 
 A context value can embed other context values.
 
-```js
+```feel
 {
   a: 1,
   b: {
@@ -47,7 +47,7 @@ A context value can embed other context values.
 
 ### Get entry or path
 
-```js
+```feel
 a.b
 ```
 
@@ -55,7 +55,7 @@ Accesses the entry with the key `b` of the context `a`. The path is separated by
 
 If the value of the entry `b` is also a context, the path can be chained (i.e. `a.b.c`).
 
-```js
+```feel
 {
   a: 2
 }.a
@@ -82,26 +82,7 @@ Filters a list of context elements. It is a special kind of the [filter expressi
 
 While filtering, the entries of the current context element can be accessed by their key.
 
-```js
-[
-  {
-    a: "p1", 
-    b: 5
-  },  
-  {
-    a: "p2", 
-    b: 10
-  } 
-][b > 7] 
-// {a: "p2", b: 10}
-```
-
-### Projection
-
-Extracts the entries of a list of context elements by a given key (i.e. a projection). It returns a
-list containing the values of the context elements for the given key.
-
-```js
+```feel
 [
   {
     a: "p1",
@@ -111,6 +92,25 @@ list containing the values of the context elements for the given key.
     a: "p2",
     b: 10
   }
-].a     
+][b > 7]
+// {a: "p2", b: 10}
+```
+
+### Projection
+
+Extracts the entries of a list of context elements by a given key (i.e. a projection). It returns a
+list containing the values of the context elements for the given key.
+
+```feel
+[
+  {
+    a: "p1",
+    b: 5
+  },
+  {
+    a: "p2",
+    b: 10
+  }
+].a
 // ["p1", "p2"]
 ```

--- a/docs/components/modeler/feel/language-guide/feel-context-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-context-expressions.md
@@ -48,7 +48,7 @@ A context value can embed other context values.
 ### Get entry or path
 
 ```js
-a.b;
+a.b
 ```
 
 Accesses the entry with the key `b` of the context `a`. The path is separated by `.`.
@@ -85,14 +85,14 @@ While filtering, the entries of the current context element can be accessed by t
 ```js
 [
   {
-    a: "p1",
-    b: 5,
-  },
+    a: "p1", 
+    b: 5
+  },  
   {
-    a: "p2",
-    b: 10,
-  },
-][b > 7];
+    a: "p2", 
+    b: 10
+  } 
+][b > 7] 
 // {a: "p2", b: 10}
 ```
 
@@ -105,12 +105,12 @@ list containing the values of the context elements for the given key.
 [
   {
     a: "p1",
-    b: 5,
+    b: 5
   },
   {
     a: "p2",
-    b: 10,
-  },
-].a;
+    b: 10
+  }
+].a     
 // ["p1", "p2"]
 ```

--- a/docs/components/modeler/feel/language-guide/feel-control-flow.md
+++ b/docs/components/modeler/feel/language-guide/feel-control-flow.md
@@ -6,14 +6,14 @@ description: "This document outlines control flow and examples."
 
 ### If conditions
 
-```js
+```feel
 if c then a else b
 ```
 
 Executes the expression `a` if the condition `c` evaluates to `true`. Otherwise, it executes the
 expression `b`.
 
-```js
+```feel
 if 5 < 10  then "low" else "high"
 // "low"
 
@@ -25,7 +25,7 @@ if 12 < 10 then "low" else "high"
 If the condition `c` doesn't evaluate to a boolean value (e.g. `null`), it
 executes the expression `b`.
 
-```js
+```feel
 if null then "low" else "high"
 // "high"
 ```
@@ -34,7 +34,7 @@ if null then "low" else "high"
 
 ### For loops
 
-```js
+```feel
 for a in b return c
 ```
 
@@ -44,7 +44,7 @@ element is assigned to the variable `a`. The result of the expression is a list.
 If multiple lists are passed to the `for` loop then it iterates over the cross-product of the
 elements in the given lists.
 
-```js
+```feel
 for x in [1,2,3] return x * 2
 // [2,4,6]
 
@@ -54,14 +54,14 @@ for x in [1,2], y in [3,4] return x * y
 
 While iterating over the list, the previous elements are assigned to the variable `partial`.
 
-```js
+```feel
 for i in 1..10 return if (i <= 2) then 1 else partial[-1] + partial[-2]
 // [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
 ```
 
 Instead of a list, the `for` loop can also iterate over a given range.
 
-```js
+```feel
 for x in 0..8 return 2 ** x
 // [1, 2, 4, 8, 16, 32, 64, 128, 256]
 

--- a/docs/components/modeler/feel/language-guide/feel-data-types.md
+++ b/docs/components/modeler/feel/language-guide/feel-data-types.md
@@ -13,7 +13,7 @@ Nothing, null, or nil (i.e. the value is not present).
 - Java Type: `null`
 
 ```js
-null;
+null
 ```
 
 ### Number
@@ -24,11 +24,13 @@ A whole or floating point number. The number can be negative.
 - Java Type: `java.math.BigDecimal`
 
 ```js
-1;
+1
 
-2.3;
+2.3
 
-0.4 - 5;
+.4
+    
+-5
 ```
 
 ### String
@@ -38,7 +40,7 @@ A sequence of characters enclosed in double quotes `"`. The sequence can also co
 - Java Type: `java.lang.String`
 
 ```js
-"valid";
+"valid"
 ```
 
 ### Boolean
@@ -48,9 +50,9 @@ A boolean value. It is either true or false.
 - Java Type: `java.lang.Boolean`
 
 ```js
-true;
+true
 
-false;
+false
 ```
 
 ### Date
@@ -61,7 +63,9 @@ A date value without a time component.
 - Java Type: `java.time.LocalDate`
 
 ```js
-date("2017-03-10");
+date("2017-03-10")
+
+@"2017-03-10"
 ```
 
 ### Time
@@ -72,12 +76,15 @@ A local or zoned time. The time can have an offset or time zone id.
 - Java Type: `java.time.LocalTime` / `java.time.OffsetTime`
 
 ```js
-time("11:45:30");
-time("13:30");
+time("11:45:30")
+time("13:30")
+time("11:45:30+02:00")
+time("10:31:10@Europe/Paris")
 
-time("11:45:30+02:00");
-
-time("10:31:10@Europe/Paris");
+@"11:45:30"
+@"13:30"
+@"11:45:30+02:00"
+@"10:31:10@Europe/Paris"
 ```
 
 ### Date-time
@@ -89,10 +96,12 @@ A date with a local or zoned time component. The time can have an offset or time
 
 ```js
 date and time("2015-09-18T10:31:10")
-
 date and time("2015-09-18T10:31:10+01:00")
-
 date and time("2015-09-18T10:31:10@Europe/Paris")
+
+@"2015-09-18T10:31:10"
+@"2015-09-18T10:31:10+01:00"
+@"2015-09-18T10:31:10@Europe/Paris"
 ```
 
 ### Days-time-duration
@@ -103,10 +112,15 @@ A duration based on seconds. It can contain days, hours, minutes, and seconds.
 - Java Type: `java.time.Duration`
 
 ```js
-duration("P4D");
-duration("PT2H");
-duration("PT30M");
-duration("P1DT6H");
+duration("P4D")
+duration("PT2H")
+duration("PT30M")
+duration("P1DT6H")
+
+@"P4D"
+@"PT2H"
+@"PT30M"
+@"P1DT6H"
 ```
 
 ### Years-months-duration
@@ -117,9 +131,13 @@ A duration based on the calendar. It can contain years and months.
 - Java Type: `java.time.Period`
 
 ```js
-duration("P2Y");
-duration("P6M");
-duration("P1Y6M");
+duration("P2Y")
+duration("P6M")
+duration("P1Y6M")
+
+@"P2Y"
+@"P6M"
+@"P1Y6M"
 ```
 
 ### List
@@ -129,7 +147,11 @@ A list of elements. The elements can be of any type. The list can be empty.
 - Java Type: `java.util.List`
 
 ```js
-[][(1, 2, 3)][("a", "b")][(["list"], "of", [["lists"]])];
+[]
+[1,2,3]
+["a","b"]
+
+[["list"], "of", [["lists"]]]
 ```
 
 ### Context

--- a/docs/components/modeler/feel/language-guide/feel-data-types.md
+++ b/docs/components/modeler/feel/language-guide/feel-data-types.md
@@ -12,7 +12,7 @@ Nothing, null, or nil (i.e. the value is not present).
 
 - Java Type: `null`
 
-```js
+```feel
 null
 ```
 
@@ -23,13 +23,13 @@ A whole or floating point number. The number can be negative.
 - not-a-number (NaN), positive/negative infinity are represented as `null`
 - Java Type: `java.math.BigDecimal`
 
-```js
+```feel
 1
 
 2.3
 
 .4
-    
+
 -5
 ```
 
@@ -39,7 +39,7 @@ A sequence of characters enclosed in double quotes `"`. The sequence can also co
 
 - Java Type: `java.lang.String`
 
-```js
+```feel
 "valid"
 ```
 
@@ -49,7 +49,7 @@ A boolean value. It is either true or false.
 
 - Java Type: `java.lang.Boolean`
 
-```js
+```feel
 true
 
 false
@@ -62,7 +62,7 @@ A date value without a time component.
 - Format: `yyyy-MM-dd`.
 - Java Type: `java.time.LocalDate`
 
-```js
+```feel
 date("2017-03-10")
 
 @"2017-03-10"
@@ -75,7 +75,7 @@ A local or zoned time. The time can have an offset or time zone id.
 - Format: `HH:mm:ss` / `HH:mm:ss+/-HH:mm` / `HH:mm:ss@ZoneId`
 - Java Type: `java.time.LocalTime` / `java.time.OffsetTime`
 
-```js
+```feel
 time("11:45:30")
 time("13:30")
 time("11:45:30+02:00")
@@ -94,7 +94,7 @@ A date with a local or zoned time component. The time can have an offset or time
 - Format: `yyyy-MM-dd'T'HH:mm:ss` / `yyyy-MM-dd'T'HH:mm:ss+/-HH:mm` / `yyyy-MM-dd'T'HH:mm:ss@ZoneId`
 - Java Type: `java.time.LocalDateTime` / `java.time.DateTime`
 
-```js
+```feel
 date and time("2015-09-18T10:31:10")
 date and time("2015-09-18T10:31:10+01:00")
 date and time("2015-09-18T10:31:10@Europe/Paris")
@@ -111,7 +111,7 @@ A duration based on seconds. It can contain days, hours, minutes, and seconds.
 - Format: `PxDTxHxMxS`
 - Java Type: `java.time.Duration`
 
-```js
+```feel
 duration("P4D")
 duration("PT2H")
 duration("PT30M")
@@ -130,7 +130,7 @@ A duration based on the calendar. It can contain years and months.
 - Format: `PxYxM`
 - Java Type: `java.time.Period`
 
-```js
+```feel
 duration("P2Y")
 duration("P6M")
 duration("P1Y6M")
@@ -146,7 +146,7 @@ A list of elements. The elements can be of any type. The list can be empty.
 
 - Java Type: `java.util.List`
 
-```js
+```feel
 []
 [1,2,3]
 ["a","b"]
@@ -161,7 +161,7 @@ can be any type. The context can be empty.
 
 - Java Type: `java.util.Map`
 
-```js
+```feel
 {}
 
 {a:1}

--- a/docs/components/modeler/feel/language-guide/feel-expressions-introduction.md
+++ b/docs/components/modeler/feel/language-guide/feel-expressions-introduction.md
@@ -27,16 +27,16 @@ An expression can contain comments to explain it and give it more context. This 
 Java-style comments: `//` to the end of line, or `/*.... */` for blocks.
 
 ```js
-// returns the last item
-[1, 2, 3, 4][-1][
-  /* returns the last item */
-  (1, 2, 3, 4)
-][-1][
-  /*
-   * returns the last item
-   */
-  (1, 2, 3, 4)
-][-1];
+// returns the last item       
+[1,2,3,4][-1]                             
+    
+/* returns the last item */
+[1,2,3,4][-1]
+
+/* 
+ * returns the last item 
+ */
+[1,2,3,4][-1]   
 ```
 
 ### Parentheses

--- a/docs/components/modeler/feel/language-guide/feel-expressions-introduction.md
+++ b/docs/components/modeler/feel/language-guide/feel-expressions-introduction.md
@@ -26,17 +26,17 @@ The following sections cover more general areas that are not restricted to one d
 An expression can contain comments to explain it and give it more context. This can be done using
 Java-style comments: `//` to the end of line, or `/*.... */` for blocks.
 
-```js
-// returns the last item       
-[1,2,3,4][-1]                             
-    
+```feel
+// returns the last item
+[1,2,3,4][-1]
+
 /* returns the last item */
 [1,2,3,4][-1]
 
-/* 
- * returns the last item 
+/*
+ * returns the last item
  */
-[1,2,3,4][-1]   
+[1,2,3,4][-1]
 ```
 
 ### Parentheses
@@ -44,7 +44,7 @@ Java-style comments: `//` to the end of line, or `/*.... */` for blocks.
 Parentheses `( .. )` can be used in expressions to separate different parts of an
 expression or to influence the precedence of the operators.
 
-```js
+```feel
 (5 - 3) * (4 / 2)
 
 x < 5 and (y > 10 or z > 20)

--- a/docs/components/modeler/feel/language-guide/feel-functions.md
+++ b/docs/components/modeler/feel/language-guide/feel-functions.md
@@ -12,7 +12,7 @@ function by its name. The arguments of the function can be passed positional or 
 - Positional: Only the values, in the same order as defined by the function (e.g. `f(1,2)`).
 - Named: The values with the argument name as prefix, in any order (e.g. `f(a: 1, b: 2)`).
 
-```js
+```feel
 contains("me@camunda.com", ".com")
 // true
 
@@ -22,7 +22,7 @@ contains(string: "me@camunda.com", match: ".de")
 
 ### User-defined
 
-```js
+```feel
 function(a,b) e
 ```
 
@@ -31,7 +31,7 @@ the function is invoked, it assigns the values to the arguments and evaluates th
 
 Within an expression, a function can be defined and invoked in a context.
 
-```js
+```feel
 {
   age: function(birthday) (today() - birthday).years
 }

--- a/docs/components/modeler/feel/language-guide/feel-list-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-list-expressions.md
@@ -9,23 +9,19 @@ description: "This document outlines list expressions and examples."
 Creates a new list of the given elements. The elements can be of any type.
 
 ```js
-[1, 2, 3, 4];
+[1,2,3,4]
 ```
 
 A list value can embed other list values.
 
 ```js
-[
-  [1, 2],
-  [3, 4],
-  [5, 6],
-];
+[[1,2], [3,4], [5,6]]
 ```
 
 ### Get element
 
 ```js
-a[i];
+a[i]
 ```
 
 Accesses an element of the list `a` at index `i`. The index starts at `1`.
@@ -33,23 +29,19 @@ Accesses an element of the list `a` at index `i`. The index starts at `1`.
 If the index is out of the range of the list, it returns `null`.
 
 ```js
-[1, 2, 3, 4][1][
-  // 1
+[1,2,3,4][1]           
+// 1
 
-  (1, 2, 3, 4)
-][2][
-  // 2
+[1,2,3,4][2]
+// 2    
 
-  (1, 2, 3, 4)
-][4][
-  // 4
+[1,2,3,4][4]                                   
+// 4
 
-  (1, 2, 3, 4)
-][5][
-  // null
-
-  (1, 2, 3, 4)
-][0];
+[1,2,3,4][5]
+// null
+    
+[1,2,3,4][0]                                   
 // null
 ```
 
@@ -57,15 +49,13 @@ If the index is negative, it starts counting the elements from the end of the li
 element of the list is at index `-1`.
 
 ```js
-[1, 2, 3, 4][-1][
-  // 4
+[1,2,3,4][-1]                                  
+// 4
 
-  (1, 2, 3, 4)
-][-2][
-  // 3
+[1,2,3,4][-2]                                  
+// 3
 
-  (1, 2, 3, 4)
-][-5];
+[1,2,3,4][-5]                                   
 // null
 ```
 
@@ -76,7 +66,7 @@ The index of a list starts at `1`. In other languages, the index starts at `0`.
 ### Filter
 
 ```js
-a[c];
+a[c]
 ```
 
 Filters the list `a` by the condition `c`. The result of the expression is a list that contains all elements where the condition `c` evaluates to `true`.
@@ -84,15 +74,13 @@ Filters the list `a` by the condition `c`. The result of the expression is a lis
 While filtering, the current element is assigned to the variable `item`.
 
 ```js
-[1, 2, 3, 4][item > 2][
-  // [3,4]
+[1,2,3,4][item > 2]   
+// [3,4]
 
-  (1, 2, 3, 4)
-][item > 10][
-  // []
+[1,2,3,4][item > 10]
+// []
 
-  (1, 2, 3, 4)
-][even(item)];
+[1,2,3,4][even(item)]
 // [2,4]
 ```
 

--- a/docs/components/modeler/feel/language-guide/feel-list-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-list-expressions.md
@@ -8,19 +8,19 @@ description: "This document outlines list expressions and examples."
 
 Creates a new list of the given elements. The elements can be of any type.
 
-```js
+```feel
 [1,2,3,4]
 ```
 
 A list value can embed other list values.
 
-```js
+```feel
 [[1,2], [3,4], [5,6]]
 ```
 
 ### Get element
 
-```js
+```feel
 a[i]
 ```
 
@@ -28,34 +28,34 @@ Accesses an element of the list `a` at index `i`. The index starts at `1`.
 
 If the index is out of the range of the list, it returns `null`.
 
-```js
-[1,2,3,4][1]           
+```feel
+[1,2,3,4][1]
 // 1
 
 [1,2,3,4][2]
-// 2    
+// 2
 
-[1,2,3,4][4]                                   
+[1,2,3,4][4]
 // 4
 
 [1,2,3,4][5]
 // null
-    
-[1,2,3,4][0]                                   
+
+[1,2,3,4][0]
 // null
 ```
 
 If the index is negative, it starts counting the elements from the end of the list. The last
 element of the list is at index `-1`.
 
-```js
-[1,2,3,4][-1]                                  
+```feel
+[1,2,3,4][-1]
 // 4
 
-[1,2,3,4][-2]                                  
+[1,2,3,4][-2]
 // 3
 
-[1,2,3,4][-5]                                   
+[1,2,3,4][-5]
 // null
 ```
 
@@ -65,7 +65,7 @@ The index of a list starts at `1`. In other languages, the index starts at `0`.
 
 ### Filter
 
-```js
+```feel
 a[c]
 ```
 
@@ -73,8 +73,8 @@ Filters the list `a` by the condition `c`. The result of the expression is a lis
 
 While filtering, the current element is assigned to the variable `item`.
 
-```js
-[1,2,3,4][item > 2]   
+```feel
+[1,2,3,4][item > 2]
 // [3,4]
 
 [1,2,3,4][item > 10]
@@ -86,7 +86,7 @@ While filtering, the current element is assigned to the variable `item`.
 
 ### Some
 
-```js
+```feel
 some a in b satisfies c
 ```
 
@@ -96,7 +96,7 @@ element is assigned to the variable `a`.
 It returns `true` if `c` evaluates to `true` for **one or more** elements of `b`. Otherwise, it
 returns `false`.
 
-```js
+```feel
 some x in [1,2,3] satisfies x > 2
 // true
 
@@ -118,7 +118,7 @@ element is assigned to the variable `a`.
 It returns `true` if `c` evaluates to `true` for **all** elements of `b`. Otherwise, it
 returns `false`.
 
-```js
+```feel
 every x in [1,2,3] satisfies x >= 1
 // true
 

--- a/docs/components/modeler/feel/language-guide/feel-numeric-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-numeric-expressions.md
@@ -9,45 +9,49 @@ description: "This document outlines numeric expressions and examples."
 Creates a new numeric value. Leading zeros are valid.
 
 ```js
-1;
+1
 
-0.5;
-0.5 - 2;
+0.5
+.5
 
-01 - 0002;
+-2 
+
+01
+
+-0002
 ```
 
 ### Addition
 
 ```js
-2 + 3;
+2 + 3
 // 5
 ```
 
 ### Subtraction
 
 ```js
-5 - 3;
+5 - 3
 // 2
 ```
 
 ### Multiplication
 
 ```js
-5 * 3;
+5 * 3        
 // 15
 ```
 
 ### Division
 
 ```js
-6 / 2;
+6 / 2  
 // 3
 ```
 
 ### Exponentiation
 
 ```js
-2 ** 3;
+2 ** 3   
 // 8
 ```

--- a/docs/components/modeler/feel/language-guide/feel-numeric-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-numeric-expressions.md
@@ -8,13 +8,13 @@ description: "This document outlines numeric expressions and examples."
 
 Creates a new numeric value. Leading zeros are valid.
 
-```js
+```feel
 1
 
 0.5
 .5
 
--2 
+-2
 
 01
 
@@ -23,35 +23,35 @@ Creates a new numeric value. Leading zeros are valid.
 
 ### Addition
 
-```js
+```feel
 2 + 3
 // 5
 ```
 
 ### Subtraction
 
-```js
+```feel
 5 - 3
 // 2
 ```
 
 ### Multiplication
 
-```js
-5 * 3        
+```feel
+5 * 3
 // 15
 ```
 
 ### Division
 
-```js
-6 / 2  
+```feel
+6 / 2
 // 3
 ```
 
 ### Exponentiation
 
-```js
-2 ** 3   
+```feel
+2 ** 3
 // 8
 ```

--- a/docs/components/modeler/feel/language-guide/feel-string-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-string-expressions.md
@@ -9,7 +9,7 @@ description: "This document outlines string expressions and examples."
 Creates a new string value.
 
 ```js
-"valid";
+"valid"
 ```
 
 ### Addition/concatenation
@@ -17,7 +17,7 @@ Creates a new string value.
 An addition concatenates the strings. The result is a string containing the characters of both strings.
 
 ```js
-"foo" + "bar";
+"foo" + "bar"
 // "foobar"
 ```
 
@@ -28,7 +28,7 @@ the [string()](/docs/components/modeler/feel/builtin-functions/feel-built-in-fun
 the value into a string first.
 
 ```js
-"order-" + string(123);
+"order-" + string(123)
 ```
 
 :::

--- a/docs/components/modeler/feel/language-guide/feel-string-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-string-expressions.md
@@ -8,7 +8,7 @@ description: "This document outlines string expressions and examples."
 
 Creates a new string value.
 
-```js
+```feel
 "valid"
 ```
 
@@ -16,7 +16,7 @@ Creates a new string value.
 
 An addition concatenates the strings. The result is a string containing the characters of both strings.
 
-```js
+```feel
 "foo" + "bar"
 // "foobar"
 ```
@@ -27,7 +27,7 @@ The concatenation is only available for string values. For other types, you can 
 the [string()](/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion#string) function to convert
 the value into a string first.
 
-```js
+```feel
 "order-" + string(123)
 ```
 

--- a/docs/components/modeler/feel/language-guide/feel-temporal-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-temporal-expressions.md
@@ -11,7 +11,7 @@ Creates a new temporal value. A value can be written in one of the following way
 - using a temporal function (e.g. `date("2020-04-06")`)
 - using the `@` - notation (e.g. `@"2020-04-06"`)
 
-```js
+```feel
 date("2020-04-06")
 @"2020-04-06"
 
@@ -93,7 +93,7 @@ duration("P3M")
 
 </table>
 
-```js
+```feel
 date("2020-04-06") + duration("P1D")
 // date("2020-04-07")
 
@@ -166,7 +166,7 @@ duration("P2D") + duration("P5D")
 
 </table>
 
-```js
+```feel
 date("2020-04-06") - date("2020-04-01")
 // duration("P5D")
 
@@ -221,7 +221,7 @@ duration("P1Y") - duration("P3M")
 
 </table>
 
-```js
+```feel
 duration("P1D") * 5
 // duration("P5D")
 
@@ -264,8 +264,8 @@ duration("P1M") * 6
 
 </table>
 
-```js
-duration("P5D") / duration("P1D")  
+```feel
+duration("P5D") / duration("P1D")
 // 5
 
 duration("P5D") / 5
@@ -382,7 +382,7 @@ for the given types:
 
 </table>
 
-```js
+```feel
 date("2020-04-06").year
 // 2020
 

--- a/docs/components/modeler/feel/language-guide/feel-temporal-expressions.md
+++ b/docs/components/modeler/feel/language-guide/feel-temporal-expressions.md
@@ -6,24 +6,38 @@ description: "This document outlines temporal expressions and examples."
 
 ### Literal
 
-Creates a new temporal value.
+Creates a new temporal value. A value can be written in one of the following ways:
+
+- using a temporal function (e.g. `date("2020-04-06")`)
+- using the `@` - notation (e.g. `@"2020-04-06"`)
 
 ```js
 date("2020-04-06")
+@"2020-04-06"
 
 time("08:00:00")
 time("08:00:00+02:00")
 time("08:00:00@Europe/Berlin")
+@"08:00:00"
+@"08:00:00+02:00"
+@"08:00:00@Europe/Berlin"
 
 date and time("2020-04-06T08:00:00")
 date and time("2020-04-06T08:00:00+02:00")
 date and time("2020-04-06T08:00:00@Europe/Berlin")
+@"2020-04-06T08:00:00"
+@"2020-04-06T08:00:00+02:00"
+@"2020-04-06T08:00:00@Europe/Berlin"
 
 duration("P5D")
 duration("PT6H")
+@"P5D"
+@"PT6H"
 
 duration("P1Y6M")
 duration("P3M")
+@"P1Y6M"
+@"P3M"
 ```
 
 ### Addition
@@ -153,22 +167,22 @@ duration("P2D") + duration("P5D")
 </table>
 
 ```js
-date("2020-04-06") - date("2020-04-01");
+date("2020-04-06") - date("2020-04-01")
 // duration("P5D")
 
-date("2020-04-06") - duration("P5D");
+date("2020-04-06") - duration("P5D")
 // date("2020-04-01")
 
-time("08:00:00") - time("06:00:00");
+time("08:00:00") - time("06:00:00")
 // duration("PT2H")
 
-time("08:00:00") - duration("PT2H");
+time("08:00:00") - duration("PT2H")
 // time("06:00:00")
 
-duration("P7D") - duration("P2D");
+duration("P7D") - duration("P2D")
 // duration("P5D")
 
-duration("P1Y") - duration("P3M");
+duration("P1Y") - duration("P3M")
 // duration("P9M")
 ```
 
@@ -208,10 +222,10 @@ duration("P1Y") - duration("P3M");
 </table>
 
 ```js
-duration("P1D") * 5;
+duration("P1D") * 5
 // duration("P5D")
 
-duration("P1M") * 6;
+duration("P1M") * 6
 // duration("P6M")
 ```
 
@@ -251,16 +265,16 @@ duration("P1M") * 6;
 </table>
 
 ```js
-duration("P5D") / duration("P1D");
+duration("P5D") / duration("P1D")  
 // 5
 
-duration("P5D") / 5;
+duration("P5D") / 5
 // duration("P1D")
 
-duration("P1Y") / duration("P1M");
+duration("P1Y") / duration("P1M")
 // 12
 
-duration("P1Y") / 12;
+duration("P1Y") / 12
 // duration("P1M")
 ```
 

--- a/docs/components/modeler/feel/language-guide/feel-unary-tests.md
+++ b/docs/components/modeler/feel/language-guide/feel-unary-tests.md
@@ -60,7 +60,7 @@ The input value is passed implicitly as the first argument of the operator.
 
 </table>
 
-```js
+```feel
 "valid"
 
 < 10
@@ -82,7 +82,7 @@ excludes the value (i.e. less/greater than).
 
 The input value is passed implicitly to the operator.
 
-```js
+```feel
 (2..5)
 // input > 2 and input < 5
 
@@ -103,7 +103,7 @@ Combines multiple unary-test expressions following the ternary logic.
 - Returns `true` if at least one unary-test evaluates to `true`.
 - Otherwise, it returns `false`.
 
-```js
+```feel
 2, 3, 4
 // input = 2 or input = 3 or input = 4
 
@@ -118,12 +118,12 @@ disjunction.
 
 It returns `true` if the given unary-test evaluates to `false`.
 
-```js
+```feel
 not("valid")
 // input != "valid"
 
-not(2, 3)             
-// input != 2 and input != 3 
+not(2, 3)
+// input != 2 and input != 3
 ```
 
 ### Expressions
@@ -132,7 +132,7 @@ Evaluates an expression that returns a boolean value. For example, [invoking a f
 
 The input value can be accessed in the expression by using the symbol `?` (a question mark).
 
-```js
+```feel
 contains(?, "good")
 // check if the input value (string) contains "good"
 

--- a/docs/components/modeler/feel/language-guide/feel-unary-tests.md
+++ b/docs/components/modeler/feel/language-guide/feel-unary-tests.md
@@ -61,7 +61,15 @@ The input value is passed implicitly as the first argument of the operator.
 </table>
 
 ```js
-"valid" < 10 <= date("2020-04-06") > time("08:00:00") >= duration("P5D");
+"valid"
+
+< 10
+
+<= date("2020-04-06")
+
+> time("08:00:00")
+
+>= duration("P5D")
 ```
 
 ### Interval
@@ -111,11 +119,11 @@ disjunction.
 It returns `true` if the given unary-test evaluates to `false`.
 
 ```js
-not("valid");
+not("valid")
 // input != "valid"
 
-not(2, 3);
-// input != 2 and input != 3
+not(2, 3)             
+// input != 2 and input != 3 
 ```
 
 ### Expressions

--- a/docs/components/modeler/feel/language-guide/feel-variables.md
+++ b/docs/components/modeler/feel/language-guide/feel-variables.md
@@ -9,13 +9,13 @@ description: "This document outlines variables and examples."
 Access the value of a variable by its variable name.
 
 ```js
-a + b;
+a + b
 ```
 
 If the value of the variable is a context, a [context entry can be accessed](/docs/components/modeler/feel/language-guide/feel-context-expressions#get-entry-or-path) by its key.
 
 ```js
-a.b;
+a.b
 ```
 
 :::tip

--- a/docs/components/modeler/feel/language-guide/feel-variables.md
+++ b/docs/components/modeler/feel/language-guide/feel-variables.md
@@ -8,13 +8,13 @@ description: "This document outlines variables and examples."
 
 Access the value of a variable by its variable name.
 
-```js
+```feel
 a + b
 ```
 
 If the value of the variable is a context, a [context entry can be accessed](/docs/components/modeler/feel/language-guide/feel-context-expressions#get-entry-or-path) by its key.
 
-```js
+```feel
 a.b
 ```
 
@@ -22,7 +22,7 @@ a.b
 
 Use a [null-check](/docs/components/modeler/feel/language-guide/feel-boolean-expressions#null-check) if the variable can be `null` or is optional.
 
-```js
+```feel
 a != null and a.b > 10
 ```
 
@@ -35,7 +35,7 @@ combination of words, it is recommended to use `camelCase` or the `snake_case` f
 
 If a variable name or context key contains any special character (e.g. whitespace, dash, etc.,) the name can be placed in single backticks (e.g. `` `foo bar` ``).
 
-```js
+```feel
 `first name`
 
 `tracking-id`

--- a/docs/components/modeler/feel/what-is-feel.md
+++ b/docs/components/modeler/feel/what-is-feel.md
@@ -16,7 +16,7 @@ FEEL has two types of expressions for different use cases:
 A [unary-tests expression](./language-guide/feel-unary-tests.md) is a special kind of boolean expression. It should be used for the input
 entries of a decision table (i.e. the conditions of a rule).
 
-```js
+```feel
 < 7
 // checks if the input value is less than 7
 
@@ -35,7 +35,7 @@ not(2,4)
 [General expressions](./language-guide/feel-expressions-introduction.md) that can return values of different types. They can be used everywhere; for
 example, in a decision table as an input expression or as an output entry.
 
-```js
+```feel
 applicant.monthly.income * 12
 
 if applicant.maritalStatus in ("M","S") then "valid" else "not valid"

--- a/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-boolean.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-boolean.md
@@ -10,8 +10,8 @@ description: "This document outlines current boolean functions and a few example
   - `negand`: boolean
 - result: boolean
 
-```js
-not(true);
+```feel
+not(true)
 // false
 ```
 
@@ -25,7 +25,7 @@ The function can be used to check if a variable or a context entry (e.g. a prope
   - `value`: any
 - result: boolean
 
-```js
+```feel
 is defined(1)
 // true
 

--- a/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-context.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-context.md
@@ -13,7 +13,7 @@ Returns the value of the context entry with the given key.
   - `key`: string
 - result: any
 
-```js
+```feel
 get value({foo: 123}, "foo")
 // 123
 ```
@@ -26,7 +26,7 @@ Returns the entries of the context as a list of key-value-pairs.
   - `context`: context
 - result: list of context which contains two entries for "key" and "value"
 
-```js
+```feel
 get entries({foo: 123})
 // [{key: "foo", value: 123}]
 ```
@@ -43,8 +43,8 @@ Returns `null` if the value is not defined.
   - `value`: any
 - result: context
 
-```js
-put({ x: 1 }, "y", 2);
+```feel
+put({x:1}, "y", 2)
 // {x:1, y:2}
 ```
 
@@ -58,7 +58,7 @@ Returns `null` if one of the values is not a context.
   - `contexts`: contexts as varargs
 - result: context
 
-```js
+```feel
 put all({x:1}, {y:2})
 // {x:1, y:2}
 ```

--- a/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
@@ -13,7 +13,7 @@ Convert a value into a different type.
   - or `year`, `month`, `day`: number
 - result: date
 
-```js
+```feel
 date(birthday)
 // date("2018-04-29")
 
@@ -32,7 +32,7 @@ date(2012, 12, 25)
     - (optional) `offset`: day-time-duration
 - result: time
 
-```js
+```feel
 time(lunchTime)
 // time("12:00:00")
 
@@ -54,7 +54,7 @@ time(14, 30, 0, duration("PT1H"))
   - or `from`: string
 - result: date-time
 
-```js
+```feel
 date and time(date("2012-12-24"),time("T23:59:00"))
 // date and time("2012-12-24T23:59:00")
 
@@ -71,11 +71,11 @@ date and time(birthday)
   - `from`: string
 - result: day-time-duration or year-month-duration
 
-```js
-duration(weekDays);
+```feel
+duration(weekDays)
 // duration("P5D")
 
-duration(age);
+duration(age)
 // duration("P32Y")
 ```
 
@@ -86,7 +86,7 @@ duration(age);
   - `to`: date
 - result: year-month-duration
 
-```js
+```feel
 years and months duration(date("2011-12-22"), date("2013-08-24"))
 // duration("P1Y8M")
 ```
@@ -97,8 +97,8 @@ years and months duration(date("2011-12-22"), date("2013-08-24"))
   - `from`: string
 - result: number
 
-```js
-number("1500.5");
+```feel
+number("1500.5")
 // 1500.5
 ```
 
@@ -108,11 +108,11 @@ number("1500.5");
   - `from`: any
 - result: string
 
-```js
-string(1.1);
+```feel
+string(1.1)
 // "1.1"
 
-string(date("2012-12-25"));
+string(date("2012-12-25"))
 // "2012-12-25"
 ```
 
@@ -130,10 +130,7 @@ Returns `null` if one of the entries is not a context or if a context doesn't co
   - `entries`: list of contexts
 - result: context
 
-```js
-context([
-  { key: "a", value: 1 },
-  { key: "b", value: 2 },
-]);
+```feel
+context([{"key":"a", "value":1}, {"key":"b", "value":2}])
 // {a:1, b:2}
 ```

--- a/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-introduction.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-introduction.md
@@ -9,7 +9,7 @@ FEEL includes many built-in functions. These functions can be invoked
 in [expressions](../language-guide/feel-expressions-introduction.md)
 and [unary-tests](../language-guide/feel-unary-tests.md).
 
-```js
+```feel
 contains("me@camunda.com", ".com")
 // invoke function with positional arguments
 

--- a/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-list.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-list.md
@@ -11,7 +11,7 @@ description: "This document outlines built-in list functions and examples."
   - `element`: any
 - result: boolean
 
-```js
+```feel
 list contains([1,2,3], 2)
 // true
 ```
@@ -22,8 +22,8 @@ list contains([1,2,3], 2)
   - `list`: list
 - result: number
 
-```js
-count([1, 2, 3]);
+```feel
+count([1,2,3])
 // 3
 ```
 
@@ -34,11 +34,11 @@ count([1, 2, 3]);
   - or numbers as varargs
 - result: number
 
-```js
-min([1, 2, 3]);
+```feel
+min([1,2,3])
 // 1
 
-min(1, 2, 3);
+min(1,2,3)
 // 1
 ```
 
@@ -49,11 +49,11 @@ min(1, 2, 3);
   - or numbers as varargs
 - result: number
 
-```js
-min([1, 2, 3]);
+```feel
+min([1,2,3])
 // 3
 
-min(1, 2, 3);
+min(1,2,3)
 // 3
 ```
 
@@ -64,11 +64,11 @@ min(1, 2, 3);
   - or numbers as varargs
 - result: number
 
-```js
-min([1, 2, 3]);
+```feel
+min([1,2,3])
 // 6
 
-min(1, 2, 3);
+min(1,2,3)
 // 6
 ```
 
@@ -79,11 +79,11 @@ min(1, 2, 3);
   - or numbers as varargs
 - result: number
 
-```js
-product([2, 3, 4]);
+```feel
+product([2, 3, 4])
 // 24
 
-product(2, 3, 4);
+product(2, 3, 4)
 // 24
 ```
 
@@ -96,11 +96,11 @@ Returns the arithmetic mean (i.e. average).
   - or numbers as varargs
 - result: number
 
-```js
-mean([1, 2, 3]);
+```feel
+mean([1,2,3])
 // 2
 
-mean(1, 2, 3);
+mean(1,2,3)
 // 2
 ```
 
@@ -113,11 +113,11 @@ Returns the median element of the list of numbers.
   - or numbers as varargs
 - result: number
 
-```js
-median(8, 2, 5, 3, 4);
+```feel
+median(8, 2, 5, 3, 4)
 // 4
 
-median([6, 1, 2, 3]);
+median([6, 1, 2, 3])
 // 2.5
 ```
 
@@ -130,11 +130,11 @@ Returns the standard deviation.
   - or numbers as varargs
 - result: number
 
-```js
-stddev(2, 4, 7, 5);
+```feel
+stddev(2, 4, 7, 5)
 // 2.0816659994661326
 
-stddev([2, 4, 7, 5]);
+stddev([2, 4, 7, 5])
 // 2.0816659994661326
 ```
 
@@ -147,11 +147,11 @@ Returns the mode of the list of numbers.
   - or numbers as varargs
 - result: list of numbers
 
-```js
-mode(6, 3, 9, 6, 6);
+```feel
+mode(6, 3, 9, 6, 6)
 // [6]
 
-mode([6, 1, 9, 6, 1]);
+mode([6, 1, 9, 6, 1])
 // [1, 6]
 ```
 
@@ -162,11 +162,11 @@ mode([6, 1, 9, 6, 1]);
   - or booleans as varargs
 - result: boolean
 
-```js
-and([true, false]);
+```feel
+and([true,false])
 // false
 
-and(false, null, true);
+and(false,null,true)
 // false
 ```
 
@@ -177,11 +177,11 @@ and(false, null, true);
   - or booleans as varargs
 - result: boolean
 
-```js
-or([false, true]);
+```feel
+or([false,true])
 // true
 
-or(false, null, true);
+or(false,null,true)
 // true
 ```
 
@@ -193,11 +193,11 @@ or(false, null, true);
   - (optional) `length`: number
 - result: list
 
-```js
-sublist([1, 2, 3], 2);
+```feel
+sublist([1,2,3], 2)
 // [2,3]
 
-sublist([1, 2, 3], 1, 2);
+sublist([1,2,3], 1, 2)
 // [1,2]
 ```
 
@@ -208,8 +208,8 @@ sublist([1, 2, 3], 1, 2);
   - `items`: elements as varargs
 - result: list
 
-```js
-append([1], 2, 3);
+```feel
+append([1], 2, 3)
 // [1,2,3]
 ```
 
@@ -219,11 +219,11 @@ append([1], 2, 3);
   - `lists`: lists as varargs
 - result: list
 
-```js
-concatenate([1, 2], [3]);
+```feel
+concatenate([1,2],[3])
 // [1,2,3]
 
-concatenate([1], [2], [3]);
+concatenate([1],[2],[3])
 // [1,2,3]
 ```
 
@@ -235,7 +235,7 @@ concatenate([1], [2], [3]);
   - `newItem`: any
 - result: list
 
-```js
+```feel
 insert before([1,3],1,2)
 // [1,2,3]
 ```
@@ -247,8 +247,8 @@ insert before([1,3],1,2)
   - `position`: number
 - result: list
 
-```js
-remove([1, 2, 3], 2);
+```feel
+remove([1,2,3], 2)
 // [1,3]
 ```
 
@@ -258,8 +258,8 @@ remove([1, 2, 3], 2);
   - `list`: list
 - result: list
 
-```js
-reverse([1, 2, 3]);
+```feel
+reverse([1,2,3])
 // [3,2,1]
 ```
 
@@ -270,7 +270,7 @@ reverse([1, 2, 3]);
   - `match`: any
 - result: list of numbers
 
-```js
+```feel
 index of([1,2,3,2],2)
 // [2,4]
 ```
@@ -281,8 +281,8 @@ index of([1,2,3,2],2)
   - `lists`: lists as varargs
 - result: list
 
-```js
-union([1, 2], [2, 3]);
+```feel
+union([1,2],[2,3])
 // [1,2,3]
 ```
 
@@ -292,7 +292,7 @@ union([1, 2], [2, 3]);
   - `list`: list
 - result: list
 
-```js
+```feel
 distinct values([1,2,3,2,1])
 // [1,2,3]
 ```
@@ -303,8 +303,8 @@ distinct values([1,2,3,2,1])
   - `list`: list
 - result: list
 
-```js
-flatten([[1, 2], [[3]], 4]);
+```feel
+flatten([[1,2],[[3]], 4])
 // [1,2,3,4]
 ```
 
@@ -315,7 +315,7 @@ flatten([[1, 2], [[3]], 4]);
   - `precedes`: function with two arguments and boolean result
 - result: list
 
-```js
+```feel
 sort(list: [3,1,4,5,2], precedes: function(x,y) x < y)
 // [1,2,3,4,5]
 ```
@@ -338,7 +338,7 @@ neither a string nor `null`, the function returns `null` instead of a string.
     string)
 - Result: The joined list as a string
 
-```js
+```feel
 string join(["a","b","c"])
 // "abc"
 string join(["a"], "X")

--- a/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-numeric.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-numeric.md
@@ -14,14 +14,14 @@ Round the given number at the given scale using the given rounding mode. If no r
   - (optional) `mode`: string - one of `UP, DOWN, CEILING, FLOOR, HALF_UP, HALF_DOWN, HALF_EVEN, UNNECESSARY` (default: `HALF_EVEN`)
 - result: number
 
-```js
-decimal(1 / 3, 2);
+```feel
+decimal(1/3, 2)
 // .33
 
-decimal(1.5, 0);
+decimal(1.5, 0)
 // 2
 
-decimal(2.5, 0, "half_up");
+decimal(2.5, 0, "half_up")
 // 3
 ```
 
@@ -31,39 +31,43 @@ decimal(2.5, 0, "half_up");
   - `n`: number
 - result: number
 
-```js
-floor(1.5);
+```feel
+floor(1.5)
 // 1
 
-floor(-1.5);
+floor(-1.5)
 // -2
 ```
 
 ## ceiling()
 
+Round the given number at the given scale using the ceiling rounding mode.
+
 - parameters:
   - `n`: number
 - result: number
 
-```js
-ceiling(1.5);
+```feel
+ceiling(1.5)
 // 2
 
-floor(-1.5);
+ceiling(-1.5)
 // -1
 ```
 
 ## abs()
 
+Returns the absolute value of the given numeric value.
+
 - parameters:
   - `number`: number
 - result: number
 
-```js
-abs(10);
+```feel
+abs(10)
 // 10
 
-abs(-10);
+abs(-10)
 // 10
 ```
 
@@ -76,8 +80,8 @@ Returns the remainder of the division of dividend by divisor.
   - `divisor`: number
 - result: number
 
-```js
-modulo(12, 5);
+```feel
+modulo(12, 5)
 // 2
 ```
 
@@ -89,8 +93,8 @@ Returns the square root.
   - `number`: number
 - result: number
 
-```js
-sqrt(16);
+```feel
+sqrt(16)
 // 4
 ```
 
@@ -102,8 +106,8 @@ Returns the natural logarithm (base e) of the number.
   - `number`: number
 - result: number
 
-```js
-log(10);
+```feel
+log(10)
 // 2.302585092994046
 ```
 
@@ -115,29 +119,39 @@ Returns the Euler’s number e raised to the power of number .
   - `number`: number
 - result: number
 
-```js
-exp(5);
+```feel
+exp(5)
 // 148.4131591025766
 ```
 
 ## odd()
 
+Returns `true` if the given numeric value is odd. Otherwise, it returns `false`.
+
 - parameters:
   - `number`: number
 - result: boolean
 
-```js
-odd(5);
+```feel
+odd(5)
 // true
+
+odd(2)
+// false
 ```
 
 ## even()
 
+Returns `true` if the given numeric value is even. Otherwise, it returns `false`.
+
 - parameters:
   - `number`: number
 - result: boolean
 
-```js
-odd(5);
+```feel
+even(5)
 // false
+
+even(2)
+// true
 ```

--- a/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-range.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-range.md
@@ -28,7 +28,7 @@ A scalar value must be of the following type:
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 before(1, 10)
 // true
 
@@ -57,7 +57,7 @@ before([1..5),[5..10])
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 after(10, 1)
 // true
 
@@ -84,7 +84,7 @@ before([5..10], [1..5))
   - `range2`: range
 - result: boolean
 
-```js
+```feel
 meets([1..5], [5..10])
 // true
 
@@ -106,7 +106,7 @@ meets([1..5], (5..8])
   - `range2`: range
 - result: boolean
 
-```js
+```feel
 met by([5..10], [1..5])
 // true
 
@@ -130,7 +130,7 @@ met by([5..10], [1..5))
   - `range2`: range
 - result: boolean
 
-```js
+```feel
 overlaps([5..10], [1..6])
 // true
 
@@ -154,7 +154,7 @@ overlaps([4..10], [1..5))
   - `range2`: range
 - result: boolean
 
-```js
+```feel
 overlaps before([1..5], [4..10])
 // true
 
@@ -178,7 +178,7 @@ overlaps before([1..5), [5..10])
   - `range2`: range
 - result: boolean
 
-```js
+```feel
 overlaps after([4..10], [1..5])
 // true
 
@@ -202,7 +202,7 @@ overlaps after([4..10], [1..5))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 finishes(5, [1..5])
 // true
 
@@ -226,7 +226,7 @@ finishes([5..10], [1..10))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 finishes by([5..10], 10)
 // true
 
@@ -250,7 +250,7 @@ finishes by([5..10], (1..10))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 includes([5..10], 6)
 // true
 
@@ -274,7 +274,7 @@ includes([1..10], [1..5))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 during(5, [1..10])
 // true
 
@@ -298,7 +298,7 @@ during((1..5], (1..10])
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 starts(1, [1..5])
 // true
 
@@ -322,7 +322,7 @@ starts((1..10), (1..10))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 started by([1..10], 1)
 // true
 
@@ -346,7 +346,7 @@ started by([1..10], [1..10))
   - or `range1`, `range2`: range
 - result: boolean
 
-```js
+```feel
 coincides(5, 5)
 // true
 

--- a/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-string.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-string.md
@@ -12,11 +12,11 @@ description: "This document outlines built-in string functions and examples."
   - (optional) `length`: number
 - result: string
 
-```js
-substring("foobar", 3);
+```feel
+substring("foobar",3)
 // "obar"
 
-substring("foobar", 3, 3);
+substring("foobar",3,3)
 // "oba"
 ```
 
@@ -26,7 +26,7 @@ substring("foobar", 3, 3);
   - `string`: string
 - result: number
 
-```js
+```feel
 string length("foo")
 // 3
 ```
@@ -37,7 +37,7 @@ string length("foo")
   - `string`: string
 - result: string
 
-```js
+```feel
 upper case("aBc4")
 // "ABC4"
 ```
@@ -48,7 +48,7 @@ upper case("aBc4")
   - `string`: string
 - result: string
 
-```js
+```feel
 lower case("aBc4")
 // "abc4"
 ```
@@ -60,7 +60,7 @@ lower case("aBc4")
   - `match`: string
 - result: string
 
-```js
+```feel
 substring before("foobar", "bar")
 // "foo"
 ```
@@ -72,7 +72,7 @@ substring before("foobar", "bar")
   - `match`: string
 - result: string
 
-```js
+```feel
 substring after("foobar", "ob")
 // "ar"
 ```
@@ -84,8 +84,8 @@ substring after("foobar", "ob")
   - `match`: string
 - result: boolean
 
-```js
-contains("foobar", "of");
+```feel
+contains("foobar", "of")
 // false
 ```
 
@@ -96,7 +96,7 @@ contains("foobar", "of");
   - `match`: string
 - result: boolean
 
-```js
+```feel
 starts with("foobar", "fo")
 // true
 ```
@@ -108,7 +108,7 @@ starts with("foobar", "fo")
   - `match`: string
 - result: boolean
 
-```js
+```feel
 ends with("foobar", "r")
 // true
 ```
@@ -120,8 +120,8 @@ ends with("foobar", "r")
   - `pattern`: string (regular expression)
 - result: boolean
 
-```js
-matches("foobar", "^fo*bar");
+```feel
+matches("foobar", "^fo*bar")
 // true
 ```
 
@@ -134,11 +134,11 @@ matches("foobar", "^fo*bar");
   - (optional) `flags`: string ("s", "m", "i", "x")
 - result: string
 
-```js
-replace("abcd", "(ab)|(a)", "[1=$1][2=$2]");
+```feel
+replace("abcd", "(ab)|(a)", "[1=$1][2=$2]")
 // "[1=ab][2=]cd"
 
-replace("0123456789", "(d{3})(d{3})(d{4})", "($1) $2-$3");
+replace("0123456789", "(\d{3})(\d{3})(\d{4})", "($1) $2-$3")
 // "(012) 345-6789"
 ```
 
@@ -149,11 +149,11 @@ replace("0123456789", "(d{3})(d{3})(d{4})", "($1) $2-$3");
   - `delimiter`: string (regular expression)
 - result: list of strings
 
-```js
-split("John Doe", "s");
+```feel
+split("John Doe", "\s" )
 // ["John", "Doe"]
 
-split("a;b;c;;", ";");
+split("a;b;c;;", ";")
 // ["a", "b", "c", "", ""]
 ```
 
@@ -167,7 +167,7 @@ match.
   - `pattern`: string (regular expression)
 - result: list of strings
 
-```js
-extract("references are 1234, 1256, 1378", "12[0-9]*");
+```feel
+extract("references are 1234, 1256, 1378", "12[0-9]*")
 // ["1234","1256"]
 ```

--- a/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-temporal.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/builtin-functions/feel-built-in-functions-temporal.md
@@ -11,8 +11,8 @@ Returns the current date and time including the timezone.
 - parameters: no
 - result: date-time with timezone
 
-```js
-now();
+```feel
+now()
 // date and time("2020-07-31T14:27:30@Europe/Berlin")
 ```
 
@@ -23,8 +23,8 @@ Returns the current date.
 - parameters: no
 - result: date
 
-```js
-today();
+```feel
+today()
 // date("2020-07-31")
 ```
 
@@ -36,7 +36,7 @@ Returns the day of the week according to the Gregorian calendar. Note that it al
   - `date`: date/date-time
 - result: string
 
-```js
+```feel
 day of week(date("2019-09-17"))
 // "Tuesday"
 ```
@@ -49,7 +49,7 @@ Returns the Gregorian number of the day within the year.
   - `date`: date/date-time
 - result: number
 
-```js
+```feel
 day of year(date("2019-09-17"))
 // 260
 ```
@@ -62,7 +62,7 @@ Returns the Gregorian number of the week within the year, according to ISO 8601.
   - `date`: date/date-time
 - result: number
 
-```js
+```feel
 week of year(date("2019-09-17"))
 // 38
 ```
@@ -75,7 +75,7 @@ Returns the month of the week according to the Gregorian calendar. Note that it 
   - `date`: date/date-time
 - result: string
 
-```js
+```feel
 month of year(date("2019-09-17"))
 // "September"
 ```
@@ -88,13 +88,13 @@ Returns the absolute value of a given duration.
   - `n`: days-time-duration/years-months-duration
 - result: duration
 
-```js
-abs(duration("-PT5H"));
+```feel
+abs(duration("-PT5H"))
 // "duration("PT5H")"
 
-abs(duration("PT5H"));
+abs(duration("PT5H"))
 // "duration("PT5H")"
 
-abs(duration("-P2M"));
+abs(duration("-P2M"))
 // duration("P2M")
 ```

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-boolean-expressions.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-boolean-expressions.md
@@ -8,10 +8,10 @@ description: "This document outlines boolean expressions and examples."
 
 Creates a new boolean value.
 
-```js
-true;
+```feel
+true
 
-false;
+false
 ```
 
 ### Comparison
@@ -69,7 +69,7 @@ Two values of the same type can be compared using the following operators:
 
 </table>
 
-```js
+```feel
 5 = 5
 // true
 
@@ -109,7 +109,7 @@ value is `null` or the variable doesn't exist.
 Comparing a context entry with `null` results in `true` if the value of the entry is `null` or if
 the context doesn't contain an entry with this key.
 
-```js
+```feel
 null = null
 // true
 
@@ -130,7 +130,7 @@ function [is defined()](../builtin-functions/feel-built-in-functions-boolean.md#
 used to differentiate between a value that is `null` and a variable or context entry that doesn't
 exist.
 
-```js
+```feel
 is defined(null)
 // true
 
@@ -151,7 +151,7 @@ Combines multiple boolean values following the ternary logic.
 - The result is `false` if one value is `false`.
 - Otherwise, the result is `null` (i.e. if a value is not a boolean.)
 
-```js
+```feel
 true and true
 // true
 
@@ -179,7 +179,7 @@ Combines multiple boolean values following the ternary logic.
 - The result is `false` if all values are `false`.
 - Otherwise, the result is `null` (i.e. if a value is not a boolean.)
 
-```js
+```feel
 true or false
 // true
 
@@ -218,7 +218,7 @@ Checks if the value is of the given type. Available type names:
 
 Use the type `Any` to check if the value is not `null`.
 
-```js
+```feel
 1 instance of number
 // true
 
@@ -236,7 +236,7 @@ null instance of Any
 
 Evaluates a [unary-tests](/docs/components/modeler/feel/language-guide/feel-unary-tests) with the given value. The keyword `in` separates the value from the unary-tests.
 
-```js
+```feel
 5 in (3..7)
 // true
 

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-context-expressions.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-context-expressions.md
@@ -9,7 +9,7 @@ description: "This document outlines context expressions and examples."
 Creates a new context with the given entries. Each entry has a key and a value. The key is either a
 name or a string. The value can be any type.
 
-```js
+```feel
 {
   a: 1,
   b: 2
@@ -25,7 +25,7 @@ name or a string. The value can be any type.
 
 Inside the context, the previous entries can be accessed.
 
-```js
+```feel
 {
   a: 2,
   b: a * 2
@@ -35,7 +35,7 @@ Inside the context, the previous entries can be accessed.
 
 A context value can embed other context values.
 
-```js
+```feel
 {
   a: 1,
   b: {
@@ -47,15 +47,15 @@ A context value can embed other context values.
 
 ### Get entry or path
 
-```js
-a.b;
+```feel
+a.b
 ```
 
 Accesses the entry with the key `b` of the context `a`. The path is separated by `.`.
 
 If the value of the entry `b` is also a context, the path can be chained (i.e. `a.b.c`).
 
-```js
+```feel
 {
   a: 2
 }.a
@@ -82,17 +82,17 @@ Filters a list of context elements. It is a special kind of the [filter expressi
 
 While filtering, the entries of the current context element can be accessed by their key.
 
-```js
+```feel
 [
   {
     a: "p1",
-    b: 5,
+    b: 5
   },
   {
     a: "p2",
-    b: 10,
-  },
-][b > 7];
+    b: 10
+  }
+][b > 7]
 // {a: "p2", b: 10}
 ```
 
@@ -101,16 +101,16 @@ While filtering, the entries of the current context element can be accessed by t
 Extracts the entries of a list of context elements by a given key (i.e. a projection). It returns a
 list containing the values of the context elements for the given key.
 
-```js
+```feel
 [
   {
     a: "p1",
-    b: 5,
+    b: 5
   },
   {
     a: "p2",
-    b: 10,
-  },
-].a;
+    b: 10
+  }
+].a
 // ["p1", "p2"]
 ```

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-control-flow.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-control-flow.md
@@ -6,14 +6,14 @@ description: "This document outlines control flow and examples."
 
 ### If conditions
 
-```js
+```feel
 if c then a else b
 ```
 
 Executes the expression `a` if the condition `c` evaluates to `true`. Otherwise, it executes the
 expression `b`.
 
-```js
+```feel
 if 5 < 10  then "low" else "high"
 // "low"
 
@@ -25,7 +25,7 @@ if 12 < 10 then "low" else "high"
 If the condition `c` doesn't evaluate to a boolean value (e.g. `null`), it
 executes the expression `b`.
 
-```js
+```feel
 if null then "low" else "high"
 // "high"
 ```
@@ -34,7 +34,7 @@ if null then "low" else "high"
 
 ### For loops
 
-```js
+```feel
 for a in b return c
 ```
 
@@ -44,7 +44,7 @@ element is assigned to the variable `a`. The result of the expression is a list.
 If multiple lists are passed to the `for` loop then it iterates over the cross-product of the
 elements in the given lists.
 
-```js
+```feel
 for x in [1,2,3] return x * 2
 // [2,4,6]
 
@@ -54,14 +54,14 @@ for x in [1,2], y in [3,4] return x * y
 
 While iterating over the list, the previous elements are assigned to the variable `partial`.
 
-```js
+```feel
 for i in 1..10 return if (i <= 2) then 1 else partial[-1] + partial[-2]
 // [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
 ```
 
 Instead of a list, the `for` loop can also iterate over a given range.
 
-```js
+```feel
 for x in 0..8 return 2 ** x
 // [1, 2, 4, 8, 16, 32, 64, 128, 256]
 

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-data-types.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-data-types.md
@@ -12,8 +12,8 @@ Nothing, null, or nil (i.e. the value is not present).
 
 - Java Type: `null`
 
-```js
-null;
+```feel
+null
 ```
 
 ### Number
@@ -23,12 +23,14 @@ A whole or floating point number. The number can be negative.
 - not-a-number (NaN), positive/negative infinity are represented as `null`
 - Java Type: `java.math.BigDecimal`
 
-```js
-1;
+```feel
+1
 
-2.3;
+2.3
 
-0.4 - 5;
+.4
+
+-5
 ```
 
 ### String
@@ -37,8 +39,8 @@ A sequence of characters enclosed in double quotes `"`. The sequence can also co
 
 - Java Type: `java.lang.String`
 
-```js
-"valid";
+```feel
+"valid"
 ```
 
 ### Boolean
@@ -47,10 +49,10 @@ A boolean value. It is either true or false.
 
 - Java Type: `java.lang.Boolean`
 
-```js
-true;
+```feel
+true
 
-false;
+false
 ```
 
 ### Date
@@ -60,8 +62,8 @@ A date value without a time component.
 - Format: `yyyy-MM-dd`.
 - Java Type: `java.time.LocalDate`
 
-```js
-date("2017-03-10");
+```feel
+date("2017-03-10")
 ```
 
 ### Time
@@ -71,13 +73,11 @@ A local or zoned time. The time can have an offset or time zone id.
 - Format: `HH:mm:ss` / `HH:mm:ss+/-HH:mm` / `HH:mm:ss@ZoneId`
 - Java Type: `java.time.LocalTime` / `java.time.OffsetTime`
 
-```js
-time("11:45:30");
-time("13:30");
-
-time("11:45:30+02:00");
-
-time("10:31:10@Europe/Paris");
+```feel
+time("11:45:30")
+time("13:30")
+time("11:45:30+02:00")
+time("10:31:10@Europe/Paris")
 ```
 
 ### Date-time
@@ -87,11 +87,9 @@ A date with a local or zoned time component. The time can have an offset or time
 - Format: `yyyy-MM-dd'T'HH:mm:ss` / `yyyy-MM-dd'T'HH:mm:ss+/-HH:mm` / `yyyy-MM-dd'T'HH:mm:ss@ZoneId`
 - Java Type: `java.time.LocalDateTime` / `java.time.DateTime`
 
-```js
+```feel
 date and time("2015-09-18T10:31:10")
-
 date and time("2015-09-18T10:31:10+01:00")
-
 date and time("2015-09-18T10:31:10@Europe/Paris")
 ```
 
@@ -102,11 +100,11 @@ A duration based on seconds. It can contain days, hours, minutes, and seconds.
 - Format: `PxDTxHxMxS`
 - Java Type: `java.time.Duration`
 
-```js
-duration("P4D");
-duration("PT2H");
-duration("PT30M");
-duration("P1DT6H");
+```feel
+duration("P4D")
+duration("PT2H")
+duration("PT30M")
+duration("P1DT6H")
 ```
 
 ### Years-months-duration
@@ -116,10 +114,10 @@ A duration based on the calendar. It can contain years and months.
 - Format: `PxYxM`
 - Java Type: `java.time.Period`
 
-```js
-duration("P2Y");
-duration("P6M");
-duration("P1Y6M");
+```feel
+duration("P2Y")
+duration("P6M")
+duration("P1Y6M")
 ```
 
 ### List
@@ -128,8 +126,12 @@ A list of elements. The elements can be of any type. The list can be empty.
 
 - Java Type: `java.util.List`
 
-```js
-[][(1, 2, 3)][("a", "b")][(["list"], "of", [["lists"]])];
+```feel
+[]
+[1,2,3]
+["a","b"]
+
+[["list"], "of", [["lists"]]]
 ```
 
 ### Context
@@ -139,7 +141,7 @@ can be any type. The context can be empty.
 
 - Java Type: `java.util.Map`
 
-```js
+```feel
 {}
 
 {a:1}

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-expressions-introduction.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-expressions-introduction.md
@@ -26,17 +26,17 @@ The following sections cover more general areas that are not restricted to one d
 An expression can contain comments to explain it and give it more context. This can be done using
 Java-style comments: `//` to the end of line, or `/*.... */` for blocks.
 
-```js
+```feel
 // returns the last item
-[1, 2, 3, 4][-1][
-  /* returns the last item */
-  (1, 2, 3, 4)
-][-1][
-  /*
-   * returns the last item
-   */
-  (1, 2, 3, 4)
-][-1];
+[1,2,3,4][-1]
+
+/* returns the last item */
+[1,2,3,4][-1]
+
+/*
+ * returns the last item
+ */
+[1,2,3,4][-1]
 ```
 
 ### Parentheses
@@ -44,7 +44,7 @@ Java-style comments: `//` to the end of line, or `/*.... */` for blocks.
 Parentheses `( .. )` can be used in expressions to separate different parts of an
 expression or to influence the precedence of the operators.
 
-```js
+```feel
 (5 - 3) * (4 / 2)
 
 x < 5 and (y > 10 or z > 20)

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-functions.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-functions.md
@@ -12,7 +12,7 @@ function by its name. The arguments of the function can be passed positional or 
 - Positional: Only the values, in the same order as defined by the function (e.g. `f(1,2)`).
 - Named: The values with the argument name as prefix, in any order (e.g. `f(a: 1, b: 2)`).
 
-```js
+```feel
 contains("me@camunda.com", ".com")
 // true
 
@@ -22,7 +22,7 @@ contains(string: "me@camunda.com", match: ".de")
 
 ### User-defined
 
-```js
+```feel
 function(a,b) e
 ```
 
@@ -31,7 +31,7 @@ the function is invoked, it assigns the values to the arguments and evaluates th
 
 Within an expression, a function can be defined and invoked in a context.
 
-```js
+```feel
 {
   age: function(birthday) (today() - birthday).years
 }

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-list-expressions.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-list-expressions.md
@@ -8,64 +8,54 @@ description: "This document outlines list expressions and examples."
 
 Creates a new list of the given elements. The elements can be of any type.
 
-```js
-[1, 2, 3, 4];
+```feel
+[1,2,3,4]
 ```
 
 A list value can embed other list values.
 
-```js
-[
-  [1, 2],
-  [3, 4],
-  [5, 6],
-];
+```feel
+[[1,2], [3,4], [5,6]]
 ```
 
 ### Get element
 
-```js
-a[i];
+```feel
+a[i]
 ```
 
 Accesses an element of the list `a` at index `i`. The index starts at `1`.
 
 If the index is out of the range of the list, it returns `null`.
 
-```js
-[1, 2, 3, 4][1][
-  // 1
+```feel
+[1,2,3,4][1]
+// 1
 
-  (1, 2, 3, 4)
-][2][
-  // 2
+[1,2,3,4][2]
+// 2
 
-  (1, 2, 3, 4)
-][4][
-  // 4
+[1,2,3,4][4]
+// 4
 
-  (1, 2, 3, 4)
-][5][
-  // null
+[1,2,3,4][5]
+// null
 
-  (1, 2, 3, 4)
-][0];
+[1,2,3,4][0]
 // null
 ```
 
 If the index is negative, it starts counting the elements from the end of the list. The last
 element of the list is at index `-1`.
 
-```js
-[1, 2, 3, 4][-1][
-  // 4
+```feel
+[1,2,3,4][-1]
+// 4
 
-  (1, 2, 3, 4)
-][-2][
-  // 3
+[1,2,3,4][-2]
+// 3
 
-  (1, 2, 3, 4)
-][-5];
+[1,2,3,4][-5]
 // null
 ```
 
@@ -75,30 +65,28 @@ The index of a list starts at `1`. In other languages, the index starts at `0`.
 
 ### Filter
 
-```js
-a[c];
+```feel
+a[c]
 ```
 
 Filters the list `a` by the condition `c`. The result of the expression is a list that contains all elements where the condition `c` evaluates to `true`.
 
 While filtering, the current element is assigned to the variable `item`.
 
-```js
-[1, 2, 3, 4][item > 2][
-  // [3,4]
+```feel
+[1,2,3,4][item > 2]
+// [3,4]
 
-  (1, 2, 3, 4)
-][item > 10][
-  // []
+[1,2,3,4][item > 10]
+// []
 
-  (1, 2, 3, 4)
-][even(item)];
+[1,2,3,4][even(item)]
 // [2,4]
 ```
 
 ### Some
 
-```js
+```feel
 some a in b satisfies c
 ```
 
@@ -108,7 +96,7 @@ element is assigned to the variable `a`.
 It returns `true` if `c` evaluates to `true` for **one or more** elements of `b`. Otherwise, it
 returns `false`.
 
-```js
+```feel
 some x in [1,2,3] satisfies x > 2
 // true
 
@@ -130,7 +118,7 @@ element is assigned to the variable `a`.
 It returns `true` if `c` evaluates to `true` for **all** elements of `b`. Otherwise, it
 returns `false`.
 
-```js
+```feel
 every x in [1,2,3] satisfies x >= 1
 // true
 

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-numeric-expressions.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-numeric-expressions.md
@@ -8,46 +8,50 @@ description: "This document outlines numeric expressions and examples."
 
 Creates a new numeric value. Leading zeros are valid.
 
-```js
-1;
+```feel
+1
 
-0.5;
-0.5 - 2;
+0.5
+.5
 
-01 - 0002;
+-2
+
+01
+
+-0002
 ```
 
 ### Addition
 
-```js
-2 + 3;
+```feel
+2 + 3
 // 5
 ```
 
 ### Subtraction
 
-```js
-5 - 3;
+```feel
+5 - 3
 // 2
 ```
 
 ### Multiplication
 
-```js
-5 * 3;
+```feel
+5 * 3
 // 15
 ```
 
 ### Division
 
-```js
-6 / 2;
+```feel
+6 / 2
 // 3
 ```
 
 ### Exponentiation
 
-```js
-2 ** 3;
+```feel
+2 ** 3
 // 8
 ```

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-string-expressions.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-string-expressions.md
@@ -8,16 +8,16 @@ description: "This document outlines string expressions and examples."
 
 Creates a new string value.
 
-```js
-"valid";
+```feel
+"valid"
 ```
 
 ### Addition/concatenation
 
 An addition concatenates the strings. The result is a string containing the characters of both strings.
 
-```js
-"foo" + "bar";
+```feel
+"foo" + "bar"
 // "foobar"
 ```
 
@@ -27,8 +27,8 @@ The concatenation is only available for string values. For other types, you can 
 the [string()](/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion#string) function to convert
 the value into a string first.
 
-```js
-"order-" + string(123);
+```feel
+"order-" + string(123)
 ```
 
 :::

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-temporal-expressions.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-temporal-expressions.md
@@ -8,7 +8,7 @@ description: "This document outlines temporal expressions and examples."
 
 Creates a new temporal value.
 
-```js
+```feel
 date("2020-04-06")
 
 time("08:00:00")
@@ -79,7 +79,7 @@ duration("P3M")
 
 </table>
 
-```js
+```feel
 date("2020-04-06") + duration("P1D")
 // date("2020-04-07")
 
@@ -152,23 +152,23 @@ duration("P2D") + duration("P5D")
 
 </table>
 
-```js
-date("2020-04-06") - date("2020-04-01");
+```feel
+date("2020-04-06") - date("2020-04-01")
 // duration("P5D")
 
-date("2020-04-06") - duration("P5D");
+date("2020-04-06") - duration("P5D")
 // date("2020-04-01")
 
-time("08:00:00") - time("06:00:00");
+time("08:00:00") - time("06:00:00")
 // duration("PT2H")
 
-time("08:00:00") - duration("PT2H");
+time("08:00:00") - duration("PT2H")
 // time("06:00:00")
 
-duration("P7D") - duration("P2D");
+duration("P7D") - duration("P2D")
 // duration("P5D")
 
-duration("P1Y") - duration("P3M");
+duration("P1Y") - duration("P3M")
 // duration("P9M")
 ```
 
@@ -207,11 +207,11 @@ duration("P1Y") - duration("P3M");
 
 </table>
 
-```js
-duration("P1D") * 5;
+```feel
+duration("P1D") * 5
 // duration("P5D")
 
-duration("P1M") * 6;
+duration("P1M") * 6
 // duration("P6M")
 ```
 
@@ -250,17 +250,17 @@ duration("P1M") * 6;
 
 </table>
 
-```js
-duration("P5D") / duration("P1D");
+```feel
+duration("P5D") / duration("P1D")
 // 5
 
-duration("P5D") / 5;
+duration("P5D") / 5
 // duration("P1D")
 
-duration("P1Y") / duration("P1M");
+duration("P1Y") / duration("P1M")
 // 12
 
-duration("P1Y") / 12;
+duration("P1Y") / 12
 // duration("P1M")
 ```
 
@@ -368,7 +368,7 @@ for the given types:
 
 </table>
 
-```js
+```feel
 date("2020-04-06").year
 // 2020
 

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-unary-tests.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-unary-tests.md
@@ -60,8 +60,16 @@ The input value is passed implicitly as the first argument of the operator.
 
 </table>
 
-```js
-"valid" < 10 <= date("2020-04-06") > time("08:00:00") >= duration("P5D");
+```feel
+"valid"
+
+< 10
+
+<= date("2020-04-06")
+
+> time("08:00:00")
+
+>= duration("P5D")
 ```
 
 ### Interval
@@ -74,7 +82,7 @@ excludes the value (i.e. less/greater than).
 
 The input value is passed implicitly to the operator.
 
-```js
+```feel
 (2..5)
 // input > 2 and input < 5
 
@@ -95,7 +103,7 @@ Combines multiple unary-test expressions following the ternary logic.
 - Returns `true` if at least one unary-test evaluates to `true`.
 - Otherwise, it returns `false`.
 
-```js
+```feel
 2, 3, 4
 // input = 2 or input = 3 or input = 4
 
@@ -110,11 +118,11 @@ disjunction.
 
 It returns `true` if the given unary-test evaluates to `false`.
 
-```js
-not("valid");
+```feel
+not("valid")
 // input != "valid"
 
-not(2, 3);
+not(2, 3)
 // input != 2 and input != 3
 ```
 
@@ -124,7 +132,7 @@ Evaluates an expression that returns a boolean value. For example, [invoking a f
 
 The input value can be accessed in the expression by using the symbol `?` (a question mark).
 
-```js
+```feel
 contains(?, "good")
 // check if the input value (string) contains "good"
 

--- a/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-variables.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/language-guide/feel-variables.md
@@ -8,21 +8,21 @@ description: "This document outlines variables and examples."
 
 Access the value of a variable by its variable name.
 
-```js
-a + b;
+```feel
+a + b
 ```
 
 If the value of the variable is a context, a [context entry can be accessed](/docs/components/modeler/feel/language-guide/feel-context-expressions#get-entry-or-path) by its key.
 
-```js
-a.b;
+```feel
+a.b
 ```
 
 :::tip
 
 Use a [null-check](/docs/components/modeler/feel/language-guide/feel-boolean-expressions#null-check) if the variable can be `null` or is optional.
 
-```js
+```feel
 a != null and a.b > 10
 ```
 
@@ -35,7 +35,7 @@ combination of words, it is recommended to use `camelCase` or the `snake_case` f
 
 If a variable name or context key contains any special character (e.g. whitespace, dash, etc.,) the name can be placed in single backticks (e.g. `` `foo bar` ``).
 
-```js
+```feel
 `first name`
 
 `tracking-id`

--- a/versioned_docs/version-8.0/components/modeler/feel/what-is-feel.md
+++ b/versioned_docs/version-8.0/components/modeler/feel/what-is-feel.md
@@ -16,7 +16,7 @@ FEEL has two types of expressions for different use cases:
 A [unary-tests expression](./language-guide/feel-unary-tests.md) is a special kind of boolean expression. It should be used for the input
 entries of a decision table (i.e. the conditions of a rule).
 
-```js
+```feel
 < 7
 // checks if the input value is less than 7
 
@@ -35,7 +35,7 @@ not(2,4)
 [General expressions](./language-guide/feel-expressions-introduction.md) that can return values of different types. They can be used everywhere; for
 example, in a decision table as an input expression or as an output entry.
 
-```js
+```feel
 applicant.monthly.income * 12
 
 if applicant.maritalStatus in ("M","S") then "valid" else "not valid"


### PR DESCRIPTION
## What is the purpose of the change

In Camunda Platform version `8.1`, we dumped the FEEL engine from `1.14` to `1.15`. Following our current process, we copy the docs from the FEEL-Scala repository into the Camunda docs.

Additionally, I changed the language of the code blocks from `js` to `feel` to avoid that Prettier formats the FEEL expressions. The formatting would make the expressions invalid. 

The downside is that we don't have a syntax highlighting of the FEEL expressions anymore. But we can work on this in the future.

Alternatively, we would have to add ignore blocks for Prettier around each code block. That would be a lot of boiler code and easy to miss for new code blocks.

## Are there related marketing activities

No.

## When should this change go live?

Camunda Platform version `8.1`.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
