### PR TITLE
docs: fix dead links connector-sdk/runtime#automatic-connector-discovery

### DIFF
--- a/docs/guides/update-guide/connectors/010-to-020.md
+++ b/docs/guides/update-guide/connectors/010-to-020.md
@@ -205,7 +205,7 @@ With version 0.2.0 of the [job worker runtime environment](/components/connector
 - Rename `io.camunda.connector.runtime.jobworker.ConnectorJobHandler` to `io.camunda.connector.runtime.jobworker.api.outbound.ConnectorJobHandler`
 - Rename connector related env variables from `ZEEBE_` to `CONNECTOR_`. Zeebe configuration properties remain unchanged
 
-As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables ([cf. documentation](https://github.com/camunda/connector-sdk/tree/main/runtime-job-worker#automatic-connector-discovery)).
+As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables ([cf. documentation](https://github.com/camunda/connector-sdk/tree/main/runtime#automatic-connector-discovery)).
 
 Also take the name changes in the [SDK core](#explicit-outbound-aspect) into account.
 

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/010-to-020.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/010-to-020.md
@@ -205,7 +205,7 @@ With version 0.2.0 of the [job worker runtime environment](/components/connector
 - Rename `io.camunda.connector.runtime.jobworker.ConnectorJobHandler` to `io.camunda.connector.runtime.jobworker.api.outbound.ConnectorJobHandler`
 - Rename connector related env variables from `ZEEBE_` to `CONNECTOR_`. Zeebe configuration properties remain unchanged
 
-As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables ([cf. documentation](https://github.com/camunda/connector-sdk/tree/main/runtime-job-worker#automatic-connector-discovery)).
+As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables ([cf. documentation](https://github.com/camunda/connector-sdk/tree/main/runtime#automatic-connector-discovery)).
 
 Also take the name changes in the [SDK core](#explicit-outbound-aspect) into account.
 

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/010-to-020.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/010-to-020.md
@@ -205,7 +205,7 @@ With version 0.2.0 of the [job worker runtime environment](/components/connector
 - Rename `io.camunda.connector.runtime.jobworker.ConnectorJobHandler` to `io.camunda.connector.runtime.jobworker.api.outbound.ConnectorJobHandler`
 - Rename connector related env variables from `ZEEBE_` to `CONNECTOR_`. Zeebe configuration properties remain unchanged
 
-As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables ([cf. documentation](https://github.com/camunda/connector-sdk/tree/main/runtime-job-worker#automatic-connector-discovery)).
+As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables ([cf. documentation](https://github.com/camunda/connector-sdk/tree/main/runtime#automatic-connector-discovery)).
 
 Also take the name changes in the [SDK core](#explicit-outbound-aspect) into account.
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes dead links pointing to [here](https://github.com/camunda/connector-sdk/tree/main/runtime#automatic-connector-discovery).

## Are there related marketing activities

No.

## When should this change go live?

I would be grateful if this PR would be accepted before 31.10.2022.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
