### PR TITLE
chore(modeler): backport BPMN coverage to 8.x

### DIFF
--- a/versioned_docs/version-8.0/components/modeler/bpmn/bpmn-coverage.md
+++ b/versioned_docs/version-8.0/components/modeler/bpmn/bpmn-coverage.md
@@ -10,8 +10,7 @@ export const Highlight = ({children, color}) => (
 </span>
 );
 
-The following BPMN elements in <Highlight color="#11c399">green</Highlight> are supported. Click on
-an element to navigate to the documentation.
+The following BPMN elements are supported by our modeling tools. Elements highlighted in <Highlight color="#11c399">green</Highlight> are supported for execution by Camunda 8. Click on an element to navigate to the documentation.
 
 ## Participants
 

--- a/versioned_docs/version-8.1/components/modeler/bpmn/bpmn-coverage.md
+++ b/versioned_docs/version-8.1/components/modeler/bpmn/bpmn-coverage.md
@@ -10,8 +10,7 @@ export const Highlight = ({children, color}) => (
 </span>
 );
 
-The following BPMN elements in <Highlight color="#11c399">green</Highlight> are supported. Click on
-an element to navigate to the documentation.
+The following BPMN elements are supported by our modeling tools. Elements highlighted in <Highlight color="#11c399">green</Highlight> are supported for execution by Camunda 8. Click on an element to navigate to the documentation.
 
 ## Participants
 


### PR DESCRIPTION
## What is the purpose of the change

Make https://github.com/camunda/camunda-platform-docs/pull/1540 available in 8.x documentation.

## Are there related marketing activities

No.

## When should this change go live?

December 12th.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
