### PR TITLE
docs: mention all none-events support variable output mapping

### DIFF
--- a/docs/components/modeler/bpmn/none-events/none-events.md
+++ b/docs/components/modeler/bpmn/none-events/none-events.md
@@ -28,7 +28,7 @@ The engine itself doesn't do anything in the event, it just passes through it.
 
 ## Variable mappings
 
-Start and intermediate none events can have [variable output mappings](../../../../components/concepts/variables.md#output-mappings). End events do not support this.
+All none events can have [variable output mappings](../../../../components/concepts/variables.md#output-mappings).
 
 For start events, this is often used to initialize process variables.
 


### PR DESCRIPTION
Signed-off-by: Anurag Pathak <anuragpathak911@gmail.com>

## What is the purpose of the change
fixes #1362 

The PR updates the documentation for the next release to reflect the changes of https://github.com/camunda/zeebe/pull/10618.

## Are there related marketing activities

No.

## When should this change go live?

Next minor release.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
