### PR TITLE
Add note about critical issue in Operate 8.1 to update guide

### DIFF
--- a/docs/guides/update-guide/800-to-810.md
+++ b/docs/guides/update-guide/800-to-810.md
@@ -27,3 +27,11 @@ Deprecated properties:
 :::note
 You can set the list of broker addresses here to make the start process of the Zeebe gateway more resilient. Refer to [the Zeebe gateway's configuration guide](../../../self-managed/zeebe-gateway-deployment/zeebe-gateway/#cluster-configuration) for more details.
 :::
+
+### Operate
+
+:::caution
+A critical issue was found on Operate data importer which may lead to incidents not being imported to Operate.
+This issue is affecting only Operate installations which where updated from 8.0, and not new installations of Operate.
+We strongly recommend to **not** update existing Operate 8.0 installations until a new patch release of Operate is available.
+:::

--- a/versioned_docs/version-8.1/guides/update-guide/800-to-810.md
+++ b/versioned_docs/version-8.1/guides/update-guide/800-to-810.md
@@ -27,3 +27,11 @@ Deprecated properties:
 :::note
 You can set the list of broker addresses here to make the start process of the Zeebe gateway more resilient. Refer to [the Zeebe gateway's configuration guide](../../../self-managed/zeebe-gateway-deployment/zeebe-gateway/#cluster-configuration) for more details.
 :::
+
+### Operate
+
+:::caution
+A critical issue was found on Operate data importer which may lead to incidents not being imported to Operate.
+This issue is affecting only Operate installations which where updated from 8.0, and not new installations of Operate.
+We strongly recommend to **not** update existing Operate 8.0 installations until a new patch release of Operate is available.
+:::


### PR DESCRIPTION
## What is the purpose of the change

Add a note to the update guides to inform users that we do not recommend from 8.0 to 8.1 at this point in time.

## Are there related marketing activities

no

## When should this change go live?

asap

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
