### PR TITLE
Add security notice for CVE-2022-3602 and CVE-2022-3786

### DIFF
--- a/docs/reference/notices.md
+++ b/docs/reference/notices.md
@@ -8,6 +8,36 @@ description: "Let's take a closer look at security notices, reporting vulnerabil
 
 Camunda publishes security notices after fixes are available.
 
+### Notice 10
+
+#### Publication Date:
+
+November 10th, 2022
+
+#### Product affected:
+
+Tasklist
+
+#### Impact:
+
+The Tasklist docker image contain an OpenSSL version 3.0.2 for which the following CVEs have been published:
+
+- https://nvd.nist.gov/vuln/detail/CVE-2022-3602
+- https://nvd.nist.gov/vuln/detail/CVE-2022-3786
+
+At this point, Camunda is not aware of any specific attack vector in Tasklist allowing attackers to exploit the vulnerability but recommends applying fixes as mentioned in the Solution section below.
+
+#### How to determine if the installation is affected
+
+You are Tasklist version (8.0.3 >= version <= 8.0.7) or <= 8.1.2
+
+#### Solution
+
+Camunda has provided the following releases which contain a fix
+
+- [Tasklist 8.1.3](https://github.com/camunda/camunda-platform/releases/tag/8.1.3)
+- [Tasklist 8.0.8](https://github.com/camunda/camunda-platform/releases/tag/8.0.8)
+
 ### Notice 9
 
 #### Publication Date:

--- a/versioned_docs/version-8.0/reference/notices.md
+++ b/versioned_docs/version-8.0/reference/notices.md
@@ -8,6 +8,36 @@ description: "Let's take a closer look at security notices, reporting vulnerabil
 
 Camunda publishes security notices after fixes are available.
 
+### Notice 10
+
+#### Publication Date:
+
+November 10th, 2022
+
+#### Product affected:
+
+Tasklist
+
+#### Impact:
+
+The Tasklist docker image contain an OpenSSL version 3.0.2 for which the following CVEs have been published:
+
+- https://nvd.nist.gov/vuln/detail/CVE-2022-3602
+- https://nvd.nist.gov/vuln/detail/CVE-2022-3786
+
+At this point, Camunda is not aware of any specific attack vector in Tasklist allowing attackers to exploit the vulnerability but recommends applying fixes as mentioned in the Solution section below.
+
+#### How to determine if the installation is affected
+
+You are Tasklist version (8.0.3 >= version <= 8.0.7) or <= 8.1.2
+
+#### Solution
+
+Camunda has provided the following releases which contain a fix
+
+- [Tasklist 8.1.3](https://github.com/camunda/camunda-platform/releases/tag/8.1.3)
+- [Tasklist 8.0.8](https://github.com/camunda/camunda-platform/releases/tag/8.0.8)
+
 ### Notice 9
 
 #### Publication Date:

--- a/versioned_docs/version-8.1/reference/notices.md
+++ b/versioned_docs/version-8.1/reference/notices.md
@@ -8,6 +8,36 @@ description: "Let's take a closer look at security notices, reporting vulnerabil
 
 Camunda publishes security notices after fixes are available.
 
+### Notice 10
+
+#### Publication Date:
+
+November 10th, 2022
+
+#### Product affected:
+
+Tasklist
+
+#### Impact:
+
+The Tasklist docker image contain an OpenSSL version 3.0.2 for which the following CVEs have been published:
+
+- https://nvd.nist.gov/vuln/detail/CVE-2022-3602
+- https://nvd.nist.gov/vuln/detail/CVE-2022-3786
+
+At this point, Camunda is not aware of any specific attack vector in Tasklist allowing attackers to exploit the vulnerability but recommends applying fixes as mentioned in the Solution section below.
+
+#### How to determine if the installation is affected
+
+You are Tasklist version (8.0.3 >= version <= 8.0.7) or <= 8.1.2
+
+#### Solution
+
+Camunda has provided the following releases which contain a fix
+
+- [Tasklist 8.1.3](https://github.com/camunda/camunda-platform/releases/tag/8.1.3)
+- [Tasklist 8.0.8](https://github.com/camunda/camunda-platform/releases/tag/8.0.8)
+
 ### Notice 9
 
 #### Publication Date:


### PR DESCRIPTION
## What is the purpose of the change

Add a security notice for Tasklist for the latest OpenSSL vulnerabilities

## Are there related marketing activities

No

## When should this change go live?

As soon as merged. The patched versions are released. 

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
