### PR TITLE
feat(modeler/bpmn): document candidate users for Assignments

### DIFF
--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -38,7 +38,7 @@ attributes can be specified simultaneously:
 - `candidateUsers`: Specifies the users that the task can be assigned to.
 - `candidateGroups`: Specifies the groups of users that the task can be assigned to.
 
-Typically, the assignee, candidate users and candidate groups are defined as static values (e.g. `some_username`, `some_username, another_username` and
+Typically, the assignee, candidate users, and candidate groups are defined as static values (e.g. `some_username`, `some_username, another_username` and
 `sales, operations`), but they can also be defined as
 [expressions](/components/concepts/expressions.md) (e.g. `= book.author` and `= remove(reviewers, book.author)` and `= reviewer_roles`). The expressions are evaluated on activating the user task and must result in a
 `string` for the assignee and a `list of strings` for the candidate users and a `list of strings` for the candidate groups.

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -35,12 +35,13 @@ This can be used to define which user the task can be assigned to. One or both o
 attributes can be specified simultaneously:
 
 - `assignee`: Specifies the user assigned to the task. [Tasklist](/components/tasklist/introduction-to-tasklist.md) will claim the task for this user.
+- `candidateUsers`: Specifies the users that the task can be assigned to.
 - `candidateGroups`: Specifies the groups of users that the task can be assigned to.
 
-Typically, the assignee and candidate groups are defined as static values (e.g. `some_username` and
+Typically, the assignee, candidate users and candidate groups are defined as static values (e.g. `some_username` and
 `sales, operations`), but they can also be defined as
-[expressions](/components/concepts/expressions.md) (e.g. `= book.author` and `= remove(reviewers, book.author)`). The expressions are evaluated on activating the user task and must result in a
-`string` for the assignee and a `list of strings` for the candidate groups.
+[expressions](/components/concepts/expressions.md) (e.g. `= book.author` and `= reviewers` and `= remove(reviewers, book.author)`). The expressions are evaluated on activating the user task and must result in a
+`string` for the assignee and a `list of strings` for the candidate users and a `list of strings` for the candidate groups.
 
 For [Tasklist](/components/tasklist/introduction-to-tasklist.md) to claim the task for a known Tasklist user,
 the value of the `assignee` must be the user's **unique identifier**.

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -38,9 +38,9 @@ attributes can be specified simultaneously:
 - `candidateUsers`: Specifies the users that the task can be assigned to.
 - `candidateGroups`: Specifies the groups of users that the task can be assigned to.
 
-Typically, the assignee, candidate users and candidate groups are defined as static values (e.g. `some_username` and
+Typically, the assignee, candidate users and candidate groups are defined as static values (e.g. `some_username`, `some_username, another_username` and
 `sales, operations`), but they can also be defined as
-[expressions](/components/concepts/expressions.md) (e.g. `= book.author` and `= reviewers` and `= remove(reviewers, book.author)`). The expressions are evaluated on activating the user task and must result in a
+[expressions](/components/concepts/expressions.md) (e.g. `= book.author` and `= remove(reviewers, book.author)` and `= reviewer_roles`). The expressions are evaluated on activating the user task and must result in a
 `string` for the assignee and a `list of strings` for the candidate users and a `list of strings` for the candidate groups.
 
 For [Tasklist](/components/tasklist/introduction-to-tasklist.md) to claim the task for a known Tasklist user,


### PR DESCRIPTION
## What is the purpose of the change
As a user I would like to specify task candidate-users for user tasks.

closes #1370 

## Are there related marketing activities
No.

## When should this change go live?
No need to hurry. Maybe 8.2?


## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @korthout as a reviewer.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
