### PR TITLE
docs(desktop-modeler): update telemetry docs

### DIFF
--- a/docs/components/modeler/desktop-modeler/telemetry/telemetry.md
+++ b/docs/components/modeler/desktop-modeler/telemetry/telemetry.md
@@ -224,3 +224,31 @@ The `Overlay Opened Event` is sent when an overlay is opened via user interactio
 For the **Version Info** overlay, the event also sends `source` of the click (`"menu"` or `"statusBar"`).
 
 For the **Deployment** and **Start Instance** overlays, the event also send the `diagramType` (BPMN, DMN or Form).
+
+### Form editor events
+
+The `Form editor events` are sent on different interactions with the form builder:
+
+- User opened or collapsed a panel in the form editor. The event includes the current open state for each form preview panel and the interaction that triggered the change.
+
+```json
+{
+  "layout": {
+    "form-input": {
+      "open": true
+    },
+    "form-output": {
+      "open": true
+    },
+    "form-preview": {
+      "open": true
+    }
+  },
+  "triggeredBy": "keyboardShortcut|previewPanel|statusBar|windowMenu"
+}
+```
+
+- User interacted with the form input data panel.
+- User interacted with the form preview panel.
+
+In all events [the execution platform and version](#diagram-openedclosed-event) are sent as well.


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/3247

## What is the purpose of the change

Adding the new Mixpanel events for the Desktop Modeler (cf. https://github.com/camunda/camunda-modeler/issues/3247)

## Are there related marketing activities

/

## When should this change go live?

With the Desktop Modeler 5.6.0 Release (December)

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
