### PR TITLE
chore(docs): remove C7 only label from Optimize public API docs

### DIFF
--- a/optimize/apis-clients/optimize-api/health-readiness.md
+++ b/optimize/apis-clients/optimize-api/health-readiness.md
@@ -4,8 +4,6 @@ title: "Health readiness"
 description: "The REST API to check the readiness of Optimize."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 The purpose of Health-Readiness REST API is to return information indicating whether Optimize is ready to be used.
 
 ## Method & HTTP target resource

--- a/optimize/apis-clients/optimize-api/report/delete-report.md
+++ b/optimize/apis-clients/optimize-api/report/delete-report.md
@@ -4,8 +4,6 @@ title: "Delete reports"
 description: "The REST API to delete reports from Optimize."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 The report deletion API allows you to delete reports by ID from Optimize.
 
 :::note Heads up!

--- a/optimize/apis-clients/optimize-api/report/get-data-export.md
+++ b/optimize/apis-clients/optimize-api/report/get-data-export.md
@@ -4,8 +4,6 @@ title: "Export report result data"
 description: "The REST API to export report result data from Optimize."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 The data export API allows users to export large amounts of data in a machine-readable format (JSON) from Optimize.
 
 ## Functionality

--- a/optimize_versioned_docs/version-3.8.0/apis-clients/optimize-api/health-readiness.md
+++ b/optimize_versioned_docs/version-3.8.0/apis-clients/optimize-api/health-readiness.md
@@ -4,8 +4,6 @@ title: "Health readiness"
 description: "The REST API to check the readiness of Optimize."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 The purpose of Health-Readiness REST API is to return information indicating whether Optimize is ready to be used.
 
 ## Method & HTTP target resource

--- a/optimize_versioned_docs/version-3.8.0/apis-clients/optimize-api/report/delete-report.md
+++ b/optimize_versioned_docs/version-3.8.0/apis-clients/optimize-api/report/delete-report.md
@@ -4,8 +4,6 @@ title: "Delete reports"
 description: "The REST API to delete reports from Optimize."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 The report deletion API allows you to delete reports by ID from Optimize.
 
 :::note Heads up!

--- a/optimize_versioned_docs/version-3.8.0/apis-clients/optimize-api/report/get-data-export.md
+++ b/optimize_versioned_docs/version-3.8.0/apis-clients/optimize-api/report/get-data-export.md
@@ -4,8 +4,6 @@ title: "Export report result data"
 description: "The REST API to export report result data from Optimize."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 The data export API allows users to export large amounts of data in a machine-readable format (JSON) from Optimize.
 
 ## Functionality

--- a/optimize_versioned_docs/version-3.9.0/apis-clients/optimize-api/health-readiness.md
+++ b/optimize_versioned_docs/version-3.9.0/apis-clients/optimize-api/health-readiness.md
@@ -4,8 +4,6 @@ title: "Health readiness"
 description: "The REST API to check the readiness of Optimize."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 The purpose of Health-Readiness REST API is to return information indicating whether Optimize is ready to be used.
 
 ## Method & HTTP target resource

--- a/optimize_versioned_docs/version-3.9.0/apis-clients/optimize-api/report/delete-report.md
+++ b/optimize_versioned_docs/version-3.9.0/apis-clients/optimize-api/report/delete-report.md
@@ -4,8 +4,6 @@ title: "Delete reports"
 description: "The REST API to delete reports from Optimize."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 The report deletion API allows you to delete reports by ID from Optimize.
 
 :::note Heads up!

--- a/optimize_versioned_docs/version-3.9.0/apis-clients/optimize-api/report/get-data-export.md
+++ b/optimize_versioned_docs/version-3.9.0/apis-clients/optimize-api/report/get-data-export.md
@@ -4,8 +4,6 @@ title: "Export report result data"
 description: "The REST API to export report result data from Optimize."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 The data export API allows users to export large amounts of data in a machine-readable format (JSON) from Optimize.
 
 ## Functionality


### PR DESCRIPTION
## What is the purpose of the change

This should never have been labelled as C7 only, so this PR removes the label from the next and previous docs

## Are there related marketing activities

No

## When should this change go live?

It's not urgent. But do we need to release the old docs at some point to see the changes reflected there? What is the process for this?

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
