### PR TITLE
feat(api-clients/grpc): add variables argument for FailJob gRPC

### DIFF
--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -395,7 +395,7 @@ Returned if:
 Marks the job as failed. If the retries argument is positive and no retry back off is set, the job is immediately
 activatable again. If the retry back off is positive the job becomes activatable once the back off timeout has passed.
 If the retries argument is zero or negative, an incident is raised, tagged with the given errorMessage, and the job is
-not activatable until the incident is resolved. If the variables argument is set, the given valid JSON document will be set locally to the job element.
+not activatable until the incident is resolved. If the variables argument is set, the variables are merged into the process at the local scope of the job's associated task.
 
 #### Input: `FailJobRequest`
 

--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -395,7 +395,7 @@ Returned if:
 Marks the job as failed. If the retries argument is positive and no retry back off is set, the job is immediately
 activatable again. If the retry back off is positive the job becomes activatable once the back off timeout has passed.
 If the retries argument is zero or negative, an incident is raised, tagged with the given errorMessage, and the job is
-not activatable until the incident is resolved.
+not activatable until the incident is resolved. If the variables argument is set, the given valid JSON document will be set locally to the job element.
 
 #### Input: `FailJobRequest`
 
@@ -411,6 +411,12 @@ message FailJobRequest {
   string errorMessage = 3;
   // the backoff timeout (in ms) for the next retry
   int64 retryBackOff = 4;
+  // JSON document that will instantiate the variables at the local scope of the
+  // job's associated task; it must be a JSON object, as variables will be mapped in a
+  // key-value fashion. e.g. { "a": 1, "b": 2 } will create two variables, named "a" and
+  // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
+  // valid argument, as the root of the JSON document is an array and not an object.
+  string variables = 5;
 }
 ```
 

--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -72,6 +72,11 @@ This could be useful when a job worker communicates with an external system. If 
 This will result in an incident when the retries run out. Using the `retry back off` will delay the retry. This allows the external system some time to recover.
 If no `retry back off` the job is immediately retried.
 
+When `Completing or failing jobs` with [variables](components/concepts/variables.md), the variables are merged into the process at the job's associated task.
+
+- When `Completing a job` the variables are propagated from the scope of the task to its higher scopes.
+- When `Failing a job` the variables are only created in the local scope of the task.
+
 ## Timeouts
 
 If the job is not completed or failed within the configured job activation timeout, Zeebe reassigns the job to another job worker. This does not affect the number of `remaining retries`.


### PR DESCRIPTION
## What is the purpose of the change

Add variables argument for FailJob gRPC.

closes #1387 

## Are there related marketing activities

No.

## When should this change go live?

May be C8.2.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
