### PR TITLE
chore(backup): align backup docs

### DIFF
--- a/docs/self-managed/backup-restore/backup-and-restore.md
+++ b/docs/self-managed/backup-restore/backup-and-restore.md
@@ -2,6 +2,7 @@
 id: backup-and-restore
 title: "Backup and restore"
 sidebar_label: "Backup and restore"
+keywords: ["backup", "backups"]
 ---
 
 :::note

--- a/docs/self-managed/backup-restore/backup-and-restore.md
+++ b/docs/self-managed/backup-restore/backup-and-restore.md
@@ -4,6 +4,10 @@ title: "Backup and restore"
 sidebar_label: "Backup and restore"
 ---
 
+:::note
+This API is subject to change.
+:::
+
 You can use the backup feature of Camunda Platform 8 Self-Managed to regularly back up the state of all of its components (Zeebe, Operate, Tasklist, and Optimize) without any downtime. In case of failures that lead to data loss, you can recover the cluster from a backup.
 
 A backup of Camunda Platform 8 consists of a backup of Zeebe, Operate, Tasklist, Optimize, and the backup of exported Zeebe records in Elasticsearch. Since the data of these applications are dependent on each other, it is important that the backup is consistent across all components. Therefore, you must take the backup of a Camunda Platform 8 cluster as a whole. The backups of individual components which are taken independently may not form a consistent recovery point. To ensure a consistent backup, follow the process described below.

--- a/docs/self-managed/backup-restore/operate-tasklist-backup.md
+++ b/docs/self-managed/backup-restore/operate-tasklist-backup.md
@@ -1,10 +1,13 @@
 ---
 id: operate-tasklist-backup
-title: Backup and restore Operate and Tasklist data
+title: Backup & restore Operate and Tasklist data
 description: "How to perform backup of Operate and Tasklist data and restore."
+keywords: ["backup", "backups"]
 ---
 
-## Backup and restore of Operate data
+:::note
+This API is subject to change.
+:::
 
 Operate stores its data over multiple indices in Elasticsearch. Backup of Operate data includes several
 Elasticsearch snapshots containing sets of Operate indices. Each backup is identified by `backupId`. E.g.
@@ -134,4 +137,4 @@ The whole process could look like:
 
 ## Backup and restore of Tasklist data
 
-Backup and restore of Tasklist may be performed in exactly the same way as [for Operate data](#backup-and-restore-of-operate-data).
+Backup and restore of Tasklist may be performed in exactly the same way as [for Operate data](#).

--- a/docs/self-managed/backup-restore/operate-tasklist-backup.md
+++ b/docs/self-managed/backup-restore/operate-tasklist-backup.md
@@ -1,6 +1,6 @@
 ---
 id: operate-tasklist-backup
-title: Backup & restore Operate and Tasklist data
+title: Backup and restore Operate and Tasklist data
 description: "How to perform backup of Operate and Tasklist data and restore."
 keywords: ["backup", "backups"]
 ---

--- a/docs/self-managed/backup-restore/optimize-backup.md
+++ b/docs/self-managed/backup-restore/optimize-backup.md
@@ -1,11 +1,12 @@
 ---
 id: optimize-backup
-title: Backup and restore Optimize data
+title: Backup & restore Optimize data
 description: "How to perform a backup of Optimize data and restore the backup."
+keywords: ["backup", "backups"]
 ---
 
 :::note
-This is an experimental feature in 3.9.0. The API may be subject to changes in later releases.
+This API is subject to change.
 :::
 
 Optimize stores its data over multiple indices in Elasticsearch. To ensure data integrity across indices, a backup of Optimize data consists of two Elasticsearch snapshots, each containing a different set of Optimize indices. Each backup is identified by a backup ID. For example, a backup with id `backup1` consists of the following Elasticsearch snapshots:

--- a/docs/self-managed/backup-restore/optimize-backup.md
+++ b/docs/self-managed/backup-restore/optimize-backup.md
@@ -1,6 +1,6 @@
 ---
 id: optimize-backup
-title: Backup & restore Optimize data
+title: Backup and restore Optimize data
 description: "How to perform a backup of Optimize data and restore the backup."
 keywords: ["backup", "backups"]
 ---

--- a/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -1,12 +1,12 @@
 ---
 id: zeebe-backup-and-restore
-title: "Zeebe Backups"
+title: "Backup & restore Zeebe data"
 description: "A guide to creating backup of a running Zeebe cluster."
 keywords: ["backup", "backups"]
 ---
 
 :::note
-The API is subject to change.
+This API is subject to change.
 :::
 
 A backup of a zeebe cluster consists of a consistent snapshot of all partitions. The backup is stored in an external storage. Backup is taken asynchronously in the background while Zeebe is processing. Thus, the backups can be taken with minimal impact to the normal processing.

--- a/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -1,6 +1,6 @@
 ---
 id: zeebe-backup-and-restore
-title: "Backup & restore Zeebe data"
+title: "Backup and restore Zeebe data"
 description: "A guide to creating backup of a running Zeebe cluster."
 keywords: ["backup", "backups"]
 ---

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -1661,19 +1661,19 @@ module.exports = {
     {
       "Backup & Restore": [
         docsLink(
-          "Backup & Restore",
+          "Backup & restore",
           "self-managed/backup-restore/backup-and-restore/"
         ),
         docsLink(
-          "Backup and restore Optimize data",
+          "Backup & restore Optimize data",
           "self-managed/backup-restore/optimize-backup/"
         ),
         docsLink(
-          "Backup and restore Operate and Tasklist data",
+          "Backup & restore Operate and Tasklist data",
           "self-managed/backup-restore/operate-tasklist-backup/"
         ),
         docsLink(
-          "Zeebe Backups",
+          "Backup & restore Zeebe data",
           "self-managed/backup-restore/zeebe-backup-and-restore/"
         ),
       ],

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -1659,21 +1659,21 @@ module.exports = {
     },
 
     {
-      "Backup & Restore": [
+      "Backup and Restore": [
         docsLink(
-          "Backup & restore",
+          "Backup and restore",
           "self-managed/backup-restore/backup-and-restore/"
         ),
         docsLink(
-          "Backup & restore Optimize data",
+          "Backup and restore Optimize data",
           "self-managed/backup-restore/optimize-backup/"
         ),
         docsLink(
-          "Backup & restore Operate and Tasklist data",
+          "Backup and restore Operate and Tasklist data",
           "self-managed/backup-restore/operate-tasklist-backup/"
         ),
         docsLink(
-          "Backup & restore Zeebe data",
+          "Backup and restore Zeebe data",
           "self-managed/backup-restore/zeebe-backup-and-restore/"
         ),
       ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -1001,7 +1001,7 @@ module.exports = {
       "Web Modeler (Beta)": ["self-managed/web-modeler/installation"],
     },
     {
-      "Backup & Restore": [
+      "Backup and Restore": [
         "self-managed/backup-restore/backup-and-restore",
         "self-managed/backup-restore/optimize-backup",
         "self-managed/backup-restore/operate-tasklist-backup",

--- a/versioned_docs/version-8.1/self-managed/backup-restore/backup-and-restore.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/backup-and-restore.md
@@ -2,7 +2,12 @@
 id: backup-and-restore
 title: "Backup and restore"
 sidebar_label: "Backup and restore"
+keywords: ["backup", "backups"]
 ---
+
+:::note
+This API is subject to change.
+:::
 
 You can use the backup feature of Camunda Platform 8 Self-Managed to regularly back up the state of all of its components (Zeebe, Operate, Tasklist, and Optimize) without any downtime. In case of failures that lead to data loss, you can recover the cluster from a backup.
 

--- a/versioned_docs/version-8.1/self-managed/backup-restore/operate-tasklist-backup.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/operate-tasklist-backup.md
@@ -1,10 +1,13 @@
 ---
 id: operate-tasklist-backup
-title: Backup and restore Operate and Tasklist data
+title: Backup & restore Operate and Tasklist data
 description: "How to perform backup of Operate and Tasklist data and restore."
+keywords: ["backup", "backups"]
 ---
 
-## Backup and restore of Operate data
+:::note
+This API is subject to change.
+:::
 
 Operate stores its data over multiple indices in Elasticsearch. Backup of Operate data includes several
 Elasticsearch snapshots containing sets of Operate indices. Each backup is identified by `backupId`. E.g.
@@ -134,4 +137,4 @@ The whole process could look like:
 
 ## Backup and restore of Tasklist data
 
-Backup and restore of Tasklist may be performed in exactly the same way as [for Operate data](#backup-and-restore-of-operate-data).
+Backup and restore of Tasklist may be performed in exactly the same way as [for Operate data](#).

--- a/versioned_docs/version-8.1/self-managed/backup-restore/operate-tasklist-backup.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/operate-tasklist-backup.md
@@ -1,6 +1,6 @@
 ---
 id: operate-tasklist-backup
-title: Backup & restore Operate and Tasklist data
+title: Backup and restore Operate and Tasklist data
 description: "How to perform backup of Operate and Tasklist data and restore."
 keywords: ["backup", "backups"]
 ---

--- a/versioned_docs/version-8.1/self-managed/backup-restore/optimize-backup.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/optimize-backup.md
@@ -1,11 +1,12 @@
 ---
 id: optimize-backup
-title: Backup and restore Optimize data
+title: Backup & restore Optimize data
 description: "How to perform a backup of Optimize data and restore the backup."
+keywords: ["backup", "backups"]
 ---
 
 :::note
-This is an experimental feature in 3.9.0. The API may be subject to changes in later releases.
+This API is subject to change.
 :::
 
 Optimize stores its data over multiple indices in Elasticsearch. To ensure data integrity across indices, a backup of Optimize data consists of two Elasticsearch snapshots, each containing a different set of Optimize indices. Each backup is identified by a backup ID. For example, a backup with id `backup1` consists of the following Elasticsearch snapshots:

--- a/versioned_docs/version-8.1/self-managed/backup-restore/optimize-backup.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/optimize-backup.md
@@ -1,6 +1,6 @@
 ---
 id: optimize-backup
-title: Backup & restore Optimize data
+title: Backup and restore Optimize data
 description: "How to perform a backup of Optimize data and restore the backup."
 keywords: ["backup", "backups"]
 ---

--- a/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -1,12 +1,12 @@
 ---
 id: zeebe-backup-and-restore
-title: "Zeebe Backups"
+title: "Backup & restore Zeebe data"
 description: "A guide to creating backup of a running Zeebe cluster."
 keywords: ["backup", "backups"]
 ---
 
 :::note
-The API is subject to change.
+This API is subject to change.
 :::
 
 A backup of a zeebe cluster consists of a consistent snapshot of all partitions. The backup is stored in an external storage. Backup is taken asynchronously in the background while Zeebe is processing. Thus, the backups can be taken with minimal impact to the normal processing.

--- a/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -1,6 +1,6 @@
 ---
 id: zeebe-backup-and-restore
-title: "Backup & restore Zeebe data"
+title: "Backup and restore Zeebe data"
 description: "A guide to creating backup of a running Zeebe cluster."
 keywords: ["backup", "backups"]
 ---


### PR DESCRIPTION
related to OPT-6521

## What is the purpose of the change

Align the backup docs for consistency across components

## Are there related marketing activities

No

## When should this change go live?

Not relevant

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
