### PR TITLE
feat(connector-sdk): release SDK version -> 0.2.0 to 0.2.2

### DIFF
--- a/docs/components/integration-framework/connectors/custom-built-connectors/connector-sdk.md
+++ b/docs/components/integration-framework/connectors/custom-built-connectors/connector-sdk.md
@@ -62,7 +62,7 @@ Ensure you adhere to the project outline detailed in the next section.
 <dependency>
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-core</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.2</version>
 </dependency>
 ```
 
@@ -71,7 +71,7 @@ Ensure you adhere to the project outline detailed in the next section.
 <TabItem value='gradle'>
 
 ```yml
-implementation 'io.camunda.connector:connector-core:0.2.0'
+implementation 'io.camunda.connector:connector-core:0.2.2'
 ```
 
 </TabItem>
@@ -341,7 +341,7 @@ Connector, add the following dependency to your project:
 <dependency>
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-validation</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.2</version>
 </dependency>
 ```
 
@@ -350,7 +350,7 @@ Connector, add the following dependency to your project:
 <TabItem value='gradle'>
 
 ```yml
-implementation 'io.camunda.connector:connector-validation:0.2.0'
+implementation 'io.camunda.connector:connector-validation:0.2.2'
 ```
 
 </TabItem>

--- a/versioned_docs/version-8.0/components/integration-framework/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.0/components/integration-framework/connectors/custom-built-connectors/connector-sdk.md
@@ -62,7 +62,7 @@ Ensure you adhere to the project outline detailed in the next section.
 <dependency>
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-core</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.2</version>
 </dependency>
 ```
 
@@ -71,7 +71,7 @@ Ensure you adhere to the project outline detailed in the next section.
 <TabItem value='gradle'>
 
 ```yml
-implementation 'io.camunda.connector:connector-core:0.2.0'
+implementation 'io.camunda.connector:connector-core:0.2.2'
 ```
 
 </TabItem>
@@ -341,7 +341,7 @@ Connector, add the following dependency to your project:
 <dependency>
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-validation</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.2</version>
 </dependency>
 ```
 
@@ -350,7 +350,7 @@ Connector, add the following dependency to your project:
 <TabItem value='gradle'>
 
 ```yml
-implementation 'io.camunda.connector:connector-validation:0.2.0'
+implementation 'io.camunda.connector:connector-validation:0.2.2'
 ```
 
 </TabItem>


### PR DESCRIPTION
## What is the purpose of the change

Adjust SDK versions in the public SDK documentation (versions 8.0 and 8.1)

## When should this change go live?
 ----

## Related to
https://github.com/camunda/team-connectors/issues/153
https://github.com/camunda/camunda-platform-docs/issues/1360

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
