### PR TITLE
docs(migrating-from-camunda-platform-7): Adjust to current state of development

### DIFF
--- a/docs/guides/migrating-from-camunda-platform-7.md
+++ b/docs/guides/migrating-from-camunda-platform-7.md
@@ -286,7 +286,7 @@ The topic `camunda-7-adapter` is set and the following attributes/elements are m
 
 The "external task topic" from Camunda Platform 7 is directly translated in a "task type name" in Camunda Platform 8, therefore `camunda:topic` gets `zeebe:taskDefinition type` in your BPMN model.
 
-The [Camunda Platform 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) will pick up your `@ExternalTaskHandler` beans, wrap them into a JobWorker and subscribe to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
+The [Camunda Platform 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) will pick up your `@ExternalTaskHandler` beans, wrap them into a JobWorker, and subscribe to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
 
 ## Adjusting Your BPMN models
 

--- a/docs/guides/migrating-from-camunda-platform-7.md
+++ b/docs/guides/migrating-from-camunda-platform-7.md
@@ -286,7 +286,7 @@ The topic `camunda-7-adapter` is set and the following attributes/elements are m
 
 The "external task topic" from Camunda Platform 7 is directly translated in a "task type name" in Camunda Platform 8, therefore `camunda:topic` gets `zeebe:taskDefinition type` in your BPMN model.
 
-Now, you must adjust your external task worker to become a job worker.
+The [Camunda Platform 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) will pick up your `@ExternalTaskHandler` beans, wrap them into a JobWorker and subscribe to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
 
 ## Adjusting Your BPMN models
 

--- a/versioned_docs/version-8.1/guides/migrating-from-camunda-platform-7.md
+++ b/versioned_docs/version-8.1/guides/migrating-from-camunda-platform-7.md
@@ -286,7 +286,7 @@ The topic `camunda-7-adapter` is set and the following attributes/elements are m
 
 The "external task topic" from Camunda Platform 7 is directly translated in a "task type name" in Camunda Platform 8, therefore `camunda:topic` gets `zeebe:taskDefinition type` in your BPMN model.
 
-The [Camunda Platform 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) will pick up your `@ExternalTaskHandler` beans, wrap them into a JobWorker and subscribe to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
+The [Camunda Platform 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) will pick up your `@ExternalTaskHandler` beans, wrap them into a JobWorker, and subscribe to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
 
 ## Adjusting Your BPMN models
 

--- a/versioned_docs/version-8.1/guides/migrating-from-camunda-platform-7.md
+++ b/versioned_docs/version-8.1/guides/migrating-from-camunda-platform-7.md
@@ -286,7 +286,7 @@ The topic `camunda-7-adapter` is set and the following attributes/elements are m
 
 The "external task topic" from Camunda Platform 7 is directly translated in a "task type name" in Camunda Platform 8, therefore `camunda:topic` gets `zeebe:taskDefinition type` in your BPMN model.
 
-Now, you must adjust your external task worker to become a job worker.
+The [Camunda Platform 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) will pick up your `@ExternalTaskHandler` beans, wrap them into a JobWorker and subscribe to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
 
 ## Adjusting Your BPMN models
 


### PR DESCRIPTION
The migration guide is updated to reflect changes to the camunda-7-adapter library regarding handling of external task subscriptions.

## What is the purpose of the change

The upgrade guide currently states that an external task worker needs to be transformed manually. This is now happening automatically as the camunda-7-adapter can now also wrap `@ExternalTaskHandler` beans.

## Are there related marketing activities

no

## When should this change go live?

As soon as possible

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
