### PR TITLE
fix: correct element template documentation link

### DIFF
--- a/docs/components/modeler/desktop-modeler/element-templates/element-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/element-templates.md
@@ -23,4 +23,4 @@ As seen in the _Mail Task_ example above, Modeler allows properties of custom el
 
 Refer to the following resources to learn more about element templates:
 
-- [Element template documentation](https://docs.camunda.io/docs/next/components/modeler/desktop-modeler/element-templates/about-templates/)
+- [Element template documentation](/components/modeler/desktop-modeler/element-templates/about-templates.md)

--- a/docs/components/modeler/desktop-modeler/element-templates/element-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/element-templates.md
@@ -23,4 +23,4 @@ As seen in the _Mail Task_ example above, Modeler allows properties of custom el
 
 Refer to the following resources to learn more about element templates:
 
-- [Element template documentation](https://github.com/camunda/desktop-modeler/tree/master/docs/element-templates)
+- [Element template documentation](https://docs.camunda.io/docs/next/components/modeler/desktop-modeler/element-templates/about-templates/)

--- a/docs/components/modeler/desktop-modeler/element-templates/element-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/element-templates.md
@@ -23,4 +23,4 @@ As seen in the _Mail Task_ example above, Modeler allows properties of custom el
 
 Refer to the following resources to learn more about element templates:
 
-- [Element template documentation](/components/modeler/desktop-modeler/element-templates/about-templates.md)
+- [Element template documentation](/components/modeler/desktop-modeler/element-templates/element-templates.md)

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -215,6 +215,10 @@ module.exports = {
             {
               "Element templates": [
                 docsLink(
+                  "Element templates",
+                  "components/modeler/desktop-modeler/element-templates/element-templates"
+                ),
+                docsLink(
                   "About element templates",
                   "components/modeler/desktop-modeler/element-templates/about-templates/"
                 ),

--- a/optimize_versioned_sidebars/version-3.8.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.8.0-sidebars.json
@@ -276,6 +276,11 @@
               "Element templates": [
                 {
                   "type": "link",
+                  "label": "Element templates",
+                  "href": "/docs/8.0/components/modeler/desktop-modeler/element-templates/element-templates"
+                },
+                {
+                  "type": "link",
                   "label": "About element templates",
                   "href": "/docs/8.0/components/modeler/desktop-modeler/element-templates/about-templates/"
                 },

--- a/optimize_versioned_sidebars/version-3.9.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.9.0-sidebars.json
@@ -270,6 +270,11 @@
               "Element templates": [
                 {
                   "type": "link",
+                  "label": "Element templates",
+                  "href": "/docs/8.0/components/modeler/desktop-modeler/element-templates/element-templates"
+                },
+                {
+                  "type": "link",
                   "label": "About element templates",
                   "href": "/docs/components/modeler/desktop-modeler/element-templates/about-templates/"
                 },

--- a/sidebars.js
+++ b/sidebars.js
@@ -132,7 +132,7 @@ module.exports = {
             "components/modeler/desktop-modeler/start-instance",
             {
               "Element templates": [
-                "components/modeler/desktop-modeler/element-templates/element-templates",
+                "components/modeler/desktop-modeler/element-templates/desktop-modeler-element-templates",
                 "components/modeler/desktop-modeler/element-templates/about-templates",
                 "components/modeler/desktop-modeler/element-templates/configuring-templates",
                 "components/modeler/desktop-modeler/element-templates/using-templates",

--- a/sidebars.js
+++ b/sidebars.js
@@ -132,6 +132,7 @@ module.exports = {
             "components/modeler/desktop-modeler/start-instance",
             {
               "Element templates": [
+                "components/modeler/desktop-modeler/element-templates/element-templates",
                 "components/modeler/desktop-modeler/element-templates/about-templates",
                 "components/modeler/desktop-modeler/element-templates/configuring-templates",
                 "components/modeler/desktop-modeler/element-templates/using-templates",

--- a/versioned_docs/version-8.0/components/modeler/desktop-modeler/element-templates/element-templates.md
+++ b/versioned_docs/version-8.0/components/modeler/desktop-modeler/element-templates/element-templates.md
@@ -23,4 +23,4 @@ As seen in the _Mail Task_ example above, Modeler allows properties of custom el
 
 Refer to the following resources to learn more about element templates:
 
-- [Element template documentation](https://github.com/camunda/desktop-modeler/tree/master/docs/element-templates)
+- [Element template documentation](/components/modeler/desktop-modeler/element-templates/about-templates.md)

--- a/versioned_docs/version-8.0/components/modeler/desktop-modeler/element-templates/element-templates.md
+++ b/versioned_docs/version-8.0/components/modeler/desktop-modeler/element-templates/element-templates.md
@@ -23,4 +23,4 @@ As seen in the _Mail Task_ example above, Modeler allows properties of custom el
 
 Refer to the following resources to learn more about element templates:
 
-- [Element template documentation](/components/modeler/desktop-modeler/element-templates/about-templates.md)
+- [Element template documentation](/components/modeler/desktop-modeler/element-templates/element-templates.md)

--- a/versioned_docs/version-8.1/components/modeler/desktop-modeler/element-templates/element-templates.md
+++ b/versioned_docs/version-8.1/components/modeler/desktop-modeler/element-templates/element-templates.md
@@ -23,4 +23,4 @@ As seen in the _Mail Task_ example above, Modeler allows properties of custom el
 
 Refer to the following resources to learn more about element templates:
 
-- [Element template documentation](https://github.com/camunda/desktop-modeler/tree/master/docs/element-templates)
+- [Element template documentation](/components/modeler/desktop-modeler/element-templates/about-templates.md)

--- a/versioned_docs/version-8.1/components/modeler/desktop-modeler/element-templates/element-templates.md
+++ b/versioned_docs/version-8.1/components/modeler/desktop-modeler/element-templates/element-templates.md
@@ -23,4 +23,4 @@ As seen in the _Mail Task_ example above, Modeler allows properties of custom el
 
 Refer to the following resources to learn more about element templates:
 
-- [Element template documentation](/components/modeler/desktop-modeler/element-templates/about-templates.md)
+- [Element template documentation](/components/modeler/desktop-modeler/element-templates/element-templates.md)

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -122,7 +122,7 @@
             "components/modeler/desktop-modeler/start-instance",
             {
               "Element templates": [
-                "components/modeler/desktop-modeler/element-templates/element-templates",
+                "components/modeler/desktop-modeler/element-templates/desktop-modeler-element-templates",
                 "components/modeler/desktop-modeler/element-templates/about-templates",
                 "components/modeler/desktop-modeler/element-templates/configuring-templates",
                 "components/modeler/desktop-modeler/element-templates/using-templates",

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -122,6 +122,7 @@
             "components/modeler/desktop-modeler/start-instance",
             {
               "Element templates": [
+                "components/modeler/desktop-modeler/element-templates/element-templates",
                 "components/modeler/desktop-modeler/element-templates/about-templates",
                 "components/modeler/desktop-modeler/element-templates/configuring-templates",
                 "components/modeler/desktop-modeler/element-templates/using-templates",

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -124,6 +124,7 @@
             "components/modeler/desktop-modeler/start-instance",
             {
               "Element templates": [
+                "components/modeler/desktop-modeler/element-templates/element-templates",
                 "components/modeler/desktop-modeler/element-templates/about-templates",
                 "components/modeler/desktop-modeler/element-templates/configuring-templates",
                 "components/modeler/desktop-modeler/element-templates/using-templates",

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -124,7 +124,7 @@
             "components/modeler/desktop-modeler/start-instance",
             {
               "Element templates": [
-                "components/modeler/desktop-modeler/element-templates/element-templates",
+                "components/modeler/desktop-modeler/element-templates/desktop-modeler-element-templates",
                 "components/modeler/desktop-modeler/element-templates/about-templates",
                 "components/modeler/desktop-modeler/element-templates/configuring-templates",
                 "components/modeler/desktop-modeler/element-templates/using-templates",


### PR DESCRIPTION
## What is the purpose of the change

Documentation was ported to the docs itself, the old link is broken.


## Are there related marketing activities

No.

## When should this change go live?

Any time. This is a bug fix.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
