### PR TITLE
Fix broken links in Java client docs

### DIFF
--- a/docs/apis-clients/java-client-examples/job-worker-open.md
+++ b/docs/apis-clients/java-client-examples/job-worker-open.md
@@ -16,7 +16,7 @@ description: "Let's analyze the prerequisites and code to open a job worker."
 
 ## JobWorkerCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/job/JobWorkerCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/job/JobWorkerCreator.java)
 
 ```java
         ...

--- a/docs/apis-clients/java-client-examples/process-deploy.md
+++ b/docs/apis-clients/java-client-examples/process-deploy.md
@@ -15,7 +15,7 @@ Run the Zeebe broker with endpoint `localhost:26500` (default).
 
 ## ProcessDeployer.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessDeployer.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessDeployer.java)
 
 ```java
 final DeploymentEvent deploymentEvent =

--- a/docs/apis-clients/java-client-examples/process-instance-create-with-result.md
+++ b/docs/apis-clients/java-client-examples/process-instance-create-with-result.md
@@ -11,7 +11,7 @@ description: "Let's analyze the prerequisites and code to create a process insta
 
 ## ProcessInstanceWithResultCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceWithResultCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceWithResultCreator.java)
 
 ```java
 final ProcessInstanceResult processInstanceResult =

--- a/docs/apis-clients/java-client-examples/process-instance-create.md
+++ b/docs/apis-clients/java-client-examples/process-instance-create.md
@@ -11,7 +11,7 @@ description: "Let's dive deeper into Zeebe and Java to create a process instance
 
 ## ProcessInstanceCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceCreator.java)
 
 ```java
 final ProcessInstanceEvent processInstanceEvent =

--- a/versioned_docs/version-1.1/components/clients/java-client-examples/job-worker-open.md
+++ b/versioned_docs/version-1.1/components/clients/java-client-examples/job-worker-open.md
@@ -16,7 +16,7 @@ description: "Let's analyze the prerequisites and code to open a job worker."
 
 ## JobWorkerCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/job/JobWorkerCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/job/JobWorkerCreator.java)
 
 ```java
         ...

--- a/versioned_docs/version-1.1/components/clients/java-client-examples/process-deploy.md
+++ b/versioned_docs/version-1.1/components/clients/java-client-examples/process-deploy.md
@@ -15,7 +15,7 @@ description: "Let's analyze the prerequisites and code to deploy a process using
 
 ## ProcessDeployer.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessDeployer.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessDeployer.java)
 
 ```java
 final DeploymentEvent deploymentEvent =

--- a/versioned_docs/version-1.1/components/clients/java-client-examples/process-instance-create-with-result.md
+++ b/versioned_docs/version-1.1/components/clients/java-client-examples/process-instance-create-with-result.md
@@ -11,7 +11,7 @@ description: "Let's analyze the prerequisites and code to create a process insta
 
 ## ProcessInstanceWithResultCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceWithResultCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceWithResultCreator.java)
 
 ```java
 final ProcessInstanceResult processInstanceResult =

--- a/versioned_docs/version-1.1/components/clients/java-client-examples/process-instance-create.md
+++ b/versioned_docs/version-1.1/components/clients/java-client-examples/process-instance-create.md
@@ -11,7 +11,7 @@ description: "Let's dive deeper into Zeebe and Java to create a process instance
 
 ## ProcessInstanceCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceCreator.java)
 
 ```java
 final ProcessInstanceEvent processInstanceEvent =

--- a/versioned_docs/version-1.2/apis-clients/java-client-examples/job-worker-open.md
+++ b/versioned_docs/version-1.2/apis-clients/java-client-examples/job-worker-open.md
@@ -16,7 +16,7 @@ description: "Let's analyze the prerequisites and code to open a job worker."
 
 ## JobWorkerCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/job/JobWorkerCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/job/JobWorkerCreator.java)
 
 ```java
         ...

--- a/versioned_docs/version-1.2/apis-clients/java-client-examples/process-deploy.md
+++ b/versioned_docs/version-1.2/apis-clients/java-client-examples/process-deploy.md
@@ -15,7 +15,7 @@ description: "Let's analyze the prerequisites and code to deploy a process using
 
 ## ProcessDeployer.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessDeployer.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessDeployer.java)
 
 ```java
 final DeploymentEvent deploymentEvent =

--- a/versioned_docs/version-1.2/apis-clients/java-client-examples/process-instance-create-with-result.md
+++ b/versioned_docs/version-1.2/apis-clients/java-client-examples/process-instance-create-with-result.md
@@ -11,7 +11,7 @@ description: "Let's analyze the prerequisites and code to create a process insta
 
 ## ProcessInstanceWithResultCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceWithResultCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceWithResultCreator.java)
 
 ```java
 final ProcessInstanceResult processInstanceResult =

--- a/versioned_docs/version-1.2/apis-clients/java-client-examples/process-instance-create.md
+++ b/versioned_docs/version-1.2/apis-clients/java-client-examples/process-instance-create.md
@@ -11,7 +11,7 @@ description: "Let's dive deeper into Zeebe and Java to create a process instance
 
 ## ProcessInstanceCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceCreator.java)
 
 ```java
 final ProcessInstanceEvent processInstanceEvent =

--- a/versioned_docs/version-1.3/apis-clients/java-client-examples/job-worker-open.md
+++ b/versioned_docs/version-1.3/apis-clients/java-client-examples/job-worker-open.md
@@ -16,7 +16,7 @@ description: "Let's analyze the prerequisites and code to open a job worker."
 
 ## JobWorkerCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/job/JobWorkerCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/job/JobWorkerCreator.java)
 
 ```java
         ...

--- a/versioned_docs/version-1.3/apis-clients/java-client-examples/process-deploy.md
+++ b/versioned_docs/version-1.3/apis-clients/java-client-examples/process-deploy.md
@@ -15,7 +15,7 @@ Run the Zeebe broker with endpoint `localhost:26500` (default).
 
 ## ProcessDeployer.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessDeployer.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessDeployer.java)
 
 ```java
 final DeploymentEvent deploymentEvent =

--- a/versioned_docs/version-1.3/apis-clients/java-client-examples/process-instance-create-with-result.md
+++ b/versioned_docs/version-1.3/apis-clients/java-client-examples/process-instance-create-with-result.md
@@ -11,7 +11,7 @@ description: "Let's analyze the prerequisites and code to create a process insta
 
 ## ProcessInstanceWithResultCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceWithResultCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceWithResultCreator.java)
 
 ```java
 final ProcessInstanceResult processInstanceResult =

--- a/versioned_docs/version-1.3/apis-clients/java-client-examples/process-instance-create.md
+++ b/versioned_docs/version-1.3/apis-clients/java-client-examples/process-instance-create.md
@@ -11,7 +11,7 @@ description: "Let's dive deeper into Zeebe and Java to create a process instance
 
 ## ProcessInstanceCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceCreator.java)
 
 ```java
 final ProcessInstanceEvent processInstanceEvent =

--- a/versioned_docs/version-8.0/apis-clients/java-client-examples/job-worker-open.md
+++ b/versioned_docs/version-8.0/apis-clients/java-client-examples/job-worker-open.md
@@ -16,7 +16,7 @@ description: "Let's analyze the prerequisites and code to open a job worker."
 
 ## JobWorkerCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/job/JobWorkerCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/job/JobWorkerCreator.java)
 
 ```java
         ...

--- a/versioned_docs/version-8.0/apis-clients/java-client-examples/process-deploy.md
+++ b/versioned_docs/version-8.0/apis-clients/java-client-examples/process-deploy.md
@@ -15,7 +15,7 @@ Run the Zeebe broker with endpoint `localhost:26500` (default).
 
 ## ProcessDeployer.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessDeployer.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessDeployer.java)
 
 ```java
 final DeploymentEvent deploymentEvent =

--- a/versioned_docs/version-8.0/apis-clients/java-client-examples/process-instance-create-with-result.md
+++ b/versioned_docs/version-8.0/apis-clients/java-client-examples/process-instance-create-with-result.md
@@ -11,7 +11,7 @@ description: "Let's analyze the prerequisites and code to create a process insta
 
 ## ProcessInstanceWithResultCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceWithResultCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceWithResultCreator.java)
 
 ```java
 final ProcessInstanceResult processInstanceResult =

--- a/versioned_docs/version-8.0/apis-clients/java-client-examples/process-instance-create.md
+++ b/versioned_docs/version-8.0/apis-clients/java-client-examples/process-instance-create.md
@@ -11,7 +11,7 @@ description: "Let's dive deeper into Zeebe and Java to create a process instance
 
 ## ProcessInstanceCreator.java
 
-[Source on GitHub](https://github.com/camunda-cloud/zeebe/tree/develop/samples/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceCreator.java)
+[Source on GitHub](https://github.com/camunda-community-hub/camunda-8-examples/blob/main/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/process/ProcessInstanceCreator.java)
 
 ```java
 final ProcessInstanceEvent processInstanceEvent =


### PR DESCRIPTION
## What is the purpose of the change

Fixes broken links on Java Client samples after the move of the sample repo. Closes #1340.

## PR Checklist

- [X] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [X] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
