### PR TITLE
docs(self-managed): add upgrade steps before helm chart v8.0.13

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
@@ -1,7 +1,7 @@
 ---
-id: deployment
+id: deploy
 title: "Camunda Platform 8 Helm deployment"
-sidebar_label: "Deployment"
+sidebar_label: "Deploy"
 ---
 
 Camunda provides continuously improved Helm charts which are not cloud provider-specific, so you can choose your Kubernetes provider. The charts are available in [Camunda Platform Helm repository](https://github.com/camunda/camunda-platform-helm) and we encourage you to [report issues](https://github.com/camunda/camunda-platform-helm/issues) if you find any of them.
@@ -123,73 +123,9 @@ If the output of the `describe` command was not beneficial, tail the logs of the
 kubectl logs -f <POD_NAME>
 ```
 
-## Upgrading from one Helm release to another
+## Upgrading Camunda Helm chart
 
-To upgrade to a more recent version of the Camunda Platform Helm charts, there are certain things you need to keep in mind.
-
-Normally for a Helm upgrade, you run the [Helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) command. If you have disabled Camunda Identity component and the related authentication mechanism, you should be able to easily do an upgrade via this command, `helm upgrade`.
-
-However, if Camunda Identity component is enabled (this is the default), the upgrade path is a bit more complex than just running `helm upgrade`. Read the next sections to familiarize yourself with the upgrade process.
-
-### Upgrading with Identity and secrets
-
-If you have installed the Camunda Platform 8 Helm charts before with default values, this means Identity and the related authentication mechanism are enabled. For authentication, the Helm charts generate for each web app the secrets randomly if not specified on installation. If you just run `helm upgrade` to upgrade to a newer chart version, you likely will see the following return:
-
-```shell
-helm upgrade camunda-platform-test camunda/camunda-platform
-
-Error: UPGRADE FAILED: execution error at (camunda-platform/charts/identity/templates/tasklist-secret.yaml:10:22):
-PASSWORDS ERROR: You must provide your current passwords when upgrading the release.
-                 Note that even after reinstallation, old credentials may be needed as they may be kept in persistent volume claims.
-                 Further information can be obtained at https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases
-
-    'global.identity.auth.tasklist.existingSecret' must not be empty, please add '--set global.identity.auth.tasklist.existingSecret=$TASKLIST_SECRET' to the command. To get the current value:
-
-        export TASKLIST_SECRET=$(kubectl get secret --namespace "zell-c8-optimize" "camunda-platform-test-tasklist-identity-secret" -o jsonpath="{.data.tasklist-secret}" | base64 --decode)
-```
-
-As mentioned, this output returns because secrets are randomly generated with the first Helm installation by default if not further specified. We use a library chart [provided by Bitnami](https://github.com/bitnami/charts/tree/master/bitnami/common) for this. The generated secrets are persisted on persistent volume claims (PVCs), which are not maintained by Helm.
-
-If you remove the Helm chart release or do an upgrade, PVCs are not removed nor recreated. On an upgrade, secrets can be recreated by Helm, and could lead to the regeneration of the secret values. This would mean that newly-generated secrets wouldn't longer match with the persisted secrets. To avoid such an issue, Bitnami blocks the upgrade path and prints the help message as shown above.
-
-In the error message, Bitnami links to their well-described [troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases). However, to avoid confusion we will step through the troubleshooting process in this guide as well.
-
-### Secrets extraction
-
-For a successful upgrade, you first need to extract all secrets which were previously generated.
-
-:::note
-You also need to extract all secrets which were generated for Keycloak, since Keycloak is a dependency of Identity.
-:::
-
-To extract the secrets, use the following code snippet. Make sure to replace `<RELEASE_NAME>` with your chosen Helm RELEASE_NAME.
-
-```shell
-export TASKLIST_SECRET=$(kubectl get secret "<RELEASE_NAME>-tasklist-identity-secret" -o jsonpath="{.data.tasklist-secret}" | base64 --decode)
-export OPTIMIZE_SECRET=$(kubectl get secret "<RELEASE_NAME>-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
-export OPERATE_SECRET=$(kubectl get secret "<RELEASE_NAME>-operate-identity-secret" -o jsonpath="{.data.operate-secret}" | base64 --decode)
-export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
-export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
-export POSTGRESQL_SECRET=$(kubectl get secret "<RELEASE_NAME>-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
-```
-
-After exporting all secrets into environment variables, run the following upgrade command.
-
-```shell
-helm upgrade <RELEASE_NAME> charts/camunda-platform/ \
-  --set global.identity.auth.tasklist.existingSecret=$TASKLIST_SECRET \
-  --set global.identity.auth.optimize.existingSecret=$OPTIMIZE_SECRET \
-  --set global.identity.auth.operate.existingSecret=$OPERATE_SECRET \
-  --set identity.keycloak.auth.adminPassword=$KEYCLOAK_ADMIN_SECRET \
-  --set identity.keycloak.auth.managementPassword=$KEYCLOAK_MANAGEMENT_SECRET \
-  --set identity.keycloak.postgresql.auth.password=$POSTGRESQL_SECRET
-```
-
-:::note
-If you have specified on the first installation certain values, you have to specify them again on the upgrade. Either via `--set` or the values file and the `-f` flag.
-:::
-
-For more details on the Keycloak upgrade path, you can also read the [Bitnami Keycloak upgrade guide](https://docs.bitnami.com/kubernetes/apps/keycloak/administration/upgrade/).
+For upgrading Camunda Helm chart from one release to another, visit the [Camunda Platform 8 Helm upgrading page](upgrade.md).
 
 ## General notes
 

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress.md
@@ -4,7 +4,7 @@ title: "Accessing components without Ingress"
 description: "Accessing Camunda Platform 8 components externally without Ingress"
 ---
 
-By default, the [Camunda Platform Helm chart](../../helm-kubernetes/deployment.md) does not expose the Camunda Platform services externally. So to interact with the Camunda Platform services inside a Kubernetes cluster without Ingress setup, you can use `kubectl port-forward` to route traffic from your local machine to the cluster. This is useful for quick tests or for development purposes.
+By default, the [Camunda Platform Helm chart](../../helm-kubernetes/deploy.md) does not expose the Camunda Platform services externally. So to interact with the Camunda Platform services inside a Kubernetes cluster without Ingress setup, you can use `kubectl port-forward` to route traffic from your local machine to the cluster. This is useful for quick tests or for development purposes.
 
 :::note
 You need to keep `port-forward` running all the time to communicate with the remote cluster.

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -68,7 +68,7 @@ zeebe-gateway:
     host: "zeebe.camunda.example.com"
 ```
 
-Using the custom values file, [deploy Camunda Platform 8 as usual](../../helm-kubernetes/deployment.md):
+Using the custom values file, [deploy Camunda Platform 8 as usual](../../helm-kubernetes/deploy.md):
 
 ```shell
 helm install demo camunda/camunda-platform -f values-combined-ingress.yaml
@@ -147,7 +147,7 @@ zeebe-gateway:
     host: "zeebe.camunda.example.com"
 ```
 
-Using the custom values file, [deploy Camunda Platform 8 as usual](../../helm-kubernetes/deployment.md):
+Using the custom values file, [deploy Camunda Platform 8 as usual](../../helm-kubernetes/deploy.md):
 
 ```shell
 helm install demo camunda/camunda-platform -f values-separated-ingress.yaml

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster.md
@@ -20,4 +20,4 @@ This will deploy the same components, but with a set of parameters tailored to a
 
 It might take some time for the services to get started depends on your internet connection speed since it will download the Docker images of all Camunda Platform components to your local KIND cluster.
 
-For more details about deployment options, visit full [Helm deployment guide](../deployment.md).
+For more details about deployment options, visit full [Helm deployment guide](../deploy.md).

--- a/docs/self-managed/platform-deployment/helm-kubernetes/overview.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/overview.md
@@ -26,7 +26,7 @@ While you can install Camunda Platform 8 on any Kubernetes environment, we only 
 - [Amazon EKS](./platforms/amazon-eks.md)
 - [Red Hat OpenShift](./platforms/redhat-openshift.md)
 
-Generally speaking [deploying Camunda Platform using Helm chart](./deployment.md) should work for all platforms, however, each platform or cloud provider could have some special prerequisites to prepare or pitfalls to avoid. So main goal of the platforms docs is to shed the light on some points to have a smooth Camunda Platform deployment on different platforms.
+Generally speaking [deploying Camunda Platform using Helm chart](./deploy.md) should work for all platforms, however, each platform or cloud provider could have some special prerequisites to prepare or pitfalls to avoid. So main goal of the platforms docs is to shed the light on some points to have a smooth Camunda Platform deployment on different platforms.
 
 ## Use Helm to install on Kubernetes
 
@@ -34,7 +34,7 @@ There are several alternatives to deploy applications to a Kubernetes cluster, b
 
 At [helm.camunda.io](https://helm.camunda.io/), you'll find a Helm chart to configure a three-broker cluster with two Elasticsearch instances, Operate, two Zeebe Gateways and Tasklist. This size is comparable with the Production-S cluster plan in [Camunda Platform 8 SaaS](https://camunda.com/get-started/). It should be sufficient for 80% of use cases.
 
-Refer to the [documentation on Camunda's Helm charts](./deployment.md) for details.
+Refer to the [documentation on Camunda's Helm charts](./deploy.md) for details.
 
 To do, you must have the following tools installed in your local environment:
 

--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
@@ -7,7 +7,7 @@ description: "Deploy Camunda Platform 8 Self-Managed on Amazon EKS"
 Amazon Elastic Kubernetes Service ([Amazon EKS](https://aws.amazon.com/eks/)) is a managed
 container service to run and scale Kubernetes applications in the cloud or on-premises.
 
-Camunda Platform 8 Self-Managed can be deployed on EKS like any Kubernetes cluster using [Helm charts](../deployment.md). However, there are a few pitfalls to avoid as described below.
+Camunda Platform 8 Self-Managed can be deployed on EKS like any Kubernetes cluster using [Helm charts](../deploy.md). However, there are a few pitfalls to avoid as described below.
 
 ## EKS cluster specification
 

--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -4,7 +4,7 @@ title: "Red Hat OpenShift"
 description: "Deploy Camunda Platform 8 Self-Managed on Red Hat OpenShift"
 ---
 
-Camunda Platform 8 can be deployed using Helm on Red Hat OpenShift with proper configurations. The primarily difference from [general Helm deployment guide](../deployment.md) is related to the Security Context Constraints (SCCs) you have in your cluster.
+Camunda Platform 8 can be deployed using Helm on Red Hat OpenShift with proper configurations. The primarily difference from [general Helm deployment guide](../deploy.md) is related to the Security Context Constraints (SCCs) you have in your cluster.
 
 ## Compatibility
 
@@ -93,7 +93,7 @@ This also affects installations done through the OpenShift console, as it still 
 
 ### Permissive SCCs
 
-To use permissive SCCs, install the charts as they are. Follow the [general Helm deployment guide](../deployment.md).
+To use permissive SCCs, install the charts as they are. Follow the [general Helm deployment guide](../deploy.md).
 
 ### Restrictive SCCs
 

--- a/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -1,0 +1,79 @@
+---
+id: upgrade
+title: "Upgrading Camunda Platform 8 Helm deployment"
+sidebar_label: "Upgrade"
+---
+
+To upgrade to a more recent version of the Camunda Platform Helm charts, there are certain things you need to keep in mind.
+
+## General upgrade instructions
+
+### Upgrading where Identity disabled
+
+Normally for a Helm upgrade, you run the [Helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) command. If you have disabled Camunda Identity component and the related authentication mechanism, you should be able to easily do an upgrade as following:
+
+```sh
+helm upgrade <RELEASE_NAME>
+```
+
+However, if Camunda Identity component is enabled (which is the default), the upgrade path is a bit more complex than just running `helm upgrade`. Read the next section to familiarize yourself with the upgrade process.
+
+### Upgrading where Identity enabled
+
+If you have installed the Camunda Platform 8 Helm charts before with default values, this means Identity and the related authentication mechanism are enabled. For authentication, the Helm charts generate for each web app the secrets randomly if not specified on installation. If you just run `helm upgrade` to upgrade to a newer chart version, you likely will see the following return:
+
+```shell
+helm upgrade camunda-platform-test camunda/camunda-platform
+
+Error: UPGRADE FAILED: execution error at (camunda-platform/charts/identity/templates/tasklist-secret.yaml:10:22):
+PASSWORDS ERROR: You must provide your current passwords when upgrading the release.
+                 Note that even after reinstallation, old credentials may be needed as they may be kept in persistent volume claims.
+                 Further information can be obtained at https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases
+
+    'global.identity.auth.tasklist.existingSecret' must not be empty, please add '--set global.identity.auth.tasklist.existingSecret=$TASKLIST_SECRET' to the command. To get the current value:
+
+        export TASKLIST_SECRET=$(kubectl get secret --namespace "zell-c8-optimize" "camunda-platform-test-tasklist-identity-secret" -o jsonpath="{.data.tasklist-secret}" | base64 --decode)
+```
+
+As mentioned, this output returns because secrets are randomly generated with the first Helm installation by default if not further specified. We use a library chart [provided by Bitnami](https://github.com/bitnami/charts/tree/master/bitnami/common) for this. The generated secrets are persisted on persistent volume claims (PVCs), which are not maintained by Helm.
+
+If you remove the Helm chart release or do an upgrade, PVCs are not removed nor recreated. On an upgrade, secrets can be recreated by Helm, and could lead to the regeneration of the secret values. This would mean that newly-generated secrets wouldn't longer match with the persisted secrets. To avoid such an issue, Bitnami blocks the upgrade path and prints the help message as shown above.
+
+In the error message, Bitnami links to their well-described [troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases). However, to avoid confusion we will step through the troubleshooting process in this guide as well.
+
+#### Secrets extraction
+
+For a successful upgrade, you first need to extract all secrets which were previously generated.
+
+:::note
+You also need to extract all secrets which were generated for Keycloak, since Keycloak is a dependency of Identity.
+:::
+
+To extract the secrets, use the following code snippet. Make sure to replace `<RELEASE_NAME>` with your chosen Helm RELEASE_NAME.
+
+```shell
+export TASKLIST_SECRET=$(kubectl get secret "<RELEASE_NAME>-tasklist-identity-secret" -o jsonpath="{.data.tasklist-secret}" | base64 --decode)
+export OPTIMIZE_SECRET=$(kubectl get secret "<RELEASE_NAME>-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
+export OPERATE_SECRET=$(kubectl get secret "<RELEASE_NAME>-operate-identity-secret" -o jsonpath="{.data.operate-secret}" | base64 --decode)
+export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
+export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
+export POSTGRESQL_SECRET=$(kubectl get secret "<RELEASE_NAME>-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
+```
+
+After exporting all secrets into environment variables, run the following upgrade command.
+
+```shell
+helm upgrade <RELEASE_NAME> charts/camunda-platform/ \
+  --set global.identity.auth.tasklist.existingSecret=$TASKLIST_SECRET \
+  --set global.identity.auth.optimize.existingSecret=$OPTIMIZE_SECRET \
+  --set global.identity.auth.operate.existingSecret=$OPERATE_SECRET \
+  --set identity.keycloak.auth.adminPassword=$KEYCLOAK_ADMIN_SECRET \
+  --set identity.keycloak.auth.managementPassword=$KEYCLOAK_MANAGEMENT_SECRET \
+  --set identity.keycloak.postgresql.auth.password=$POSTGRESQL_SECRET
+```
+
+:::note
+If you have specified on the first installation certain values, you have to specify them again on the upgrade. Either via `--set` or the values file and the `-f` flag.
+:::
+
+For more details on the Keycloak upgrade path, you can also read the [Bitnami Keycloak upgrade guide](https://docs.bitnami.com/kubernetes/apps/keycloak/administration/upgrade/).

--- a/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -13,7 +13,7 @@ To upgrade to a more recent version of the Camunda Platform Helm charts, there a
 
 Normally for a Helm upgrade, you run the [Helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) command. If you have disabled Camunda Identity and the related authentication mechanism, you should be able to do an upgrade as follows:
 
-```sh
+```shell
 helm upgrade <RELEASE_NAME>
 ```
 
@@ -21,11 +21,22 @@ However, if Camunda Identity is enabled (which is the default), the upgrade path
 
 ### Upgrading where Identity enabled
 
+<<<<<<< HEAD
+If you have installed the Camunda Platform 8 Helm charts before with default values, this means Identity and the related authentication mechanism are enabled. For authentication, the Helm charts generate for each web app the secrets randomly if not specified on installation.
+
+# If you just tried upgrading to a newer chart version
+
 If you have installed the Camunda Platform 8 Helm charts before with default values, this means Identity and the related authentication mechanism are enabled. For authentication, the Helm charts generate the secrets randomly if not specified on installation for each web app. If you run `helm upgrade` to upgrade to a newer chart version, you likely will see the following return:
+
+> > > > > > > 0e9331a4a7bebcab85fe41cfd7c2ac42bd2e6814
 
 ```shell
 helm upgrade camunda-platform-test camunda/camunda-platform
+```
 
+You likely will see the following error:
+
+```shell
 Error: UPGRADE FAILED: execution error at (camunda-platform/charts/identity/templates/tasklist-secret.yaml:10:22):
 PASSWORDS ERROR: You must provide your current passwords when upgrading the release.
                  Note that even after reinstallation, old credentials may be needed as they may be kept in persistent volume claims.
@@ -33,7 +44,7 @@ PASSWORDS ERROR: You must provide your current passwords when upgrading the rele
 
     'global.identity.auth.tasklist.existingSecret' must not be empty, please add '--set global.identity.auth.tasklist.existingSecret=$TASKLIST_SECRET' to the command. To get the current value:
 
-        export TASKLIST_SECRET=$(kubectl get secret --namespace "zell-c8-optimize" "camunda-platform-test-tasklist-identity-secret" -o jsonpath="{.data.tasklist-secret}" | base64 --decode)
+        export TASKLIST_SECRET=$(kubectl get secret --namespace "camunda" "camunda-platform-test-tasklist-identity-secret" -o jsonpath="{.data.tasklist-secret}" | base64 --decode)
 ```
 
 As mentioned, this output returns because secrets are randomly generated with the first Helm installation by default if not further specified. We use a library chart [provided by Bitnami](https://github.com/bitnami/charts/tree/master/bitnami/common) for this. The generated secrets persist on persistent volume claims (PVCs), which are not maintained by Helm.
@@ -89,7 +100,7 @@ If you installed Camunda Platform 8 using Helm charts before `8.0.13`, you need 
 
 As a prerequisite, make sure you have the Elasticsearch Helm repository added:
 
-```sh
+```shell
 helm repo add elastic https://helm.elastic.co
 ```
 
@@ -97,7 +108,7 @@ helm repo add elastic https://helm.elastic.co
 
 First get the name of Elasticsearch Persistent Volumes:
 
-```sh
+```shell
 ES_PV_NAME0=$(kubectl get pvc elasticsearch-master-elasticsearch-master-0 -o jsonpath="{.spec.volumeName}")
 
 ES_PV_NAME1=$(kubectl get pvc elasticsearch-master-elasticsearch-master-1 -o jsonpath="{.spec.volumeName}")
@@ -105,7 +116,7 @@ ES_PV_NAME1=$(kubectl get pvc elasticsearch-master-elasticsearch-master-1 -o jso
 
 Make sure these are the correct Persistent Volumes:
 
-```sh
+```shell
 kubectl get persistentvolume $ES_PV_NAME0 $ES_PV_NAME1
 ```
 
@@ -119,7 +130,7 @@ pvc-3e9129bc-9415-46c3-a005-00ce3b9b3be9   64Gi       RWO            Delete     
 
 The final step here is to change Persistent Volumes reclaim policy:
 
-```sh
+```shell
 kubectl patch persistentvolume "${ES_PV_NAME0}" \
     -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 
@@ -129,7 +140,7 @@ kubectl patch persistentvolume "${ES_PV_NAME1}" \
 
 #### 2. Update Elasticsearch PersistentVolumeClaim labels
 
-```sh
+```shell
 kubectl label persistentvolumeclaim elasticsearch-master-elasticsearch-master-0 \
     release=<RELEASE_NAME> chart=elasticsearch app=elasticsearch-master
 
@@ -141,13 +152,13 @@ kubectl label persistentvolumeclaim elasticsearch-master-elasticsearch-master-1 
 
 Please note that there will be a **downtime** between this step and the next step.
 
-```sh
+```shell
 kubectl delete statefulset elasticsearch-master
 ```
 
 #### 4. Apply Elasticsearch StatefulSet chart
 
-```sh
+```shell
 helm template camunda/camunda-platform <RELEASE_NAME> --version <CHART_VERSION> \
     --show-only charts/elasticsearch/templates/statefulset.yaml
 ```

--- a/docs/self-managed/platform-deployment/overview.md
+++ b/docs/self-managed/platform-deployment/overview.md
@@ -36,7 +36,7 @@ As you can see below, we recommend [SaaS](https://camunda.com/get-started) whene
 
 ### Production
 
-For production usage, we highly recommend using a real Kubernetes cluster and our [Helm charts](./helm-kubernetes/deployment.md) if SaaS provided by Camunda is not an option for you.
+For production usage, we highly recommend using a real Kubernetes cluster and our [Helm charts](./helm-kubernetes/deploy.md) if SaaS provided by Camunda is not an option for you.
 
 We support the following deployment options (the sequence expresses preference) for production:
 

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -1151,8 +1151,12 @@ module.exports = {
               "self-managed/platform-deployment/helm-kubernetes/overview/"
             ),
             docsLink(
-              "Deployment",
-              "self-managed/platform-deployment/helm-kubernetes/deployment/"
+              "Deploy",
+              "self-managed/platform-deployment/helm-kubernetes/deploy/"
+            ),
+            docsLink(
+              "Upgrade",
+              "self-managed/platform-deployment/helm-kubernetes/upgrade/"
             ),
             {
               Platforms: [

--- a/sidebars.js
+++ b/sidebars.js
@@ -634,7 +634,8 @@ module.exports = {
         {
           "Helm/Kubernetes": [
             "self-managed/platform-deployment/helm-kubernetes/overview",
-            "self-managed/platform-deployment/helm-kubernetes/deployment",
+            "self-managed/platform-deployment/helm-kubernetes/deploy",
+            "self-managed/platform-deployment/helm-kubernetes/upgrade",
             {
               Platforms: [
                 "self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks",

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -9,7 +9,7 @@ Options -Indexes -MultiViews
 # Redirect pages - https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule
 
 # These redirects go from /next/ to /next/ and should be revisted when /next/ is removed from the sitemap
-RewriteRule ~docs/next/self-managed/platform-deployment/helm-kubernetes/deployment/(.*)$ /docs/next/self-managed/platform-deployment/helm-kubernetes/deploy/$1 [R=301,L]
+RewriteRule ^docs/next/self-managed/platform-deployment/helm-kubernetes/deployment/(.*)$ /docs/next/self-managed/platform-deployment/helm-kubernetes/deploy/$1 [R=301,L]
 RewriteRule ^docs/next/self-managed/platform-deployment/ingress-setup/(.*)$ /docs/next/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup/$1 [R=301,L]
 RewriteRule ^docs/next/self-managed/platform-deployment/local/(.*)$ /docs/next/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster/$1 [R=301,L]
 RewriteRule ^docs/next/self-managed/platform-deployment/openshift-helm/(.*)$ /docs/next/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift/$1 [R=301,L]

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -9,6 +9,7 @@ Options -Indexes -MultiViews
 # Redirect pages - https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule
 
 # These redirects go from /next/ to /next/ and should be revisted when /next/ is removed from the sitemap
+RewriteRule ~docs/next/self-managed/platform-deployment/helm-kubernetes/deployment/(.*)$ /docs/next/self-managed/platform-deployment/helm-kubernetes/deploy/$1 [R=301,L]
 RewriteRule ^docs/next/self-managed/platform-deployment/ingress-setup/(.*)$ /docs/next/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup/$1 [R=301,L]
 RewriteRule ^docs/next/self-managed/platform-deployment/local/(.*)$ /docs/next/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster/$1 [R=301,L]
 RewriteRule ^docs/next/self-managed/platform-deployment/openshift-helm/(.*)$ /docs/next/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift/$1 [R=301,L]


### PR DESCRIPTION
## What is the purpose of the change

Added upgrade steps before Helm chart `v8.0.13`, which requires moving the upgrade to its own page. 

## Are there related marketing activities

No.

## When should this change go live?

Before the Camunda Platform `8.1.0` release.

## PR Checklist

- [x] My changes are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory.
- [x] My changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.