### PR TITLE
chore: add newer optimize update guides to sidebars

### DIFF
--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -1519,6 +1519,8 @@ module.exports = {
         {
           "Migration & update": [
             "self-managed/optimize-deployment/migration-update/instructions",
+            "self-managed/optimize-deployment/migration-update/3.9-preview-1-to-3.9",
+            "self-managed/optimize-deployment/migration-update/3.8-to-3.9-preview-1",
             "self-managed/optimize-deployment/migration-update/3.7-to-3.8",
             "self-managed/optimize-deployment/migration-update/3.6-to-3.7",
             "self-managed/optimize-deployment/migration-update/3.5-to-3.6",

--- a/optimize_versioned_sidebars/version-3.8.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.8.0-sidebars.json
@@ -1863,6 +1863,7 @@
         {
           "Migration & update": [
             "self-managed/optimize-deployment/migration-update/instructions",
+            "self-managed/optimize-deployment/migration-update/3.8-to-3.9-preview-1",
             "self-managed/optimize-deployment/migration-update/3.7-to-3.8",
             "self-managed/optimize-deployment/migration-update/3.6-to-3.7",
             "self-managed/optimize-deployment/migration-update/3.5-to-3.6",

--- a/optimize_versioned_sidebars/version-3.9.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.9.0-sidebars.json
@@ -1948,6 +1948,8 @@
         {
           "Migration & update": [
             "self-managed/optimize-deployment/migration-update/instructions",
+            "self-managed/optimize-deployment/migration-update/3.9-preview-1-to-3.9",
+            "self-managed/optimize-deployment/migration-update/3.8-to-3.9-preview-1",
             "self-managed/optimize-deployment/migration-update/3.7-to-3.8",
             "self-managed/optimize-deployment/migration-update/3.6-to-3.7",
             "self-managed/optimize-deployment/migration-update/3.5-to-3.6",

--- a/sidebars.js
+++ b/sidebars.js
@@ -874,6 +874,14 @@ module.exports = {
               "self-managed/optimize-deployment/migration-update/instructions/"
             ),
             optimizeLink(
+              "Update notes (3.9.x-preview-x to 3.9.x)",
+              "self-managed/optimize-deployment/migration-update/3.9-preview-1-to-3.9/"
+            ),
+            optimizeLink(
+              "Update notes (3.8.x to 3.9.x-preview-1)",
+              "self-managed/optimize-deployment/migration-update/3.8-to-3.9-preview-1/"
+            ),
+            optimizeLink(
               "Update notes (3.7.x to 3.8.x)",
               "self-managed/optimize-deployment/migration-update/3.7-to-3.8/"
             ),

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -1002,6 +1002,11 @@
             },
             {
               "type": "link",
+              "label": "Update notes (3.8.x to 3.9.x-preview-1)",
+              "href": "/optimize/3.8.0/self-managed/optimize-deployment/migration-update/3.8-to-3.9-preview-1/"
+            },
+            {
+              "type": "link",
               "label": "Update notes (3.7.x to 3.8.x)",
               "href": "/optimize/3.8.0/self-managed/optimize-deployment/migration-update/3.7-to-3.8/"
             },

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -1041,6 +1041,16 @@
             },
             {
               "type": "link",
+              "label": "Update notes (3.9.x-preview-x to 3.9.x)",
+              "href": "/optimize/self-managed/optimize-deployment/migration-update/3.9-preview-1-to-3.9/"
+            },
+            {
+              "type": "link",
+              "label": "Update notes (3.8.x to 3.9.x-preview-1)",
+              "href": "/optimize/self-managed/optimize-deployment/migration-update/3.8-to-3.9-preview-1/"
+            },
+            {
+              "type": "link",
               "label": "Update notes (3.7.x to 3.8.x)",
               "href": "/optimize/self-managed/optimize-deployment/migration-update/3.7-to-3.8/"
             },


### PR DESCRIPTION
## What is the purpose of the change

Adds the 3.8-to-3.9-preview and 3.9-preview-to-3.9 update guides to the sidebar navigation.

cc @andromaqui 

### Follow-up work

We do have [docs on adding new pages](https://github.com/camunda/camunda-platform-docs/blob/f46fa75d646a380f67a3918a5ea6fae6d522a038/howtos/documentation-guidelines.md#adding-a-new-documentation-page), and it does mention adding to `sidebars` files, but (a) it's outdated and doesn't include info about `optimize_sidebars`, and (b) it's easy to overlook. I have it on my list to update this guide today to at least bring it up to date.

## Are there related marketing activities

No

## When should this change go live?

Soon!

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
