### PR TITLE
fix(self-managed): fix misleading description for restore

### DIFF
--- a/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -118,7 +118,7 @@ To restore a Zeebe cluster, run the following in each node where the broker will
 
 ```
 tar -xzf zeebe-distribution-X.Y.Z.tar.gz -C zeebe/
-./bin/restore <backupId>
+./bin/restore --backupId=<backupId>
 ```
 
 If restore was successful, the app exits with a log message of `Successfully restored broker from backup`.

--- a/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -118,7 +118,7 @@ To restore a Zeebe cluster, run the following in each node where the broker will
 
 ```
 tar -xzf zeebe-distribution-X.Y.Z.tar.gz -C zeebe/
-./bin/restore <backupId>
+./bin/restore --backupId=<backupId>
 ```
 
 If restore was successful, the app exits with a log message of `Successfully restored broker from backup`.


### PR DESCRIPTION
## What is the purpose of the change

![image](https://user-images.githubusercontent.com/24605947/199650924-c7931eba-3a09-4913-8686-85d128a4a7ad.png)

----
I think this document is misleading, when I try to execute the command `./bin/restore 1` as shown in the documentation to restore a backup, I get the following error message, until I look at the source code and see the correct way to use it somewhere: `bin/resotre --backupId=1`

```
Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2022-11-03 11:02:33.559 [] [main] ERROR
      org.springframework.boot.SpringApplication - Application run failed
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'restoreApp': Injection of autowired dependencies failed; nested exception is java.lang.IllegalArgumentException: Could not resolve placeholder 'backupId' in value "${backupId}"
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessProperties(AutowiredAnnotationBeanPostProcessor.java:405) ~[spring-beans-5.3.23.jar:5.3.23]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1431) ~[spring-beans-5.3.23.jar:5.3.23]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:619) ~[spring-beans-5.3.23.jar:5.3.23]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542) ~[spring-beans-5.3.23.jar:5.3.23]
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335) ~[spring-beans-5.3.23.jar:5.3.23]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-5.3.23.jar:5.3.23]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333) ~[spring-beans-5.3.23.jar:5.3.23]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208) ~[spring-beans-5.3.23.jar:5.3.23]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:955) ~[spring-beans-5.3.23.jar:5.3.23]
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:918) ~[spring-context-5.3.23.jar:5.3.23]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583) ~[spring-context-5.3.23.jar:5.3.23]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:734) ~[spring-boot-2.7.4.jar:2.7.4]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:408) ~[spring-boot-2.7.4.jar:2.7.4]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:308) ~[spring-boot-2.7.4.jar:2.7.4]
```


## Are there related marketing activities

N/A

## When should this change go live?

version 8.1

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory.
- [ ]  My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ]  My changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
