### PR TITLE
chore(typo): Fix grammar and missing Oxford Comma

### DIFF
--- a/versioned_docs/version-8.1/components/best-practices/best-practices-overview.md
+++ b/versioned_docs/version-8.1/components/best-practices/best-practices-overview.md
@@ -2,14 +2,14 @@
 title: Overview
 ---
 
-The Camunda best practices are our condensed experience of using BPMN and DMN on the Camunda toolstack, and collected by consulting engagement with our customers, feedback from the community and various other occasions. Best Practices are a mix of conceptual and practical implementation information.
+The Camunda Best Practices are our condensed experience of using BPMN and DMN on the Camunda toolstack, and collected by consulting engagement with our customers, feedback from the community, and various other occasions. Best Practices are a mix of conceptual and practical implementation information.
 
 Best Practices represent the current state of our practical project experience as far as it is generalizable. They are neither "final" (in the sense that we ourselves will hopefully continue to learn!) nor are they necessarily the best approach for your own situation.
 
-Note that Camunda give the same guarantee as the core product for best practices. In order to present as much experiences as possible, we cannot accept any responsibility for the accuracy or timeliness of the statements made. If examples of source code are shown, a total absence of errors in the provided source code cannot be guaranteed. Liability for any damage resulting from the application of the recommendations presented here, is excluded.
+Note that Camunda gives the same guarantee as the core product for best practices. In order to present as much experiences as possible, we cannot accept any responsibility for the accuracy or timeliness of the statements made. If examples of source code are shown, a total absence of errors in the provided source code cannot be guaranteed. Liability for any damage resulting from the application of the recommendations presented here, is excluded.
 
 :::caution Camunda Platform 8
-In general, best practices apply to Camunda Platform 8, but there are also some specific Camunda Platform 7 practices in their own section below.
+In general, Camunda Best Practices apply to Camunda Platform 8, but there are also some specific Camunda Platform 7 practices in their own section below.
 :::
 
 ## Project management best practices


### PR DESCRIPTION
I hope it is perfectly fine to ignore the template for these trivial typo fixes.
