### PR TITLE
feat: add upper-level section for backup and restore feature

### DIFF
--- a/docs/self-managed/backup-restore/backup-and-restore.md
+++ b/docs/self-managed/backup-restore/backup-and-restore.md
@@ -1,0 +1,7 @@
+---
+id: backup-and-restore
+title: "Backup & Restore"
+sidebar_label: "Backup & Restore"
+---
+
+## Backup & Restore

--- a/sidebars.js
+++ b/sidebars.js
@@ -977,6 +977,9 @@ module.exports = {
       "Zeebe Gateway": ["self-managed/zeebe-gateway-deployment/zeebe-gateway"],
     },
     {
+      "Backup & Restore": ["self-managed/backup-restore/backup-and-restore"],
+    },
+    {
       Troubleshooting: ["self-managed/troubleshooting/log-levels"],
     },
   ],


### PR DESCRIPTION
## What is the purpose of the change

Add the upper-level section for Backup and Restore docs, that will be filled by several teams.

## Are there related marketing activities

_Are there any marketing activities related to the related feature or component? If so, please briefly describe them._

## When should this change go live?

_Does this change need to be released before a certain date or milestone? If so, when?_

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
