### PR TITLE
docs(identity): add step to set keycloak realm when connecting to an existing keycloak instance

### DIFF
--- a/docs/self-managed/identity/user-guide/connect-to-an-existing-keycloak.md
+++ b/docs/self-managed/identity/user-guide/connect-to-an-existing-keycloak.md
@@ -59,7 +59,14 @@ Identity is designed to allow users to manage the various entities related to th
 
 10. Set the `IDENTITY_CLIENT_SECRET` [environment variable](/docs/self-managed/identity/deployment/configuration-variables.md) with the value from step 9.
 
-11. Start the Identity application.
+11. Set the `KEYCLOAK_REALM` [environment variable](/docs/self-managed/identity/deployment/configuration-variables.md) to the realm you selected in step 2.
+
+:::tip
+Identity provides default values for required variables, if you are using a specific realm you may need to also set additional variables to use the intended realm.
+See the [environment variables](/docs/self-managed/identity/deployment/configuration-variables.md) page for details of Keycloak specific variables to consider.
+:::
+
+12. Start the Identity application.
 
 :::note What does Identity create when starting?
 The Identity application creates a base set of configurations required to function successfully. To understand more about what is created and why, see [the starting configuration](/docs/self-managed/identity/deployment/starting-configuration.md).

--- a/docs/self-managed/identity/user-guide/connect-to-an-existing-keycloak.md
+++ b/docs/self-managed/identity/user-guide/connect-to-an-existing-keycloak.md
@@ -62,7 +62,7 @@ Identity is designed to allow users to manage the various entities related to th
 11. Set the `KEYCLOAK_REALM` [environment variable](/docs/self-managed/identity/deployment/configuration-variables.md) to the realm you selected in step 2.
 
 :::tip
-Identity provides default values for required variables, if you are using a specific realm you may need to also set additional variables to use the intended realm.
+If you are using a specific realm you need to also set additional variables to use the intended realm.
 See the [environment variables](/docs/self-managed/identity/deployment/configuration-variables.md) page for details of Keycloak specific variables to consider.
 :::
 

--- a/versioned_docs/version-8.1/self-managed/identity/user-guide/connect-to-an-existing-keycloak.md
+++ b/versioned_docs/version-8.1/self-managed/identity/user-guide/connect-to-an-existing-keycloak.md
@@ -59,7 +59,14 @@ Identity is designed to allow users to manage the various entities related to th
 
 10. Set the `IDENTITY_CLIENT_SECRET` [environment variable](/docs/self-managed/identity/deployment/configuration-variables.md) with the value from step 9.
 
-11. Start the Identity application.
+11. Set the `KEYCLOAK_REALM` [environment variable](/docs/self-managed/identity/deployment/configuration-variables.md) to the realm you selected in step 2.
+
+:::tip
+Identity provides default values for required variables, if you are using a specific realm you may need to also set additional variables to use the intended realm.
+See the [environment variables](/docs/self-managed/identity/deployment/configuration-variables.md) page for details of Keycloak specific variables to consider.
+:::
+
+12. Start the Identity application.
 
 :::note What does Identity create when starting?
 The Identity application creates a base set of configurations required to function successfully. To understand more about what is created and why, see [the starting configuration](/docs/self-managed/identity/deployment/starting-configuration.md).

--- a/versioned_docs/version-8.1/self-managed/identity/user-guide/connect-to-an-existing-keycloak.md
+++ b/versioned_docs/version-8.1/self-managed/identity/user-guide/connect-to-an-existing-keycloak.md
@@ -62,7 +62,7 @@ Identity is designed to allow users to manage the various entities related to th
 11. Set the `KEYCLOAK_REALM` [environment variable](/docs/self-managed/identity/deployment/configuration-variables.md) to the realm you selected in step 2.
 
 :::tip
-Identity provides default values for required variables, if you are using a specific realm you may need to also set additional variables to use the intended realm.
+If you are using a specific realm you need to also set additional variables to use the intended realm.
 See the [environment variables](/docs/self-managed/identity/deployment/configuration-variables.md) page for details of Keycloak specific variables to consider.
 :::
 


### PR DESCRIPTION
## What is the purpose of the change
Whilst working recently with @mschoe I realised that the documentation around connecting to an existing Keycloak instance was a little unclear with regards to setting the realm variable, this variable is an important consideration for this task and could easily cause confusion if not mentioned.

Given this, I have decided to add a step specifically to handle the realm setting as it should be a part of the defined process.

## Are there related marketing activities

None :) 

## When should this change go live?

This functionality is already live therefore this can be released whenever

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
