### PR TITLE
chore(backup): update take backup response code

### DIFF
--- a/docs/self-managed/backup-restore/optimize-backup.md
+++ b/docs/self-managed/backup-restore/optimize-backup.md
@@ -46,7 +46,7 @@ POST actuator/backup
 
 | Code             | Description                                                                                                                                 |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| 202 Accepted     | Backup process was successfully initiated. To determine whether backup process has completed refer to the GET API.                          |
+| 202 Accepted     | Backup process was successfully initiated. To determine whether backup process was completed refer to the GET API.                          |
 | 400 Bad Request  | Indicates issues with the request, for example when the `backupId` contains invalid characters.                                             |
 | 409 Conflict     | Indicates that a backup with the same `backupId` already exists.                                                                            |
 | 500 Server Error | All other errors, e.g. issues communicating with Elasticsearch for snapshot creation. Refer to the returned error message for more details. |

--- a/docs/self-managed/backup-restore/optimize-backup.md
+++ b/docs/self-managed/backup-restore/optimize-backup.md
@@ -44,12 +44,12 @@ POST actuator/backup
 
 ### Response
 
-| Code             | Description                                                                                                                                                                                                                                                   |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 200 OK           | Backup was successfully started. List of snapshot names is returned in response body (see example below). We recommend storing this information to be able to refer to it later when, for example, checking the backup state or restoring specific snapshots. |
-| 400 Bad Request  | Indicates issues with the request, for example when the `backupId` contains invalid characters.                                                                                                                                                               |
-| 409 Conflict     | Indicates that a backup with the same `backupId` already exists.                                                                                                                                                                                              |
-| 500 Server Error | All other errors, e.g. issues communicating with Elasticsearch for snapshot creation. Refer to the returned error message for more details.                                                                                                                   |
+| Code             | Description                                                                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| 202 Accepted     | Backup process was successfully initiated. To determine whether backup process has completed refer to the GET API.                          |
+| 400 Bad Request  | Indicates issues with the request, for example when the `backupId` contains invalid characters.                                             |
+| 409 Conflict     | Indicates that a backup with the same `backupId` already exists.                                                                            |
+| 500 Server Error | All other errors, e.g. issues communicating with Elasticsearch for snapshot creation. Refer to the returned error message for more details. |
 
 ### Example request
 


### PR DESCRIPTION
related to OPT-6568

## What is the purpose of the change

Update the response code for the take backup API as adjusted with OPT-6568 (https://github.com/camunda/camunda-optimize/pull/5466)

## Are there related marketing activities

No

## When should this change go live?

With the next release

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
