### PR TITLE
chore(self-managed): set index page for platform guides

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/guides.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/guides.md
@@ -9,6 +9,6 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
 Camunda Platform 8 Self-Managed is highly customizable and can be deployed in different setups. This section highlights various use cases and scenarios of configuring Camunda Platform 8 beyond the default values.
 
-Each guide is considered complete and standalone use case, however, make sure to view the [Deploying Camunda Platform 8 using Helm charts](../deploy.md) page which is the base for all guides.
+Each guide is considered complete and a standalone use case. However, view the [deploying Camunda Platform 8 using Helm charts](../deploy.md) page, as this is the base for all guides.
 
 <DocCardList items={useCurrentSidebarCategory().items}/>

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/guides.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/guides.md
@@ -1,0 +1,14 @@
+---
+id: guides
+title: "Configuration and deployment user guides"
+description: "Various use cases configuring and deploying Camunda Platform 8."
+---
+
+import DocCardList from '@theme/DocCardList';
+import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
+
+Camunda Platform 8 Self-Managed is highly customizable and can be deployed in different setups. This section highlights various use cases and scenarios of configuring Camunda Platform 8 beyond the default values.
+
+Each guide is considered complete and standalone use case, however, make sure to view the [Deploying Camunda Platform 8 using Helm charts](../deploy.md) page which is the base for all guides.
+
+<DocCardList items={useCurrentSidebarCategory().items}/>

--- a/sidebars.js
+++ b/sidebars.js
@@ -666,7 +666,13 @@ module.exports = {
               ],
             },
             {
-              Guides: [
+              type: "category",
+              label: "Guides",
+              link: {
+                type: "doc",
+                id: "self-managed/platform-deployment/helm-kubernetes/guides/guides",
+              },
+              items: [
                 "self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster",
                 "self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress",
                 "self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup",

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/guides.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/guides.md
@@ -9,6 +9,6 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
 Camunda Platform 8 Self-Managed is highly customizable and can be deployed in different setups. This section highlights various use cases and scenarios of configuring Camunda Platform 8 beyond the default values.
 
-Each guide is considered complete and standalone use case, however, make sure to view the [Deploying Camunda Platform 8 using Helm charts](../deploy.md) page which is the base for all guides.
+Each guide is considered complete and a standalone use case. However, view the [deploying Camunda Platform 8 using Helm charts](../deploy.md) page, as this is the base for all guides.
 
 <DocCardList items={useCurrentSidebarCategory().items}/>

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/guides.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/guides.md
@@ -1,0 +1,14 @@
+---
+id: guides
+title: "Configuration and deployment user guides"
+description: "Various use cases configuring and deploying Camunda Platform 8."
+---
+
+import DocCardList from '@theme/DocCardList';
+import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
+
+Camunda Platform 8 Self-Managed is highly customizable and can be deployed in different setups. This section highlights various use cases and scenarios of configuring Camunda Platform 8 beyond the default values.
+
+Each guide is considered complete and standalone use case, however, make sure to view the [Deploying Camunda Platform 8 using Helm charts](../deploy.md) page which is the base for all guides.
+
+<DocCardList items={useCurrentSidebarCategory().items}/>

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -796,7 +796,13 @@
               ]
             },
             {
-              "Guides": [
+              "type": "category",
+              "label": "Guides",
+              "link": {
+                "type": "doc",
+                "id": "self-managed/platform-deployment/helm-kubernetes/guides/guides"
+              },
+              "items": [
                 "self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster",
                 "self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress",
                 "self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup",


### PR DESCRIPTION
## What is the purpose of the change

The same as in #1502,  adding an index page for the `guides` category where it has its own link as well as embedded auto-generated items. 

This will also make it better for readability when referring to or sharing this specific category.

Here is the newly introduced link:
https://docs.camunda.io/docs/next/self-managed/platform-deployment/helm-kubernetes/guides/

## Are there related marketing activities

No.

## When should this change go live?

No specific time, as soon as possible.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory.
- [x] My changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.