### PR TITLE
feat: document zeebe pause and resume exporting management api

### DIFF
--- a/docs/self-managed/zeebe-deployment/operations/management-api.md
+++ b/docs/self-managed/zeebe-deployment/operations/management-api.md
@@ -4,21 +4,23 @@ title: "Management API"
 description: "Additional cluster management API"
 ---
 
-Besides the grpc api for process instance execution, Zeebe Gateway also exposes an HTTP endpoint for cluster management operations. This api is not expected to be used by a normal user, but by a privileged user such as a cluster administrator. It is thus exposed via a different port which is configured using configuration `server.port` (or via environment variable SERVER_PORT). By default, this is set to `9600`. The api is a custom endpoint available via [Spring boot actuators](https://docs.spring.io/spring-boot/docs/2.0.x/reference/html/production-ready-endpoints.html). For additional configurations such as security, please refer Spring Boot documentation.
+Besides the [gRPC API](/apis-clients/grpc.md) for process instance execution, Zeebe Gateway also exposes an HTTP endpoint for cluster management operations. This API is not expected to be used by a normal user, but by a privileged user such as a cluster administrator. It is exposed via a different port which is configured using configuration `server.port` (or via environment variable SERVER_PORT). By default, this is set to `9600`.
+
+The API is a custom endpoint available via [Spring boot actuators](https://docs.spring.io/spring-boot/docs/2.0.x/reference/html/production-ready-endpoints.html). For additional configurations such as security, please refer to the Spring Boot documentation.
 
 Following operations are available now:
 
 - [Rebalancing](/self-managed/zeebe-deployment/operations/rebalancing.md)
 - [Pause and Resume Exporting](#exporting-api)
 
-### Exporting API
+## Exporting API
 
-This is useful:
+This is used:
 
-- As a debugging tool
-- When taking a backup of Camunda Platform 8 (See [Backup & Restore](/self-managed/backup-restore/backup-and-restore.md))
+- As a debugging tool.
+- When taking a backup of Camunda Platform 8 (see [Backup & Restore](/self-managed/backup-restore/backup-and-restore.md)).
 
-#### Pause Exporting
+### Pause Exporting
 
 To pause exporting on all partitions, send the following request to the gateway's management endpoint.
 
@@ -28,12 +30,12 @@ POST actuator/exporting/pause
 
 When a successful response is received, all partitions have paused exporting. If the request fails, some partitions may have paused exporting. So it is important to either retry until success or revert the partial pause by resuming exporting.
 
-#### Resume Exporting
+### Resume Exporting
 
-After the exporting is paused, it must be resumed eventually. Otherwise, it could lead to the cluster being not available. To resume exporting, send the following request to the gateway's management endpoint.
+After the exporting is paused, it must be resumed eventually. Otherwise, it could lead to the cluster being unavailable. To resume exporting, send the following request to the gateway's management endpoint.
 
 ```
 POST actuator/exporting/resume
 ```
 
-When a successful response is received, all partitions have resumed exporting. If the request fails, only some partitions may have resumed exporting. So it is important to retry them until success.
+When a successful response is received, all partitions have resumed exporting. If the request fails, only some partitions may have resumed exporting, so it is important to retry them until successful.

--- a/docs/self-managed/zeebe-deployment/operations/management-api.md
+++ b/docs/self-managed/zeebe-deployment/operations/management-api.md
@@ -1,0 +1,39 @@
+---
+id: management-api
+title: "Management API"
+description: "Additional cluster management API"
+---
+
+Besides the grpc api for process instance execution, Zeebe Gateway also exposes an HTTP endpoint for cluster management operations. This api is not expected to be used by a normal user, but by a privileged user such as a cluster administrator. It is thus exposed via a different port which is configured using configuration `server.port` (or via environment variable SERVER_PORT). By default, this is set to `9600`. The api is a custom endpoint available via [Spring boot actuators](https://docs.spring.io/spring-boot/docs/2.0.x/reference/html/production-ready-endpoints.html). For additional configurations such as security, please refer Spring Boot documentation.
+
+Following operations are available now:
+
+- [Rebalancing](/self-managed/zeebe-deployment/operations/rebalancing.md)
+- [Pause and Resume Exporting](#exporting-api)
+
+### Exporting API
+
+This is useful:
+
+- As a debugging tool
+- When taking a backup of Camunda Platform 8 (See [Backup & Restore](/self-managed/backup-restore/backup-and-restore.md))
+
+#### Pause Exporting
+
+To pause exporting on all partitions, send the following request to the gateway's management endpoint.
+
+```
+POST actuator/exporting/pause
+```
+
+When a successful response is received, all partitions have paused exporting. If the request fails, some partitions may have paused exporting. So it is important to either retry until success or revert the partial pause by resuming exporting.
+
+#### Resume Exporting
+
+After the exporting is paused, it must be resumed eventually. Otherwise, it could lead to the cluster being not available. To resume exporting, send the following request to the gateway's management endpoint.
+
+```
+POST actuator/exporting/resume
+```
+
+When a successful response is received, all partitions have resumed exporting. If the request fails, only some partitions may have resumed exporting. So it is important to retry them until success.

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -1313,6 +1313,10 @@ module.exports = {
               "Backups",
               "self-managed/zeebe-deployment/operations/backups/"
             ),
+            docsLink(
+              "Management API",
+              "self-managed/zeebe-deployment/operations/management-api/"
+            ),
           ],
         },
       ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -701,6 +701,7 @@ module.exports = {
             "self-managed/zeebe-deployment/operations/disk-space",
             "self-managed/zeebe-deployment/operations/update-zeebe",
             "self-managed/zeebe-deployment/operations/rebalancing",
+            "self-managed/zeebe-deployment/operations/management-api",
             "self-managed/zeebe-deployment/operations/backups",
           ],
         },


### PR DESCRIPTION
## What is the purpose of the change

- Document pause/resume exporting api of Zeebe. This api is required for the C8 backup process.

## Are there related marketing activities

_Are there any marketing activities related to the related feature or component? If so, please briefly describe them._

## When should this change go live?

_Does this change need to be released before a certain date or milestone? If so, when?_

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
