### PR TITLE
docs(zeebe): specify private key format

### DIFF
--- a/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -48,7 +48,7 @@ More specifically, the certificate chain will be part of the trust store of the 
 
 This will allow you to configure each node with a different leaf certificate sharing the same root certificate (or at least an intermediate authority), as long as they're contained in the chain. If all nodes use the same certificate, or if you're certain the certificate is trusted by the root certificates available on each node, it's sufficient for the file to only contain the leaf certificate.
 
-The private key file should be a PEM private key file, and should be the one during generation of the node's public certificate. Algorithms supported for the private keys are: RSA, DSA, and EC. The private key must be generated using [PKCS8](https://datatracker.ietf.org/doc/html/rfc5208); any other format (e.g. PKCS1) will not work with Zeebe. If you're unsure what format your private key is, you can quickly run it through the `openssl` utility to convert it to PKCS8:
+The private key file should be a PEM private key file, and should be the one during generation of the node's public certificate. Algorithms supported for the private keys are RSA, DSA, and EC. The private key must be generated using [PKCS8](https://datatracker.ietf.org/doc/html/rfc5208); any other format (e.g. PKCS1) will not work with Zeebe. If you're unsure what format your private key is, you can quickly run it through the `openssl` utility to convert it to PKCS8:
 
 ```shell
 > openssl pkcs8 -topk8 -nocrypt -in my_private_key -out my_private_pkcs8_key.pem
@@ -157,6 +157,8 @@ openssl genpkey -out nodeC.key -algorithm RSA -pkeyopt rsa_keygen_bits:2048
 :::note
 
 Generating a private key using RSA and `openssl` will generate a PKCS8 private key by default.
+
+:::
 
 2. Create a certificate signing request (CSR) for each as well:
 

--- a/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -48,7 +48,13 @@ More specifically, the certificate chain will be part of the trust store of the 
 
 This will allow you to configure each node with a different leaf certificate sharing the same root certificate (or at least an intermediate authority), as long as they're contained in the chain. If all nodes use the same certificate, or if you're certain the certificate is trusted by the root certificates available on each node, it's sufficient for the file to only contain the leaf certificate.
 
-The private key file should be a PEM private key file, and should be the one during generation of the node's public certificate. Algorithms supported for the private keys are: RSA, DSA, and EC.
+The private key file should be a PEM private key file, and should be the one during generation of the node's public certificate. Algorithms supported for the private keys are: RSA, DSA, and EC. The private key must be generated using [PKCS8](https://datatracker.ietf.org/doc/html/rfc5208); any other format (e.g. PKCS1) will not work with Zeebe. If you're unsure what format your private key is, you can quickly run it through the `openssl` utility to convert it to PKCS8:
+
+```shell
+> openssl pkcs8 -topk8 -nocrypt -in my_private_key -out my_private_pkcs8_key.pem
+```
+
+Remove the `-nocrypt` parameter if your private key has a password. If your certificate is already in the right format, it will simply do nothing. See the [OpenSSL manpages](https://www.openssl.org/docs/man1.1.1/man1/openssl-pkcs8.html) for more options.
 
 :::caution
 
@@ -134,7 +140,6 @@ For this example, whenever you are asked for input, feel free to just press ente
 
 ```shell
 openssl req -config <(printf "[req]\ndistinguished_name=dn\n[dn]\n[ext]\nbasicConstraints=CA:TRUE,pathlen:0") -new -newkey rsa:2048 -nodes -subj "/C=DE/O=Test/OU=Test/ST=BE/CN=cluster.local" -x509 -extensions ext -keyout ca.key -out ca.pem
-openssl x509 -trustout -signkey ca.key -days 365 -req -in ca.csr -out ca.pem
 ```
 
 Once we have our certificate authority, we can now generate certificates for each node. Let's say we have a cluster of three nodes, `A`, `B`, and `C`.
@@ -148,6 +153,10 @@ openssl genpkey -out nodeA.key -algorithm RSA -pkeyopt rsa_keygen_bits:2048
 openssl genpkey -out nodeB.key -algorithm RSA -pkeyopt rsa_keygen_bits:2048
 openssl genpkey -out nodeC.key -algorithm RSA -pkeyopt rsa_keygen_bits:2048
 ```
+
+:::note
+
+Generating a private key using RSA and `openssl` will generate a PKCS8 private key by default.
 
 2. Create a certificate signing request (CSR) for each as well:
 

--- a/docs/self-managed/zeebe-gateway-deployment/the-zeebe-gateway.md
+++ b/docs/self-managed/zeebe-gateway-deployment/the-zeebe-gateway.md
@@ -94,22 +94,28 @@ If you use the Helm charts, both properties are configured for you already.
 
 To configure how the gateway connects and distributes information with other nodes (brokers or gateways) via SWIM, the following properties can be used. It might be useful to increase timeouts for setups that encounter a high latency between nodes.
 
-| Environment variable                                | Application.yaml property                            | Description                                                                                          | Default value |
-| --------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_BROADCASTUPDATES`  | `zeebe.gateway.cluster.membership.broadcastUpdates`  | Configure whether to broadcast member updates to all members.                                        | `false`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_BROADCASTDISPUTES` | `zeebe.gateway.cluster.membership.broadcastDisputes` | Configure whether to broadcast disputes to all members.                                              | `true`        |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_NOTIFYSUSPECT`     | `zeebe.gateway.cluster.membership.notifySuspect`     | Configure whether to notify a suspect node on state changes.                                         | `false`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_GOSSIPINTERVAL`    | `zeebe.gateway.cluster.membership.gossipInterval`    | Sets the interval at which the membership updates are sent to a random member.                       | `250ms`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_GOSSIPFANOUT`      | `zeebe.gateway.cluster.membership.gossipFanout`      | Sets the number of members to which membership updates are sent at each gossip interval.             | `2`           |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBEINTERVAL`     | `zeebe.gateway.cluster.membership.probeInterval`     | Sets the interval at which to probe a random member.                                                 | `1s`          |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT`      | `zeebe.gateway.cluster.membership.probeTimeout`      | Sets the timeout for a probe response.                                                               | `100ms`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SUSPECTPROBES`     | `zeebe.gateway.cluster.membership.suspectProbes`     | Sets the number of probes failed before declaring a member is suspect.                               | `3`           |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_FAILURETIMEOUT`    | `zeebe.gateway.cluster.membership.failureTimeout`    | Sets the timeout for a suspect member declared dead.                                                 | `10s`         |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SYNCINTERVAL`      | `zeebe.gateway.cluster.membership.syncInterval`      | Sets the interval at which this member synchronizes its membership information with a random member. | `10s`         |
+| Environment variable                                 | Application.yaml property                            | Description                                                                                          | Default value |
+| ---------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_BROADCASTUPDATES`  | `zeebe.gateway.cluster.membership.broadcastUpdates`  | Configure whether to broadcast member updates to all members.                                        | `false`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_BROADCASTDISPUTES` | `zeebe.gateway.cluster.membership.broadcastDisputes` | Configure whether to broadcast disputes to all members.                                              | `true`        |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_NOTIFYSUSPECT`     | `zeebe.gateway.cluster.membership.notifySuspect`     | Configure whether to notify a suspect node on state changes.                                         | `false`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_GOSSIPINTERVAL`    | `zeebe.gateway.cluster.membership.gossipInterval`    | Sets the interval at which the membership updates are sent to a random member.                       | `250ms`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_GOSSIPFANOUT`      | `zeebe.gateway.cluster.membership.gossipFanout`      | Sets the number of members to which membership updates are sent at each gossip interval.             | `2`           |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBEINTERVAL`     | `zeebe.gateway.cluster.membership.probeInterval`     | Sets the interval at which to probe a random member.                                                 | `1s`          |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBETIMEOUT`      | `zeebe.gateway.cluster.membership.probeTimeout`      | Sets the timeout for a probe response.                                                               | `100ms`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_SUSPECTPROBES`     | `zeebe.gateway.cluster.membership.suspectProbes`     | Sets the number of probes failed before declaring a member is suspect.                               | `3`           |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_FAILURETIMEOUT`    | `zeebe.gateway.cluster.membership.failureTimeout`    | Sets the timeout for a suspect member declared dead.                                                 | `10s`         |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_SYNCINTERVAL`      | `zeebe.gateway.cluster.membership.syncInterval`      | Sets the interval at which this member synchronizes its membership information with a random member. | `10s`         |
 
-### Security configuration
+### Cluster security configuration
 
-The security configurations allow configuring how the gateway interacts with other nodes inside the Zeebe cluster.
+The cluster security configuration options allow securing communication between the gateway and other nodes in the cluster.
+
+:::note
+
+You can read more about intra-cluster security on [its dedicated page](../zeebe-deployment/security/secure-cluster-communication.md).
+
+:::
 
 | Environment variable                                  | Application.yaml property                             | Description                                                                     | Default value |
 | ----------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------- | ------------- |
@@ -146,7 +152,15 @@ To explore how the gateway behaves, or what it does, metrics can be consumed. By
 | ----------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------- | ------------- |
 | `ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS` | `zeebe.gateway.threads.managementThreads` | Sets the number of threads the gateway will use to communicate with the broker cluster. | `1`           |
 
-### Security configurations
+### Client security configuration
+
+The client security configuration options allow securing the communication between a gateway and clients.
+
+:::note
+
+You can read more about client-gateway security on [its dedicated page](../zeebe-deployment/security/secure-client-communication.md).
+
+:::
 
 | Environment variable                          | Application.yaml property                     | Description                                                 | Default value |
 | --------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------- | ------------- |

--- a/versioned_docs/version-8.0/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.0/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -48,7 +48,13 @@ More specifically, the certificate chain will be part of the trust store of the 
 
 This will allow you to configure each node with a different leaf certificate sharing the same root certificate (or at least an intermediate authority), as long as they're contained in the chain. If all nodes use the same certificate, or if you're certain the certificate is trusted by the root certificates available on each node, it's sufficient for the file to only contain the leaf certificate.
 
-The private key file should be a PEM private key file, and should be the one during generation of the node's public certificate. Algorithms supported for the private keys are: RSA, DSA, and EC.
+The private key file should be a PEM private key file, and should be the one during generation of the node's public certificate. Algorithms supported for the private keys are: RSA, DSA, and EC. The private key must be generated using [PKCS8](https://datatracker.ietf.org/doc/html/rfc5208); any other format (e.g. PKCS1) will not work with Zeebe. If you're unsure what format your private key is, you can quickly run it through the `openssl` utility to convert it to PKCS8:
+
+```shell
+> openssl pkcs8 -topk8 -nocrypt -in my_private_key -out my_private_pkcs8_key.pem
+```
+
+Remove the `-nocrypt` parameter if your private key has a password. If your certificate is already in the right format, it will simply do nothing. See the [OpenSSL manpages](https://www.openssl.org/docs/man1.1.1/man1/openssl-pkcs8.html) for more options.
 
 :::caution
 

--- a/versioned_docs/version-8.0/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.0/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -48,7 +48,7 @@ More specifically, the certificate chain will be part of the trust store of the 
 
 This will allow you to configure each node with a different leaf certificate sharing the same root certificate (or at least an intermediate authority), as long as they're contained in the chain. If all nodes use the same certificate, or if you're certain the certificate is trusted by the root certificates available on each node, it's sufficient for the file to only contain the leaf certificate.
 
-The private key file should be a PEM private key file, and should be the one during generation of the node's public certificate. Algorithms supported for the private keys are: RSA, DSA, and EC. The private key must be generated using [PKCS8](https://datatracker.ietf.org/doc/html/rfc5208); any other format (e.g. PKCS1) will not work with Zeebe. If you're unsure what format your private key is, you can quickly run it through the `openssl` utility to convert it to PKCS8:
+The private key file should be a PEM private key file, and should be the one during generation of the node's public certificate. Algorithms supported for the private keys are RSA, DSA, and EC. The private key must be generated using [PKCS8](https://datatracker.ietf.org/doc/html/rfc5208); any other format (e.g. PKCS1) will not work with Zeebe. If you're unsure what format your private key is, you can quickly run it through the `openssl` utility to convert it to PKCS8:
 
 ```shell
 > openssl pkcs8 -topk8 -nocrypt -in my_private_key -out my_private_pkcs8_key.pem

--- a/versioned_docs/version-8.0/self-managed/zeebe-gateway-deployment/the-zeebe-gateway.md
+++ b/versioned_docs/version-8.0/self-managed/zeebe-gateway-deployment/the-zeebe-gateway.md
@@ -94,22 +94,28 @@ If you use the Helm charts, both properties are configured for you already.
 
 To configure how the gateway connects and distributes information with other nodes (brokers or gateways) via SWIM, the following properties can be used. It might be useful to increase timeouts for setups that encounter a high latency between nodes.
 
-| Environment variable                                | Application.yaml property                            | Description                                                                                          | Default value |
-| --------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_BROADCASTUPDATES`  | `zeebe.gateway.cluster.membership.broadcastUpdates`  | Configure whether to broadcast member updates to all members.                                        | `false`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_BROADCASTDISPUTES` | `zeebe.gateway.cluster.membership.broadcastDisputes` | Configure whether to broadcast disputes to all members.                                              | `true`        |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_NOTIFYSUSPECT`     | `zeebe.gateway.cluster.membership.notifySuspect`     | Configure whether to notify a suspect node on state changes.                                         | `false`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_GOSSIPINTERVAL`    | `zeebe.gateway.cluster.membership.gossipInterval`    | Sets the interval at which the membership updates are sent to a random member.                       | `250ms`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_GOSSIPFANOUT`      | `zeebe.gateway.cluster.membership.gossipFanout`      | Sets the number of members to which membership updates are sent at each gossip interval.             | `2`           |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBEINTERVAL`     | `zeebe.gateway.cluster.membership.probeInterval`     | Sets the interval at which to probe a random member.                                                 | `1s`          |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT`      | `zeebe.gateway.cluster.membership.probeTimeout`      | Sets the timeout for a probe response.                                                               | `100ms`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SUSPECTPROBES`     | `zeebe.gateway.cluster.membership.suspectProbes`     | Sets the number of probes failed before declaring a member is suspect.                               | `3`           |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_FAILURETIMEOUT`    | `zeebe.gateway.cluster.membership.failureTimeout`    | Sets the timeout for a suspect member declared dead.                                                 | `10s`         |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SYNCINTERVAL`      | `zeebe.gateway.cluster.membership.syncInterval`      | Sets the interval at which this member synchronizes its membership information with a random member. | `10s`         |
+| Environment variable                                 | Application.yaml property                            | Description                                                                                          | Default value |
+| ---------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_BROADCASTUPDATES`  | `zeebe.gateway.cluster.membership.broadcastUpdates`  | Configure whether to broadcast member updates to all members.                                        | `false`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_BROADCASTDISPUTES` | `zeebe.gateway.cluster.membership.broadcastDisputes` | Configure whether to broadcast disputes to all members.                                              | `true`        |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_NOTIFYSUSPECT`     | `zeebe.gateway.cluster.membership.notifySuspect`     | Configure whether to notify a suspect node on state changes.                                         | `false`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_GOSSIPINTERVAL`    | `zeebe.gateway.cluster.membership.gossipInterval`    | Sets the interval at which the membership updates are sent to a random member.                       | `250ms`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_GOSSIPFANOUT`      | `zeebe.gateway.cluster.membership.gossipFanout`      | Sets the number of members to which membership updates are sent at each gossip interval.             | `2`           |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBEINTERVAL`     | `zeebe.gateway.cluster.membership.probeInterval`     | Sets the interval at which to probe a random member.                                                 | `1s`          |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBETIMEOUT`      | `zeebe.gateway.cluster.membership.probeTimeout`      | Sets the timeout for a probe response.                                                               | `100ms`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_SUSPECTPROBES`     | `zeebe.gateway.cluster.membership.suspectProbes`     | Sets the number of probes failed before declaring a member is suspect.                               | `3`           |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_FAILURETIMEOUT`    | `zeebe.gateway.cluster.membership.failureTimeout`    | Sets the timeout for a suspect member declared dead.                                                 | `10s`         |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_SYNCINTERVAL`      | `zeebe.gateway.cluster.membership.syncInterval`      | Sets the interval at which this member synchronizes its membership information with a random member. | `10s`         |
 
-### Security configuration
+### Cluster security configuration
 
-The security configurations allow configuring how the gateway interacts with other nodes inside the Zeebe cluster.
+The cluster security configuration options allow securing communication between the gateway and other nodes in the cluster.
+
+:::note
+
+You can read more about intra-cluster security on [its dedicated page](../zeebe-deployment/security/secure-cluster-communication.md).
+
+:::
 
 | Environment variable                                  | Application.yaml property                             | Description                                                                     | Default value |
 | ----------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------- | ------------- |
@@ -146,7 +152,15 @@ To explore how the gateway behaves, or what it does, metrics can be consumed. By
 | ----------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------- | ------------- |
 | `ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS` | `zeebe.gateway.threads.managementThreads` | Sets the number of threads the gateway will use to communicate with the broker cluster. | `1`           |
 
-### Security configurations
+### Client security configuration
+
+The client security configuration options allow securing the communication between a gateway and clients.
+
+:::note
+
+You can read more about client-gateway security on [its dedicated page](../zeebe-deployment/security/secure-client-communication.md).
+
+:::
 
 | Environment variable                          | Application.yaml property                     | Description                                                 | Default value |
 | --------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------- | ------------- |

--- a/versioned_docs/version-8.1/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.1/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -48,7 +48,13 @@ More specifically, the certificate chain will be part of the trust store of the 
 
 This will allow you to configure each node with a different leaf certificate sharing the same root certificate (or at least an intermediate authority), as long as they're contained in the chain. If all nodes use the same certificate, or if you're certain the certificate is trusted by the root certificates available on each node, it's sufficient for the file to only contain the leaf certificate.
 
-The private key file should be a PEM private key file, and should be the one during generation of the node's public certificate. Algorithms supported for the private keys are: RSA, DSA, and EC.
+The private key file should be a PEM private key file, and should be the one during generation of the node's public certificate. Algorithms supported for the private keys are: RSA, DSA, and EC. The private key must be generated using [PKCS8](https://datatracker.ietf.org/doc/html/rfc5208); any other format (e.g. PKCS1) will not work with Zeebe. If you're unsure what format your private key is, you can quickly run it through the `openssl` utility to convert it to PKCS8:
+
+```shell
+> openssl pkcs8 -topk8 -nocrypt -in my_private_key -out my_private_pkcs8_key.pem
+```
+
+Remove the `-nocrypt` parameter if your private key has a password. If your certificate is already in the right format, it will simply do nothing. See the [OpenSSL manpages](https://www.openssl.org/docs/man1.1.1/man1/openssl-pkcs8.html) for more options.
 
 :::caution
 

--- a/versioned_docs/version-8.1/self-managed/zeebe-gateway-deployment/the-zeebe-gateway.md
+++ b/versioned_docs/version-8.1/self-managed/zeebe-gateway-deployment/the-zeebe-gateway.md
@@ -94,22 +94,28 @@ If you use the Helm charts, both properties are configured for you already.
 
 To configure how the gateway connects and distributes information with other nodes (brokers or gateways) via SWIM, the following properties can be used. It might be useful to increase timeouts for setups that encounter a high latency between nodes.
 
-| Environment variable                                | Application.yaml property                            | Description                                                                                          | Default value |
-| --------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_BROADCASTUPDATES`  | `zeebe.gateway.cluster.membership.broadcastUpdates`  | Configure whether to broadcast member updates to all members.                                        | `false`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_BROADCASTDISPUTES` | `zeebe.gateway.cluster.membership.broadcastDisputes` | Configure whether to broadcast disputes to all members.                                              | `true`        |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_NOTIFYSUSPECT`     | `zeebe.gateway.cluster.membership.notifySuspect`     | Configure whether to notify a suspect node on state changes.                                         | `false`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_GOSSIPINTERVAL`    | `zeebe.gateway.cluster.membership.gossipInterval`    | Sets the interval at which the membership updates are sent to a random member.                       | `250ms`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_GOSSIPFANOUT`      | `zeebe.gateway.cluster.membership.gossipFanout`      | Sets the number of members to which membership updates are sent at each gossip interval.             | `2`           |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBEINTERVAL`     | `zeebe.gateway.cluster.membership.probeInterval`     | Sets the interval at which to probe a random member.                                                 | `1s`          |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT`      | `zeebe.gateway.cluster.membership.probeTimeout`      | Sets the timeout for a probe response.                                                               | `100ms`       |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SUSPECTPROBES`     | `zeebe.gateway.cluster.membership.suspectProbes`     | Sets the number of probes failed before declaring a member is suspect.                               | `3`           |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_FAILURETIMEOUT`    | `zeebe.gateway.cluster.membership.failureTimeout`    | Sets the timeout for a suspect member declared dead.                                                 | `10s`         |
-| `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SYNCINTERVAL`      | `zeebe.gateway.cluster.membership.syncInterval`      | Sets the interval at which this member synchronizes its membership information with a random member. | `10s`         |
+| Environment variable                                 | Application.yaml property                            | Description                                                                                          | Default value |
+| ---------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_BROADCASTUPDATES`  | `zeebe.gateway.cluster.membership.broadcastUpdates`  | Configure whether to broadcast member updates to all members.                                        | `false`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_BROADCASTDISPUTES` | `zeebe.gateway.cluster.membership.broadcastDisputes` | Configure whether to broadcast disputes to all members.                                              | `true`        |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_NOTIFYSUSPECT`     | `zeebe.gateway.cluster.membership.notifySuspect`     | Configure whether to notify a suspect node on state changes.                                         | `false`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_GOSSIPINTERVAL`    | `zeebe.gateway.cluster.membership.gossipInterval`    | Sets the interval at which the membership updates are sent to a random member.                       | `250ms`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_GOSSIPFANOUT`      | `zeebe.gateway.cluster.membership.gossipFanout`      | Sets the number of members to which membership updates are sent at each gossip interval.             | `2`           |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBEINTERVAL`     | `zeebe.gateway.cluster.membership.probeInterval`     | Sets the interval at which to probe a random member.                                                 | `1s`          |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBETIMEOUT`      | `zeebe.gateway.cluster.membership.probeTimeout`      | Sets the timeout for a probe response.                                                               | `100ms`       |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_SUSPECTPROBES`     | `zeebe.gateway.cluster.membership.suspectProbes`     | Sets the number of probes failed before declaring a member is suspect.                               | `3`           |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_FAILURETIMEOUT`    | `zeebe.gateway.cluster.membership.failureTimeout`    | Sets the timeout for a suspect member declared dead.                                                 | `10s`         |
+| `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_SYNCINTERVAL`      | `zeebe.gateway.cluster.membership.syncInterval`      | Sets the interval at which this member synchronizes its membership information with a random member. | `10s`         |
 
-### Security configuration
+### Cluster security configuration
 
-The security configurations allow configuring how the gateway interacts with other nodes inside the Zeebe cluster.
+The cluster security configuration options allow securing communication between the gateway and other nodes in the cluster.
+
+:::note
+
+You can read more about intra-cluster security on [its dedicated page](../zeebe-deployment/security/secure-cluster-communication.md).
+
+:::
 
 | Environment variable                                  | Application.yaml property                             | Description                                                                     | Default value |
 | ----------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------- | ------------- |
@@ -146,7 +152,15 @@ To explore how the gateway behaves, or what it does, metrics can be consumed. By
 | ----------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------- | ------------- |
 | `ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS` | `zeebe.gateway.threads.managementThreads` | Sets the number of threads the gateway will use to communicate with the broker cluster. | `1`           |
 
-### Security configurations
+### Client security configuration
+
+The client security configuration options allow securing the communication between a gateway and clients.
+
+:::note
+
+You can read more about client-gateway security on [its dedicated page](../zeebe-deployment/security/secure-client-communication.md).
+
+:::
 
 | Environment variable                          | Application.yaml property                     | Description                                                 | Default value |
 | --------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------- | ------------- |


### PR DESCRIPTION
## What is the purpose of the change

Adds a note to specify that private keys for Zeebe (both broker and gateway) must be in the PKCS8 format, and explain how to convert existing private keys to this format.

For the record, this is a Netty limitation, and Netty is used both by the intra-cluster communication layer and grpc-java (for the clients). See https://netty.io/wiki/sslcontextbuilder-and-private-key.html

This came out of a question on Slack by @jonathanlukas, see https://camunda.slack.com/archives/CSQ2E3BT4/p1667382648872449, and a support ticket: https://jira.camunda.com/browse/SUPPORT-14626

## When should this change go live?

Whenever, it's not particular urgent.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
