### PR TITLE
docs(identity): add to identity config vars

### DIFF
--- a/docs/self-managed/identity/deployment/configuration-variables.md
+++ b/docs/self-managed/identity/deployment/configuration-variables.md
@@ -10,18 +10,19 @@ methods.
 
 ### Core configuration
 
-| Environment variable                 | Description                                          | Default value                                                                                                                                                            |
-| ------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `IDENTITY_URL`                       | The URL of the Identity service                      | http://localhost:8080                                                                                                                                                    |
-| `KEYCLOAK_URL`                       | The URL of the Keycloak instance to use              | http://localhost:18080/auth                                                                                                                                              |
-| `IDENTITY_AUTH_PROVIDER_BACKEND_URL` | Used to support container to container communication | http://localhost:18080/auth/realms/camunda-platform                                                                                                                      |
-| `IDENTITY_BASE_PATH`                 | Used to configure Identity to run on a subpath       |                                                                                                                                                                          |
-| `IDENTITY_LOG_LEVEL`                 | The level of which to log messages at                | INFO                                                                                                                                                                     |
-| `IDENTITY_LOG_PATTERN`               | The pattern to use when logging                      | `%clr{%d{yyyy-MM-dd HH:mm:ss.SSS}}{faint} %clr{%5p} %clr{${sys:PID}}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n%xwEx` |
-
-:::note
-When setting the `IDENTITY_BASE_PATH` variable, a secure connection (HTTPS) is required to allow Identity to correctly handle requests.
-:::
+| Environment variable                 | Description                                                                        | Default value                                                                                                                                                            |
+| ------------------------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- |
+| `IDENTITY_AUTH_PROVIDER_BACKEND_URL` | Used to support container to container communication                               | http://localhost:18080/auth/realms/camunda-platform                                                                                                                      |
+| `IDENTITY_AUTH_PROVIDER_ISSUER_URL`  | Used to denote the token issuer                                                    | http://localhost:18080/auth/realms/camunda-platform                                                                                                                      |     |
+| `IDENTITY_BASE_PATH`                 | Used to configure Identity to run on a subpath (Requires HTTPs for `IDENTITY_URL`) |                                                                                                                                                                          |
+| `IDENTITY_LOG_LEVEL`                 | The level of which to log messages at                                              | INFO                                                                                                                                                                     |
+| `IDENTITY_LOG_PATTERN`               | The pattern to use when logging                                                    | `%clr{%d{yyyy-MM-dd HH:mm:ss.SSS}}{faint} %clr{%5p} %clr{${sys:PID}}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n%xwEx` |
+| `IDENTITY_URL`                       | The URL of the Identity service                                                    | http://localhost:8080                                                                                                                                                    |
+| `KEYCLOAK_URL`                       | The URL of the Keycloak instance to use                                            | http://localhost:18080/auth                                                                                                                                              |
+| `KEYCLOAK_SETUP_USER`                | The username of a user with admin access to Keycloak                               | admin                                                                                                                                                                    |
+| `KEYCLOAK_SETUP_PASSWORD`            | The password of a user with admin access to Keycloak                               | admin                                                                                                                                                                    |
+| `KEYCLOAK_SETUP_REALM`               | The realm that the setup user is in                                                | master                                                                                                                                                                   |
+| `KEYCLOAK_SETUP_CLIENT_ID`           | The client to use for authentication during setup of the provided Keycloak         | admin-cli                                                                                                                                                                |
 
 ### Component configuration
 
@@ -34,7 +35,8 @@ component for use within Identity, all that is required is to set two variables:
 | `KEYCLOAK_INIT_<COMPONENT>_ROOT_URL` | The root URL of where the component is hosted | No default    |
 
 :::note
-Identity supports the following values for the `<COMPONENT>` placeholder: `OPERATE`, `OPTIMIZE`, `TASKLIST`, and `WEBMODELER`.
+Identity supports the following values for the `<COMPONENT>` placeholder: `OPERATE`, `OPTIMIZE`, `TASKLIST`,
+and `WEBMODELER`.
 
 For the `WEBMODELER` value, only the `KEYCLOAK_INIT_<COMPONENT>_ROOT_URL` variable is required to be set.
 :::

--- a/versioned_docs/version-8.0/self-managed/identity/deployment/configuration-variables.md
+++ b/versioned_docs/version-8.0/self-managed/identity/deployment/configuration-variables.md
@@ -10,11 +10,18 @@ methods.
 
 ### Core configuration
 
-| Environment variable                 | Description                                          | Default value                                       |
-| ------------------------------------ | ---------------------------------------------------- | --------------------------------------------------- |
-| `IDENTITY_URL`                       | The URL of the Identity service                      | http://localhost:8080                               |
-| `KEYCLOAK_URL`                       | The URL of the Keycloak instance to use              | http://localhost:18080/auth                         |
-| `IDENTITY_AUTH_PROVIDER_BACKEND_URL` | Used to support container to container communication | http://localhost:18080/auth/realms/camunda-platform |
+### Core configuration
+
+| Environment variable                 | Description                                                                | Default value                                       |
+| ------------------------------------ | -------------------------------------------------------------------------- | --------------------------------------------------- | --- |
+| `IDENTITY_AUTH_PROVIDER_BACKEND_URL` | Used to support container to container communication                       | http://localhost:18080/auth/realms/camunda-platform |
+| `IDENTITY_AUTH_PROVIDER_ISSUER_URL`  | Used to denote the token issuer                                            | http://localhost:18080/auth/realms/camunda-platform |     |
+| `IDENTITY_URL`                       | The URL of the Identity service                                            | http://localhost:8080                               |
+| `KEYCLOAK_URL`                       | The URL of the Keycloak instance to use                                    | http://localhost:18080/auth                         |
+| `KEYCLOAK_SETUP_USER`                | The username of a user with admin access to Keycloak                       | admin                                               |
+| `KEYCLOAK_SETUP_PASSWORD`            | The password of a user with admin access to Keycloak                       | admin                                               |
+| `KEYCLOAK_SETUP_REALM`               | The realm that the setup user is in                                        | master                                              |
+| `KEYCLOAK_SETUP_CLIENT_ID`           | The client to use for authentication during setup of the provided Keycloak | admin-cli                                           |
 
 ### Component configuration
 


### PR DESCRIPTION
Resolves https://github.com/camunda/camunda-platform-docs/issues/1164 and https://github.com/camunda-cloud/identity/issues/988

## What is the purpose of the change

The identity component offers different configuration options by way of environmental variables, there are values that Users may find helpful which are currently not listed. This PR adds these environmental variables to the existing list.

## Are there related marketing activities

Nope :)

## When should this change go live?

These configuration variable have existed for a while so they can go live whenever

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
