### PR TITLE
docs(self-managed): Add guide for air-gapped installation

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -1,0 +1,147 @@
+---
+id: air-gapped-installation
+title: "Installing in an air-gapped environment"
+description: "Camunda Platform 8 Self-Managed installation in an air-gapped environment"
+---
+
+Also in an air-gapped environment, one would like to profit from the [Camunda Platform Helm chart](../../helm-kubernetes/deploy.md). By default the images are fetched via docker hub.
+With the dependencies to third-party images and helm charts, additional steps are required to have all charts available.
+
+## Required Images
+
+The following images must be available in your air-gapped environment:
+
+- [camunda/zeebe](https://hub.docker.com/r/camunda/zeebe)
+- [camunda/operate](https://hub.docker.com/r/camunda/operate)
+- [camunda/tasklist](https://hub.docker.com/r/camunda/tasklist)
+- [camunda/optimize](https://hub.docker.com/r/camunda/optimize)
+- [camunda/identity](https://hub.docker.com/r/camunda/identity)
+- [postgres](https://hub.docker.com/_/postgres)
+- [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak)
+- [elasticsearch](https://hub.docker.com/_/elasticsearch)
+
+## Required Helm Charts
+
+The following charts must be available in your air-gapped environment:
+
+- [Camunda Platform Helm Chart](https://github.com/camunda/camunda-platform-helm)
+- [Elasticsearch Helm Chart](https://github.com/elastic/helm-charts/tree/main/elasticsearch)
+- [Keycloak Helm Chart](https://github.com/bitnami/charts/tree/master/bitnami/keycloak)
+- [Postgres Helm Chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql/)
+
+## Dependencies explained
+
+Identity utilizes Keycloak and allows you to manage users, roles, and permissions for Camunda Platform 8 components. This third-party dependency is reflected in the Helm Chart as follows:
+
+```
+camunda-platform
+    |_ elasticsearch
+    |_ identity
+        |_ keycloak
+            |_ postgresql
+    |_ zeebe
+    |_ optimize
+    |_ operate
+    |_ tasklist
+```
+
+- Keycloak is a dependency for Camunda Identity and PostgreSQL is a dependency for Keycloak.
+- Elasticsearch is a dependency for Zeebe, Operate, Tasklist and Optimize.
+
+The values for the dependencies Keycloak and PostgreSQL can be set in the same hierarchy.
+
+```yaml
+identity:
+  [identity values]
+  keycloak:
+    [keycloak values]
+    postgresql:
+      [postgresql values]
+```
+
+## Push Images to your repository
+
+All the [required images](#required-images) need to be pushed to your repository.
+
+1. Tag your image using the following command (replace `<IMAGE ID>`, `<DOCKER REPOSITORY>` and `<DOCKER TAG>` with the corresponding values)
+
+```
+docker tag <IMAGE_ID> example.jfrog.io/camunda/<DOCKER_IMAGE>:<DOCKER_TAG>
+```
+
+2. Push your image using the following command
+
+```
+docker push example.jfrog.io/camunda/<DOCKER_IMAGE>:<DOCKER_TAG>
+```
+
+## Deploy Helm Charts to your repository
+
+You have to deploy the [required Helm Charts](#required-helm-charts) to your repository.
+E.g. In JFrog you can do it via the Artifactory's REST API.
+
+```
+curl -u <USER>:<PASSWORD> -T <PATH_TO_FILE> "https://example.jfrog.io/artifactory/camunda-platform/<TARGET_FILE_PATH>"
+```
+
+Alternatively, you can setup remote repositories (e.g. with url: https://helm.camunda.io for Camunda Charts, https://helm.elastic.co for Elastic)
+
+### Add your Helm repositories
+
+You have to add your Helm chart repositories in order to use the charts.
+
+```
+helm repo add camunda https://example.jfrog.io/artifactory/api/helm/camunda-platform
+helm repo add elastic https://example.jfrog.io/artifactory/api/helm/elastic
+helm repo add bitnami https://example.jfrog.io/artifactory/api/helm/bitnami
+helm repo update
+```
+
+### Helm Chart values
+
+In a custom values file, it is possible to override the image repository and the image tag.
+
+```yaml
+zeebe:
+  image:
+    repository: example.jfrog.io/camunda/zeebe
+    # e.g. work with the latest versions in development
+    tag: latest
+zeebe-gateway:
+  image:
+    repository: example.jfrog.io/camunda/zeebe
+    tag: latest
+elasticsearch:
+  image: example.jfrog.io/elastic/elasticsearch
+  imageTag: 7.16.3
+identity:
+  image:
+    repository: example.jfrog.io/camunda/identity
+    ...
+  keycloak:
+    image:
+      repository: example.jfrog.io/bitnami/keycloak
+      ...
+    postgresql:
+      image:
+        repository: example.jfrog.io/bitnami/postgres
+        ...
+operate:
+  image:
+    repository: example.jfrog.io/camunda/operate
+    ...
+tasklist:
+  image:
+    repository: example.jfrog.io/camunda/tasklist
+    ...
+optimize:
+  image:
+    repository: example.jfrog.io/camunda/optimize
+    ...
+```
+
+Afterwards you can deploy Camunda Platform using Helm and the custom values file.
+
+```
+helm install my-camunda-platform camunda-cloud/camunda-platform -f values.yaml
+```

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -4,10 +4,10 @@ title: "Installing in an air-gapped environment"
 description: "Camunda Platform 8 Self-Managed installation in an air-gapped environment"
 ---
 
-The [Camunda Platform Helm chart](../../helm-kubernetes/deploy.md) may assist in an air-gapped environment. By default, the images are fetched via Docker Hub.
-With the dependencies in third-party images and Helm charts, additional steps are required to make all charts available as outlined in this resource.
+The [Camunda Platform Helm chart](../../helm-kubernetes/deploy.md) may assist in an air-gapped environment. By default, the Docker images are fetched via Docker Hub.
+With the dependencies in third-party Docker images and Helm charts, additional steps are required to make all charts available as outlined in this resource.
 
-## Required images
+## Required Docker images
 
 The following images must be available in your air-gapped environment:
 
@@ -26,8 +26,9 @@ The following charts must be available in your air-gapped environment:
 
 - [Camunda Platform Helm chart](https://github.com/camunda/camunda-platform-helm)
 - [Elasticsearch Helm chart](https://github.com/elastic/helm-charts/tree/main/elasticsearch)
-- [Keycloak Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/keycloak)
-- [Postgres Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql/)
+- [Keycloak Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/keycloak)
+- [Postgres Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
+- [Bitnami Common Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/common)
 
 ## Dependencies explained
 
@@ -59,9 +60,9 @@ identity:
       [postgresql values]
 ```
 
-## Push images to your repository
+## Push Docker images to your repository
 
-All the [required images](#required-images) need to be pushed to your repository using the following steps:
+All the [required Docker images](#required-docker-images) need to be pushed to your repository using the following steps:
 
 1. Tag your image using the following command (replace `<IMAGE ID>`, `<DOCKER REPOSITORY>`, and `<DOCKER TAG>` with the corresponding values.)
 
@@ -78,13 +79,7 @@ docker push example.jfrog.io/camunda/<DOCKER_IMAGE>:<DOCKER_TAG>
 ## Deploy Helm charts to your repository
 
 You must deploy the [required Helm charts](#required-helm-charts) to your repository.
-For example, in JFrog you can do this via the Artifactory's REST API.
-
-```
-curl -u <USER>:<PASSWORD> -T <PATH_TO_FILE> "https://example.jfrog.io/artifactory/camunda-platform/<TARGET_FILE_PATH>"
-```
-
-Alternatively, you can set up remote repositories (for example, with URL [https://helm.camunda.io](https://helm.camunda.io) for Camunda charts, [https://helm.elastic.co](https://helm.elastic.co) for Elastic).
+For details about hosting options, visit the [chart repository guide](https://helm.sh/docs/topics/chart_repository).
 
 ### Add your Helm repositories
 
@@ -97,7 +92,7 @@ helm repo add bitnami https://example.jfrog.io/artifactory/api/helm/bitnami
 helm repo update
 ```
 
-### Helm Chart values
+### Helm chart values
 
 In a custom values file, it is possible to override the image repository and the image tag.
 
@@ -143,5 +138,5 @@ optimize:
 Afterwards, you can deploy Camunda Platform using Helm and the custom values file.
 
 ```
-helm install my-camunda-platform camunda-cloud/camunda-platform -f values.yaml
+helm install my-camunda-platform camunda/camunda-platform -f values.yaml
 ```

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -4,10 +4,10 @@ title: "Installing in an air-gapped environment"
 description: "Camunda Platform 8 Self-Managed installation in an air-gapped environment"
 ---
 
-Also in an air-gapped environment, one would like to profit from the [Camunda Platform Helm chart](../../helm-kubernetes/deploy.md). By default the images are fetched via docker hub.
-With the dependencies to third-party images and helm charts, additional steps are required to have all charts available.
+The [Camunda Platform Helm chart](../../helm-kubernetes/deploy.md) may assist in an air-gapped environment. By default, the images are fetched via Docker Hub.
+With the dependencies in third-party images and Helm charts, additional steps are required to make all charts available as outlined in this resource.
 
-## Required Images
+## Required images
 
 The following images must be available in your air-gapped environment:
 
@@ -20,18 +20,18 @@ The following images must be available in your air-gapped environment:
 - [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak)
 - [elasticsearch](https://hub.docker.com/_/elasticsearch)
 
-## Required Helm Charts
+## Required Helm charts
 
 The following charts must be available in your air-gapped environment:
 
-- [Camunda Platform Helm Chart](https://github.com/camunda/camunda-platform-helm)
-- [Elasticsearch Helm Chart](https://github.com/elastic/helm-charts/tree/main/elasticsearch)
-- [Keycloak Helm Chart](https://github.com/bitnami/charts/tree/master/bitnami/keycloak)
-- [Postgres Helm Chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql/)
+- [Camunda Platform Helm chart](https://github.com/camunda/camunda-platform-helm)
+- [Elasticsearch Helm chart](https://github.com/elastic/helm-charts/tree/main/elasticsearch)
+- [Keycloak Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/keycloak)
+- [Postgres Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql/)
 
 ## Dependencies explained
 
-Identity utilizes Keycloak and allows you to manage users, roles, and permissions for Camunda Platform 8 components. This third-party dependency is reflected in the Helm Chart as follows:
+Identity utilizes Keycloak and allows you to manage users, roles, and permissions for Camunda Platform 8 components. This third-party dependency is reflected in the Helm chart as follows:
 
 ```
 camunda-platform
@@ -46,9 +46,9 @@ camunda-platform
 ```
 
 - Keycloak is a dependency for Camunda Identity and PostgreSQL is a dependency for Keycloak.
-- Elasticsearch is a dependency for Zeebe, Operate, Tasklist and Optimize.
+- Elasticsearch is a dependency for Zeebe, Operate, Tasklist, and Optimize.
 
-The values for the dependencies Keycloak and PostgreSQL can be set in the same hierarchy.
+The values for the dependencies Keycloak and PostgreSQL can be set in the same hierarchy:
 
 ```yaml
 identity:
@@ -59,36 +59,36 @@ identity:
       [postgresql values]
 ```
 
-## Push Images to your repository
+## Push images to your repository
 
-All the [required images](#required-images) need to be pushed to your repository.
+All the [required images](#required-images) need to be pushed to your repository using the following steps:
 
-1. Tag your image using the following command (replace `<IMAGE ID>`, `<DOCKER REPOSITORY>` and `<DOCKER TAG>` with the corresponding values)
+1. Tag your image using the following command (replace `<IMAGE ID>`, `<DOCKER REPOSITORY>`, and `<DOCKER TAG>` with the corresponding values.)
 
 ```
 docker tag <IMAGE_ID> example.jfrog.io/camunda/<DOCKER_IMAGE>:<DOCKER_TAG>
 ```
 
-2. Push your image using the following command
+2. Push your image using the following command:
 
 ```
 docker push example.jfrog.io/camunda/<DOCKER_IMAGE>:<DOCKER_TAG>
 ```
 
-## Deploy Helm Charts to your repository
+## Deploy Helm charts to your repository
 
-You have to deploy the [required Helm Charts](#required-helm-charts) to your repository.
-E.g. In JFrog you can do it via the Artifactory's REST API.
+You must deploy the [required Helm charts](#required-helm-charts) to your repository.
+For example, in JFrog you can do this via the Artifactory's REST API.
 
 ```
 curl -u <USER>:<PASSWORD> -T <PATH_TO_FILE> "https://example.jfrog.io/artifactory/camunda-platform/<TARGET_FILE_PATH>"
 ```
 
-Alternatively, you can setup remote repositories (e.g. with url: https://helm.camunda.io for Camunda Charts, https://helm.elastic.co for Elastic)
+Alternatively, you can set up remote repositories (for example, with URL [https://helm.camunda.io](https://helm.camunda.io) for Camunda charts, [https://helm.elastic.co](https://helm.elastic.co) for Elastic).
 
 ### Add your Helm repositories
 
-You have to add your Helm chart repositories in order to use the charts.
+You must add your Helm chart repositories to use the charts:
 
 ```
 helm repo add camunda https://example.jfrog.io/artifactory/api/helm/camunda-platform
@@ -140,7 +140,7 @@ optimize:
     ...
 ```
 
-Afterwards you can deploy Camunda Platform using Helm and the custom values file.
+Afterwards, you can deploy Camunda Platform using Helm and the custom values file.
 
 ```
 helm install my-camunda-platform camunda-cloud/camunda-platform -f values.yaml

--- a/sidebars.js
+++ b/sidebars.js
@@ -652,6 +652,7 @@ module.exports = {
                 "self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster",
                 "self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress",
                 "self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup",
+                "self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation",
               ],
             },
             "self-managed/platform-deployment/troubleshooting",


### PR DESCRIPTION
## What is the purpose of the change

 Also in an air-gapped environment, one would like to profit from the use of helm charts. By default the images are fetched via docker hub. 
 Also with the dependencies to third-party images and helm charts, additional steps are required to have all charts available.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
