### PR TITLE
feat(comp/console): add dev cluster reservations

### DIFF
--- a/docs/components/console/manage-organization/update-billing-reservations.md
+++ b/docs/components/console/manage-organization/update-billing-reservations.md
@@ -26,3 +26,9 @@ You can access the **Billing** page by selecting **Organization Management** in 
 ### Edit reservations (Professional Plan only)
 
 Use the **Edit** button to change the number of reserved clusters. The number of reserved clusters cannot exceed the maximum limit and cannot go below what is currently in use.
+
+### Edit development cluster reservations (Professional Plan only)
+
+In order to be able to use a **Development Cluster**, reservations must be available, as with hardware packages. To update reservations, scroll to the Development Cluster section and use the **Edit** button to increase or decrease the reservations. The number of reserved development clusters cannot exceed the maximum limit and cannot go below what is currently in use.
+
+As soon as a reservation has been made, a development cluster can be set up via the [create cluster dialog](../manage-clusters/create-cluster-include.md).

--- a/docs/components/console/manage-organization/update-billing-reservations.md
+++ b/docs/components/console/manage-organization/update-billing-reservations.md
@@ -29,6 +29,6 @@ Use the **Edit** button to change the number of reserved clusters. The number of
 
 ### Edit development cluster reservations (Professional Plan only)
 
-In order to be able to use a **Development Cluster**, reservations must be available, as with hardware packages. To update reservations, scroll to the Development Cluster section and use the **Edit** button to increase or decrease the reservations. The number of reserved development clusters cannot exceed the maximum limit and cannot go below what is currently in use.
+To use a **development cluster**, reservations must be available, as with hardware packages. To update reservations, scroll to the **Development Cluster** section and click the **Edit** button to increase or decrease the reservations. The number of reserved development clusters cannot exceed the maximum limit and cannot go below what is currently in use.
 
 As soon as a reservation has been made, a development cluster can be set up via the [create cluster dialog](../manage-clusters/create-cluster-include.md).

--- a/versioned_docs/version-8.1/components/console/manage-organization/update-billing-reservations.md
+++ b/versioned_docs/version-8.1/components/console/manage-organization/update-billing-reservations.md
@@ -26,3 +26,9 @@ You can access the **Billing** page by selecting **Organization Management** in 
 ### Edit reservations (Professional Plan only)
 
 Use the **Edit** button to change the number of reserved clusters. The number of reserved clusters cannot exceed the maximum limit and cannot go below what is currently in use.
+
+### Edit development cluster reservations (Professional Plan only)
+
+In order to be able to use a **Development Cluster**, reservations must be available, as with hardware packages. To update reservations, scroll to the Development Cluster section and use the **Edit** button to increase or decrease the reservations. The number of reserved development clusters cannot exceed the maximum limit and cannot go below what is currently in use.
+
+As soon as a reservation has been made, a development cluster can be set up via the [create cluster dialog](../manage-clusters/create-cluster-include.md).

--- a/versioned_docs/version-8.1/components/console/manage-organization/update-billing-reservations.md
+++ b/versioned_docs/version-8.1/components/console/manage-organization/update-billing-reservations.md
@@ -29,6 +29,6 @@ Use the **Edit** button to change the number of reserved clusters. The number of
 
 ### Edit development cluster reservations (Professional Plan only)
 
-In order to be able to use a **Development Cluster**, reservations must be available, as with hardware packages. To update reservations, scroll to the Development Cluster section and use the **Edit** button to increase or decrease the reservations. The number of reserved development clusters cannot exceed the maximum limit and cannot go below what is currently in use.
+To use a **development cluster**, reservations must be available, as with hardware packages. To update reservations, scroll to the **Development Cluster** section and click the **Edit** button to increase or decrease the reservations. The number of reserved development clusters cannot exceed the maximum limit and cannot go below what is currently in use.
 
 As soon as a reservation has been made, a development cluster can be set up via the [create cluster dialog](../manage-clusters/create-cluster-include.md).


### PR DESCRIPTION
## What is the purpose of the change

* New Feature in SaaS: Development Clusters
* Add docs about how to change dev cluster reservations on billing page

## Are there related marketing activities

I guess a blog post is in preparation for this feature.

## When should this change go live?

After Prod Launch of dev clusters, relates https://github.com/camunda-cloud/console/issues/3520

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
