### PR TITLE
docs(go-client): add missing task header detail and refer to Operate instead of Zeebe Monitor

### DIFF
--- a/docs/apis-clients/go-client/go-get-started.md
+++ b/docs/apis-clients/go-client/go-get-started.md
@@ -213,6 +213,8 @@ Now, we want to do some work within our process. Follow the steps below:
 - Set the **type** of the second task to `fetcher-service`.
 - Set the **type** of the third task to `shipping-service`.
 
+5. Additionally, for the service task `Collect Money` set a [**task-header**](/docs/next/components/modeler/bpmn/service-tasks/#task-headers) with the key `method` and the value `VISA`. This header is used as a configuration parameter for the payment-service worker to hand over the payment method.
+
 The consolidated example looks as follows:
 
 ```go
@@ -339,7 +341,7 @@ The job worker will repeatedly poll for new jobs of the type `payment-service` a
 The handler will then complete the job with its result or fail the job if
 it encounters a problem while processing the job.
 
-When observing the Zeebe Monitor, you can see the process instance moved from the first service task to the next one.
+When observing the current state of the process in Operate, you can see the process instance moved from the first service task to the next one.
 
 When you run the example above, you should see a similar output to the following:
 

--- a/versioned_docs/version-1.3/apis-clients/go-client/get-started.md
+++ b/versioned_docs/version-1.3/apis-clients/go-client/get-started.md
@@ -214,6 +214,8 @@ Now, we want to do some work within our process. Follow the steps below:
 - Set the **type** of the second task to `fetcher-service`.
 - Set the **type** of the third task to `shipping-service`.
 
+5. Additionally, for the service task `Collect Money` set a [**task-header**](/docs/1.3/components/modeler/bpmn/service-tasks/#task-headers) with the key `method` and the value `VISA`. This header is used as a configuration parameter for the payment-service worker to hand over the payment method.
+
 The consolidated example looks as follows:
 
 ```go
@@ -340,7 +342,7 @@ The job worker will repeatedly poll for new jobs of the type `payment-service` a
 The handler will then complete the job with its result or fail the job if
 it encounters a problem while processing the job.
 
-When observing the Zeebe Monitor, you can see the process instance moved from the first service task to the next one.
+When observing the current state of the process in Operate, you can see the process instance moved from the first service task to the next one.
 
 When you run the example above, you should see a similar output to the following:
 

--- a/versioned_docs/version-8.0/apis-clients/go-client/go-get-started.md
+++ b/versioned_docs/version-8.0/apis-clients/go-client/go-get-started.md
@@ -213,6 +213,8 @@ Now, we want to do some work within our process. Follow the steps below:
 - Set the **type** of the second task to `fetcher-service`.
 - Set the **type** of the third task to `shipping-service`.
 
+5. Additionally, for the service task `Collect Money` set a [**task-header**](/docs/8.0/components/modeler/bpmn/service-tasks/#task-headers) with the key `method` and the value `VISA`. This header is used as a configuration parameter for the payment-service worker to hand over the payment method.
+
 The consolidated example looks as follows:
 
 ```go
@@ -339,7 +341,7 @@ The job worker will repeatedly poll for new jobs of the type `payment-service` a
 The handler will then complete the job with its result or fail the job if
 it encounters a problem while processing the job.
 
-When observing the Zeebe Monitor, you can see the process instance moved from the first service task to the next one.
+When observing the current state of the process in Operate, you can see the process instance moved from the first service task to the next one.
 
 When you run the example above, you should see a similar output to the following:
 

--- a/versioned_docs/version-8.1/apis-clients/go-client/go-get-started.md
+++ b/versioned_docs/version-8.1/apis-clients/go-client/go-get-started.md
@@ -213,6 +213,8 @@ Now, we want to do some work within our process. Follow the steps below:
 - Set the **type** of the second task to `fetcher-service`.
 - Set the **type** of the third task to `shipping-service`.
 
+5. Additionally, for the service task `Collect Money` set a [**task-header**](/docs/components/modeler/bpmn/service-tasks/#task-headers) with the key `method` and the value `VISA`. This header is used as a configuration parameter for the payment-service worker to hand over the payment method.
+
 The consolidated example looks as follows:
 
 ```go
@@ -339,7 +341,7 @@ The job worker will repeatedly poll for new jobs of the type `payment-service` a
 The handler will then complete the job with its result or fail the job if
 it encounters a problem while processing the job.
 
-When observing the Zeebe Monitor, you can see the process instance moved from the first service task to the next one.
+When observing the current state of the process in Operate, you can see the process instance moved from the first service task to the next one.
 
 When you run the example above, you should see a similar output to the following:
 


### PR DESCRIPTION
## What is the purpose of the change

1. Went through the "Go client - Getting started guide" and in the end I noticed that my result looked slightly different as one  value was missing in my output. That value is there in the screenshots in the docs, however it is nowhere mentioned to (and how to) set it. Added that detail in all the relevant versions

![missing-task-header](https://user-images.githubusercontent.com/17708599/204585884-874afa77-2996-453f-bf0c-a95524e3c605.png)

2. As of now in the section https://docs.camunda.io/docs/next/apis-clients/go-client/go-get-started/#see-the-process-in-action it is mentioned to use Operate. Later in the text there still was a reference to "Zeebe Monitor" which was never mentioned before in the guide and should be replaced with Operate, especially as it already was introduced before in the guide.

## Are there related marketing activities

No.

## When should this change go live?

Not urgent. As soon as possible.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
