### PR TITLE
improve(es): allow skipping of hostname verification

### DIFF
--- a/optimize/self-managed/optimize-deployment/configuration/service-config.yaml
+++ b/optimize/self-managed/optimize-deployment/configuration/service-config.yaml
@@ -286,8 +286,11 @@ es:
       port: null
       # whether this proxy is using a secured connection
       sslEnabled: false
+    # Determines whether the hostname verification should be skipped
+    skipHostnameVerification: false
+  # Configuration relating to ES backup
   backup:
-    # the name of the snapshot repository to store backups
+    # The repository name in which the backups should be stored
     repositoryName: ""
 
   # Elasticsearch security settings

--- a/optimize/self-managed/optimize-deployment/configuration/system-configuration.md
+++ b/optimize/self-managed/optimize-deployment/configuration/system-configuration.md
@@ -148,6 +148,7 @@ if one node fails, Optimize is still able to talk to the cluster.
 | es.connection.proxy.host                      | null          | The proxy host to use, must be set if es.connection.proxy.enabled = true.                                                                                                 |
 | es.connection.proxy.port                      | null          | The proxy port to use, must be set if es.connection.proxy.enabled = true.                                                                                                 |
 | es.connection.proxy.sslEnabled                | false         | Whether this proxy is using a secured connection (HTTPS).                                                                                                                 |
+| es.connection.skipHostnameVerification        | false         | Determines whether the hostname verification should be skipped.                                                                                                           |
 
 #### Index settings
 


### PR DESCRIPTION
relates to OPT-6410

## What is the purpose of the change

Adds configuration information for a new feature to allow the disabling of ES hostname verification

## Are there related marketing activities

N/A

## When should this change go live?

In the next release, it is for a future Optimize version

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
