### PR TITLE
feat(guides): add Connectors `0.3` update guide

### DIFF
--- a/docs/guides/update-guide/connectors/010-to-020.md
+++ b/docs/guides/update-guide/connectors/010-to-020.md
@@ -19,12 +19,13 @@ Be aware that the update from 0.1 to 0.2 requires manual migration steps as desc
 
 :::
 
-## Connector runtime
+## Connector function
 
 With SDK version 0.2.0, we introduce the following structural changes:
 
 - Input validation and secret replacement move from writing imperative code to declaratively using annotations.
 - The Outbound aspect of APIs is more explicit. Classes have been moved to more explicit packages and have been renamed.
+- New required annotation for outbound Connectors.
 
 ### Declarative validation and secrets
 
@@ -181,7 +182,7 @@ SPI for the connector function itself. Therefore, rename the file `META-INF/serv
 
 ### `@OutboundConnector` annotation
 
-For best interoperability connectors shall provide default meta-data (`name`, `type`, `inputVariables`) via the `@OutboundConnector` annotation:
+For best interoperability, Connectors provide default meta-data (`name`, `type`, `inputVariables`) via the `@OutboundConnector` annotation:
 
 ```java
 @OutboundConnector(
@@ -205,7 +206,7 @@ With version 0.2.0 of the [job worker runtime environment](/components/connector
 - Rename `io.camunda.connector.runtime.jobworker.ConnectorJobHandler` to `io.camunda.connector.runtime.jobworker.api.outbound.ConnectorJobHandler`
 - Rename connector related env variables from `ZEEBE_` to `CONNECTOR_`. Zeebe configuration properties remain unchanged
 
-As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables ([cf. documentation](https://github.com/camunda/connector-sdk/tree/main/runtime#automatic-connector-discovery)).
+As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables.
 
 Also take the name changes in the [SDK core](#explicit-outbound-aspect) into account.
 

--- a/docs/guides/update-guide/connectors/020-to-030.md
+++ b/docs/guides/update-guide/connectors/020-to-030.md
@@ -44,9 +44,9 @@ changes to the following:
 
 ```java
 import io.camunda.connector.api.annotation.Secret;
+import javax.validation.constraints.NotEmpty;
 import java.io.IOException;
 import java.util.Objects;
-import javax.validation.constraints.NotEmpty;
 ```
 
 This way, the Connector runtime environments are able to pick up your validations correctly.

--- a/docs/guides/update-guide/connectors/020-to-030.md
+++ b/docs/guides/update-guide/connectors/020-to-030.md
@@ -1,0 +1,117 @@
+---
+id: 020-to-030
+title: Update 0.2 to 0.3
+description: "Review which adjustments must be made to migrate from Connector SDK 0.2.x to 0.3.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--primary">Intermediate</span>
+
+The following sections explain which adjustments must be made to migrate from
+[Connector SDK](/components/connectors/custom-built-connectors/connector-sdk.md)
+0.2.x to 0.3.0.
+
+:::caution
+
+Be aware that the update from 0.2 to 0.3 requires manual migration steps as described below.
+
+:::
+
+## Connector function
+
+With SDK version 0.3.0, we introduce the following structural changes:
+
+- Input validation moves from Jakarta Bean Validation API version 3.0 to 2.0.
+- SDK artifacts have to be in scope `provided`.
+
+### Update to Validation API 2.0
+
+To better integrate in the current Java ecosystem and widely used frameworks like Spring 5 and Spring Boot 2, the `connector-validation` module
+now operates on Jakarta Bean Validation API version 2.0 instead of version 3.0. Adjust your Connector input objects using validation as follows:
+
+Replace all class imports starting with `jakarta.validation` by `javax.validation`. A Connector input class on SDK 0.2.x with the following imports:
+
+```java
+import io.camunda.connector.api.annotation.Secret;
+import jakarta.validation.constraints.NotEmpty;
+import java.io.IOException;
+import java.util.Objects;
+```
+
+changes to the following:
+
+```java
+import io.camunda.connector.api.annotation.Secret;
+import java.io.IOException;
+import java.util.Objects;
+import javax.validation.constraints.NotEmpty;
+```
+
+This way, the Connector runtime environments are able to pick up your validations correctly.
+
+### Provided SDK artifacts
+
+The Connector runtime environments can execute multiple Connectors at once. The environments also provide the base SDK artifacts and their classes
+to any Connector they execute. This comprises runtime-specific classes related to the Connector context as well as the Connector core and the validation
+classes. To minimize the possibility of incompatible classes being on the same classpath, Connectors are required to depend on `connector-core` and
+`connector-validation` in Maven's dependency scope `provided`. Other dependency management frameworks like Gradle offer similar scopes.
+
+As a result, you need to include the SDK artifacts as follows in Maven:
+
+```xml
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-core</artifactId>
+  <scope>provided</scope>
+</dependency>
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-validation</artifactId>
+  <scope>provided</scope>
+</dependency>
+```
+
+## Connector runtime environment
+
+The SDK provides a [pre-packaged runtime environment](/components/connectors/custom-built-connectors/connector-sdk.md#pre-packaged-runtime-environment)
+that you can start manually. With version 0.3.0, this runtime moves from the [SDK repository](https://github.com/camunda/connector-sdk/tree/stable/0.2/runtime-job-worker)
+to [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime). This also means that the provided runtime now is
+a Spring Boot application, based on Spring Zeebe. Thus, it offers all out-of-the-box capabilities Spring Zeebe provides.
+
+The Connector runtime JAR for manual installation can now be fetched from https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime/
+(starting with version `8.1.3`) instead of https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-job-worker/. You can start the runtime
+environment with the following command:
+
+```bash
+java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
+    io.camunda.connector.runtime.ConnectorRuntimeApplication
+```
+
+The Docker image is still accessible at https://hub.docker.com/r/camunda/connectors/tags.
+
+### Custom runtime environments
+
+If you are building a custom runtime environment, please note the following adjustments:
+
+- The `runtime-util` artifact replaces the `runtime-job-worker` artifact.
+- The `io.camunda.connector.runtime.jobworker.api.outbound.ConnectorJobHandler` has moved to `import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler`.
+- The `io.camunda.connector.impl.outbound.AbstractOutboundConnectorContext` has moved to `io.camunda.connector.impl.context.AbstractConnectorContext`.
+- To build your own context class, we recommend to use the following signature:
+
+```java
+public class MyContext extends AbstractConnectorContext implements OutboundConnectorContext {}
+```
+
+- The `SecretStore` class has been removed. Please initialize your context class with a `super(SecretProvider)` call. Remove the `getSecretStore` method, if you used it.
+
+```java
+public class MyContext extends AbstractConnectorContext implements OutboundConnectorContext {
+
+  public MyContext(final SecretProvider provider) {
+    super(provider);
+    ...
+  }
+}
+```

--- a/docs/guides/update-guide/connectors/introduction.md
+++ b/docs/guides/update-guide/connectors/introduction.md
@@ -9,9 +9,14 @@ Connector runtimes to a newer version of the
 
 There is a dedicated update guide for each version:
 
+### [Connector SDK 0.2 to 0.3](../020-to-030)
+
+Update from 0.2.x to 0.3.0
+
+[//]: # "TODO: As soon as the release will be created[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.2.0)"
+
 ### [Connector SDK 0.1 to 0.2](../010-to-020)
 
 Update from 0.1.x to 0.2.0
 
-[//]: # "TODO: As soon as the release will be created[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.2.0)"
-[//]: # "TODO: As soon as the release will be created[Release blog](https://camunda.com/blog/)"
+[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.2.0)

--- a/sidebars.js
+++ b/sidebars.js
@@ -38,6 +38,7 @@ module.exports = {
           Connectors: [
             "guides/update-guide/connectors/introduction",
             "guides/update-guide/connectors/010-to-020",
+            "guides/update-guide/connectors/020-to-030",
           ],
         },
         "guides/update-guide/800-to-810",

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/010-to-020.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/010-to-020.md
@@ -19,12 +19,13 @@ Be aware that the update from 0.1 to 0.2 requires manual migration steps as desc
 
 :::
 
-## Connector runtime
+## Connector function
 
 With SDK version 0.2.0, we introduce the following structural changes:
 
 - Input validation and secret replacement move from writing imperative code to declaratively using annotations.
 - The Outbound aspect of APIs is more explicit. Classes have been moved to more explicit packages and have been renamed.
+- New required annotation for outbound Connectors.
 
 ### Declarative validation and secrets
 
@@ -181,7 +182,7 @@ SPI for the connector function itself. Therefore, rename the file `META-INF/serv
 
 ### `@OutboundConnector` annotation
 
-For best interoperability connectors shall provide default meta-data (`name`, `type`, `inputVariables`) via the `@OutboundConnector` annotation:
+For best interoperability, Connectors provide default meta-data (`name`, `type`, `inputVariables`) via the `@OutboundConnector` annotation:
 
 ```java
 @OutboundConnector(
@@ -205,7 +206,7 @@ With version 0.2.0 of the [job worker runtime environment](/components/connector
 - Rename `io.camunda.connector.runtime.jobworker.ConnectorJobHandler` to `io.camunda.connector.runtime.jobworker.api.outbound.ConnectorJobHandler`
 - Rename connector related env variables from `ZEEBE_` to `CONNECTOR_`. Zeebe configuration properties remain unchanged
 
-As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables ([cf. documentation](https://github.com/camunda/connector-sdk/tree/main/runtime#automatic-connector-discovery)).
+As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables.
 
 Also take the name changes in the [SDK core](#explicit-outbound-aspect) into account.
 

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/020-to-030.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/020-to-030.md
@@ -44,9 +44,9 @@ changes to the following:
 
 ```java
 import io.camunda.connector.api.annotation.Secret;
+import javax.validation.constraints.NotEmpty;
 import java.io.IOException;
 import java.util.Objects;
-import javax.validation.constraints.NotEmpty;
 ```
 
 This way, the Connector runtime environments are able to pick up your validations correctly.

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/020-to-030.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/020-to-030.md
@@ -1,0 +1,117 @@
+---
+id: 020-to-030
+title: Update 0.2 to 0.3
+description: "Review which adjustments must be made to migrate from Connector SDK 0.2.x to 0.3.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--primary">Intermediate</span>
+
+The following sections explain which adjustments must be made to migrate from
+[Connector SDK](/components/connectors/custom-built-connectors/connector-sdk.md)
+0.2.x to 0.3.0.
+
+:::caution
+
+Be aware that the update from 0.2 to 0.3 requires manual migration steps as described below.
+
+:::
+
+## Connector function
+
+With SDK version 0.3.0, we introduce the following structural changes:
+
+- Input validation moves from Jakarta Bean Validation API version 3.0 to 2.0.
+- SDK artifacts have to be in scope `provided`.
+
+### Update to Validation API 2.0
+
+To better integrate in the current Java ecosystem and widely used frameworks like Spring 5 and Spring Boot 2, the `connector-validation` module
+now operates on Jakarta Bean Validation API version 2.0 instead of version 3.0. Adjust your Connector input objects using validation as follows:
+
+Replace all class imports starting with `jakarta.validation` by `javax.validation`. A Connector input class on SDK 0.2.x with the following imports:
+
+```java
+import io.camunda.connector.api.annotation.Secret;
+import jakarta.validation.constraints.NotEmpty;
+import java.io.IOException;
+import java.util.Objects;
+```
+
+changes to the following:
+
+```java
+import io.camunda.connector.api.annotation.Secret;
+import java.io.IOException;
+import java.util.Objects;
+import javax.validation.constraints.NotEmpty;
+```
+
+This way, the Connector runtime environments are able to pick up your validations correctly.
+
+### Provided SDK artifacts
+
+The Connector runtime environments can execute multiple Connectors at once. The environments also provide the base SDK artifacts and their classes
+to any Connector they execute. This comprises runtime-specific classes related to the Connector context as well as the Connector core and the validation
+classes. To minimize the possibility of incompatible classes being on the same classpath, Connectors are required to depend on `connector-core` and
+`connector-validation` in Maven's dependency scope `provided`. Other dependency management frameworks like Gradle offer similar scopes.
+
+As a result, you need to include the SDK artifacts as follows in Maven:
+
+```xml
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-core</artifactId>
+  <scope>provided</scope>
+</dependency>
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-validation</artifactId>
+  <scope>provided</scope>
+</dependency>
+```
+
+## Connector runtime environment
+
+The SDK provides a [pre-packaged runtime environment](/components/connectors/custom-built-connectors/connector-sdk.md#pre-packaged-runtime-environment)
+that you can start manually. With version 0.3.0, this runtime moves from the [SDK repository](https://github.com/camunda/connector-sdk/tree/stable/0.2/runtime-job-worker)
+to [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime). This also means that the provided runtime now is
+a Spring Boot application, based on Spring Zeebe. Thus, it offers all out-of-the-box capabilities Spring Zeebe provides.
+
+The Connector runtime JAR for manual installation can now be fetched from https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime/
+(starting with version `8.1.3`) instead of https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-job-worker/. You can start the runtime
+environment with the following command:
+
+```bash
+java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
+    io.camunda.connector.runtime.ConnectorRuntimeApplication
+```
+
+The Docker image is still accessible at https://hub.docker.com/r/camunda/connectors/tags.
+
+### Custom runtime environments
+
+If you are building a custom runtime environment, please note the following adjustments:
+
+- The `runtime-util` artifact replaces the `runtime-job-worker` artifact.
+- The `io.camunda.connector.runtime.jobworker.api.outbound.ConnectorJobHandler` has moved to `import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler`.
+- The `io.camunda.connector.impl.outbound.AbstractOutboundConnectorContext` has moved to `io.camunda.connector.impl.context.AbstractConnectorContext`.
+- To build your own context class, we recommend to use the following signature:
+
+```java
+public class MyContext extends AbstractConnectorContext implements OutboundConnectorContext {}
+```
+
+- The `SecretStore` class has been removed. Please initialize your context class with a `super(SecretProvider)` call. Remove the `getSecretStore` method, if you used it.
+
+```java
+public class MyContext extends AbstractConnectorContext implements OutboundConnectorContext {
+
+  public MyContext(final SecretProvider provider) {
+    super(provider);
+    ...
+  }
+}
+```

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/introduction.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/introduction.md
@@ -9,9 +9,14 @@ Connector runtimes to a newer version of the
 
 There is a dedicated update guide for each version:
 
+### [Connector SDK 0.2 to 0.3](../020-to-030)
+
+Update from 0.2.x to 0.3.0
+
+[//]: # "TODO: As soon as the release will be created[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.2.0)"
+
 ### [Connector SDK 0.1 to 0.2](../010-to-020)
 
 Update from 0.1.x to 0.2.0
 
-[//]: # "TODO: As soon as the release will be created[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.2.0)"
-[//]: # "TODO: As soon as the release will be created[Release blog](https://camunda.com/blog/)"
+[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.2.0)

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/010-to-020.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/010-to-020.md
@@ -19,12 +19,13 @@ Be aware that the update from 0.1 to 0.2 requires manual migration steps as desc
 
 :::
 
-## Connector runtime
+## Connector function
 
 With SDK version 0.2.0, we introduce the following structural changes:
 
 - Input validation and secret replacement move from writing imperative code to declaratively using annotations.
 - The Outbound aspect of APIs is more explicit. Classes have been moved to more explicit packages and have been renamed.
+- New required annotation for outbound Connectors.
 
 ### Declarative validation and secrets
 
@@ -181,7 +182,7 @@ SPI for the connector function itself. Therefore, rename the file `META-INF/serv
 
 ### `@OutboundConnector` annotation
 
-For best interoperability connectors shall provide default meta-data (`name`, `type`, `inputVariables`) via the `@OutboundConnector` annotation:
+For best interoperability, Connectors provide default meta-data (`name`, `type`, `inputVariables`) via the `@OutboundConnector` annotation:
 
 ```java
 @OutboundConnector(
@@ -205,7 +206,7 @@ With version 0.2.0 of the [job worker runtime environment](/components/connector
 - Rename `io.camunda.connector.runtime.jobworker.ConnectorJobHandler` to `io.camunda.connector.runtime.jobworker.api.outbound.ConnectorJobHandler`
 - Rename connector related env variables from `ZEEBE_` to `CONNECTOR_`. Zeebe configuration properties remain unchanged
 
-As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables ([cf. documentation](https://github.com/camunda/connector-sdk/tree/main/runtime#automatic-connector-discovery)).
+As a general change in behavior the module will now pick up connectors from classpath unless it is explicitly configured via environment variables.
 
 Also take the name changes in the [SDK core](#explicit-outbound-aspect) into account.
 

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/020-to-030.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/020-to-030.md
@@ -44,9 +44,9 @@ changes to the following:
 
 ```java
 import io.camunda.connector.api.annotation.Secret;
+import javax.validation.constraints.NotEmpty;
 import java.io.IOException;
 import java.util.Objects;
-import javax.validation.constraints.NotEmpty;
 ```
 
 This way, the Connector runtime environments are able to pick up your validations correctly.

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/020-to-030.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/020-to-030.md
@@ -1,0 +1,117 @@
+---
+id: 020-to-030
+title: Update 0.2 to 0.3
+description: "Review which adjustments must be made to migrate from Connector SDK 0.2.x to 0.3.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--primary">Intermediate</span>
+
+The following sections explain which adjustments must be made to migrate from
+[Connector SDK](/components/connectors/custom-built-connectors/connector-sdk.md)
+0.2.x to 0.3.0.
+
+:::caution
+
+Be aware that the update from 0.2 to 0.3 requires manual migration steps as described below.
+
+:::
+
+## Connector function
+
+With SDK version 0.3.0, we introduce the following structural changes:
+
+- Input validation moves from Jakarta Bean Validation API version 3.0 to 2.0.
+- SDK artifacts have to be in scope `provided`.
+
+### Update to Validation API 2.0
+
+To better integrate in the current Java ecosystem and widely used frameworks like Spring 5 and Spring Boot 2, the `connector-validation` module
+now operates on Jakarta Bean Validation API version 2.0 instead of version 3.0. Adjust your Connector input objects using validation as follows:
+
+Replace all class imports starting with `jakarta.validation` by `javax.validation`. A Connector input class on SDK 0.2.x with the following imports:
+
+```java
+import io.camunda.connector.api.annotation.Secret;
+import jakarta.validation.constraints.NotEmpty;
+import java.io.IOException;
+import java.util.Objects;
+```
+
+changes to the following:
+
+```java
+import io.camunda.connector.api.annotation.Secret;
+import java.io.IOException;
+import java.util.Objects;
+import javax.validation.constraints.NotEmpty;
+```
+
+This way, the Connector runtime environments are able to pick up your validations correctly.
+
+### Provided SDK artifacts
+
+The Connector runtime environments can execute multiple Connectors at once. The environments also provide the base SDK artifacts and their classes
+to any Connector they execute. This comprises runtime-specific classes related to the Connector context as well as the Connector core and the validation
+classes. To minimize the possibility of incompatible classes being on the same classpath, Connectors are required to depend on `connector-core` and
+`connector-validation` in Maven's dependency scope `provided`. Other dependency management frameworks like Gradle offer similar scopes.
+
+As a result, you need to include the SDK artifacts as follows in Maven:
+
+```xml
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-core</artifactId>
+  <scope>provided</scope>
+</dependency>
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-validation</artifactId>
+  <scope>provided</scope>
+</dependency>
+```
+
+## Connector runtime environment
+
+The SDK provides a [pre-packaged runtime environment](/components/connectors/custom-built-connectors/connector-sdk.md#pre-packaged-runtime-environment)
+that you can start manually. With version 0.3.0, this runtime moves from the [SDK repository](https://github.com/camunda/connector-sdk/tree/stable/0.2/runtime-job-worker)
+to [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime). This also means that the provided runtime now is
+a Spring Boot application, based on Spring Zeebe. Thus, it offers all out-of-the-box capabilities Spring Zeebe provides.
+
+The Connector runtime JAR for manual installation can now be fetched from https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime/
+(starting with version `8.1.3`) instead of https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-job-worker/. You can start the runtime
+environment with the following command:
+
+```bash
+java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
+    io.camunda.connector.runtime.ConnectorRuntimeApplication
+```
+
+The Docker image is still accessible at https://hub.docker.com/r/camunda/connectors/tags.
+
+### Custom runtime environments
+
+If you are building a custom runtime environment, please note the following adjustments:
+
+- The `runtime-util` artifact replaces the `runtime-job-worker` artifact.
+- The `io.camunda.connector.runtime.jobworker.api.outbound.ConnectorJobHandler` has moved to `import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler`.
+- The `io.camunda.connector.impl.outbound.AbstractOutboundConnectorContext` has moved to `io.camunda.connector.impl.context.AbstractConnectorContext`.
+- To build your own context class, we recommend to use the following signature:
+
+```java
+public class MyContext extends AbstractConnectorContext implements OutboundConnectorContext {}
+```
+
+- The `SecretStore` class has been removed. Please initialize your context class with a `super(SecretProvider)` call. Remove the `getSecretStore` method, if you used it.
+
+```java
+public class MyContext extends AbstractConnectorContext implements OutboundConnectorContext {
+
+  public MyContext(final SecretProvider provider) {
+    super(provider);
+    ...
+  }
+}
+```

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/introduction.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/introduction.md
@@ -9,9 +9,14 @@ Connector runtimes to a newer version of the
 
 There is a dedicated update guide for each version:
 
+### [Connector SDK 0.2 to 0.3](../020-to-030)
+
+Update from 0.2.x to 0.3.0
+
+[//]: # "TODO: As soon as the release will be created[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.2.0)"
+
 ### [Connector SDK 0.1 to 0.2](../010-to-020)
 
 Update from 0.1.x to 0.2.0
 
-[//]: # "TODO: As soon as the release will be created[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.2.0)"
-[//]: # "TODO: As soon as the release will be created[Release blog](https://camunda.com/blog/)"
+[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.2.0)

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -29,7 +29,8 @@
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
-            "guides/update-guide/connectors/010-to-020"
+            "guides/update-guide/connectors/010-to-020",
+            "guides/update-guide/connectors/020-to-030"
           ]
         },
         "guides/update-guide/130-to-800",

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -29,7 +29,8 @@
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
-            "guides/update-guide/connectors/010-to-020"
+            "guides/update-guide/connectors/010-to-020",
+            "guides/update-guide/connectors/020-to-030"
           ]
         },
         "guides/update-guide/800-to-810",


### PR DESCRIPTION
## What is the purpose of the change

Provide an update guide for Connectors from 0.2.x to 0.3

related to https://github.com/camunda/connector-sdk/issues/203

## Are there related marketing activities

n/a

## When should this change go live?

After Connector SDK `0.3.0` has been released, we'll ping manually here and remove the `hold` label.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
