### PR TITLE
Explicitly mention variable creation behaviour

### DIFF
--- a/docs/components/modeler/bpmn/event-subprocesses/event-subprocesses.md
+++ b/docs/components/modeler/bpmn/event-subprocesses/event-subprocesses.md
@@ -26,7 +26,7 @@ If an event subprocess is triggered, its containing scope is not completed until
 
 Unlike a boundary event, an event subprocess is inside the scope. Therefore, it can access and modify all local variables of its containing scope. This is not possible with a boundary event because a boundary event is outside of the scope.
 
-Input mappings can be used to create new local variables in the scope of the event subprocess. These variables are only visible within the event subprocess.
+Input mappings can be used to create new local variables in the scope of the event subprocess. These variables are only visible within the event subprocess. If no input mappings are defined, the [default behaviour](../../../concepts/variables.md#variable-scopes) is applied to the variables coming with the event.
 
 By default, the local variables of the event subprocess are not propagated (i.e. removed with the scope). This behavior can be customized by defining output mappings at the event subprocess. The output mappings are applied on completion of the event subprocess.
 

--- a/docs/components/modeler/bpmn/event-subprocesses/event-subprocesses.md
+++ b/docs/components/modeler/bpmn/event-subprocesses/event-subprocesses.md
@@ -26,7 +26,7 @@ If an event subprocess is triggered, its containing scope is not completed until
 
 Unlike a boundary event, an event subprocess is inside the scope. Therefore, it can access and modify all local variables of its containing scope. This is not possible with a boundary event because a boundary event is outside of the scope.
 
-Input mappings can be used to create new local variables in the scope of the event subprocess. These variables are only visible within the event subprocess. If no input mappings are defined, the [default behaviour](../../../concepts/variables.md#variable-scopes) is applied to the variables coming with the event.
+Input mappings can be used to create new local variables in the scope of the event subprocess. These variables are only visible within the event subprocess. If no input mappings are defined, the [default behavior](../../../concepts/variables.md#variable-scopes) is applied to the variables alongside the event.
 
 By default, the local variables of the event subprocess are not propagated (i.e. removed with the scope). This behavior can be customized by defining output mappings at the event subprocess. The output mappings are applied on completion of the event subprocess.
 

--- a/versioned_docs/version-8.0/components/modeler/bpmn/event-subprocesses/event-subprocesses.md
+++ b/versioned_docs/version-8.0/components/modeler/bpmn/event-subprocesses/event-subprocesses.md
@@ -26,7 +26,7 @@ If an event subprocess is triggered, its containing scope is not completed until
 
 Unlike a boundary event, an event subprocess is inside the scope. Therefore, it can access and modify all local variables of its containing scope. This is not possible with a boundary event because a boundary event is outside of the scope.
 
-Input mappings can be used to create new local variables in the scope of the event subprocess. These variables are only visible within the event subprocess.
+Input mappings can be used to create new local variables in the scope of the event subprocess. These variables are only visible within the event subprocess. If no input mappings are defined, the [default behavior](../../../concepts/variables.md#variable-scopes) is applied to the variables alongside the event.
 
 By default, the local variables of the event subprocess are not propagated (i.e. removed with the scope). This behavior can be customized by defining output mappings at the event subprocess. The output mappings are applied on completion of the event subprocess.
 

--- a/versioned_docs/version-8.1/components/modeler/bpmn/event-subprocesses/event-subprocesses.md
+++ b/versioned_docs/version-8.1/components/modeler/bpmn/event-subprocesses/event-subprocesses.md
@@ -26,7 +26,7 @@ If an event subprocess is triggered, its containing scope is not completed until
 
 Unlike a boundary event, an event subprocess is inside the scope. Therefore, it can access and modify all local variables of its containing scope. This is not possible with a boundary event because a boundary event is outside of the scope.
 
-Input mappings can be used to create new local variables in the scope of the event subprocess. These variables are only visible within the event subprocess.
+Input mappings can be used to create new local variables in the scope of the event subprocess. These variables are only visible within the event subprocess. If no input mappings are defined, the [default behavior](../../../concepts/variables.md#variable-scopes) is applied to the variables alongside the event.
 
 By default, the local variables of the event subprocess are not propagated (i.e. removed with the scope). This behavior can be customized by defining output mappings at the event subprocess. The output mappings are applied on completion of the event subprocess.
 


### PR DESCRIPTION
When variables are coming with a start-event of an event-subprocess, the variable creation works in the default way. However, this might be confusing. So we should actually mention it.

## What is the purpose of the change

Give a better insight on engine behaviour

## Are there related marketing activities

no

## When should this change go live?

asap

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
