### PR TITLE
Update Guide changes related to 8.1.1 import issue

### DIFF
--- a/docs/guides/update-guide/800-to-810.md
+++ b/docs/guides/update-guide/800-to-810.md
@@ -33,5 +33,7 @@ You can set the list of broker addresses here to make the start process of the Z
 :::caution
 A critical issue was found on Operate data importer which may lead to incidents not being imported to Operate.
 This issue is affecting only Operate installations which where updated from 8.0, and not new installations of Operate.
-We strongly recommend to **not** update existing Operate 8.0 installations until a new patch release of Operate is available.
+When updating, it is recommended that you skip versions 8.1.0 and update directly to 8.1.1.
+
+Please refer to the [release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.1) for more.
 :::

--- a/versioned_docs/version-8.1/guides/update-guide/800-to-810.md
+++ b/versioned_docs/version-8.1/guides/update-guide/800-to-810.md
@@ -33,5 +33,7 @@ You can set the list of broker addresses here to make the start process of the Z
 :::caution
 A critical issue was found on Operate data importer which may lead to incidents not being imported to Operate.
 This issue is affecting only Operate installations which where updated from 8.0, and not new installations of Operate.
-We strongly recommend to **not** update existing Operate 8.0 installations until a new patch release of Operate is available.
+When updating, it is recommended that you skip versions 8.1.0 and update directly to 8.1.1.
+
+Please refer to the [release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.1) for more.
 :::


### PR DESCRIPTION
## What is the purpose of the change

Updated warning text in Update Guide to now point users to 8.1.1 version to use when updating from 8.0