### PR TITLE
incorporate javadoc link

### DIFF
--- a/docs/apis-clients/java-client/index.md
+++ b/docs/apis-clients/java-client/index.md
@@ -86,6 +86,10 @@ ZeebeClient client =
         .build();
 ```
 
+## Javadoc
+
+The official Java client library API documentation can be found [here](https://javadoc.io/doc/io.camunda/zeebe-client-java). These are standard Javadocs, so your favorite JVM IDE will be able to install them locally as well.
+
 ## Next steps
 
 - [Getting Started Guide](https://github.com/camunda/camunda-platform-get-started): A comprehensive tutorial that covers Camunda Modeler, Operate, and the Java client.

--- a/versioned_docs/version-8.0/apis-clients/java-client/index.md
+++ b/versioned_docs/version-8.0/apis-clients/java-client/index.md
@@ -86,6 +86,10 @@ ZeebeClient client =
         .build();
 ```
 
+## Javadoc
+
+The official Java client library API documentation can be found [here](https://javadoc.io/doc/io.camunda/zeebe-client-java). These are standard Javadocs, so your favorite JVM IDE will be able to install them locally as well
+
 ## Next steps
 
 - [Getting Started Guide](https://github.com/camunda/camunda-platform-get-started): A comprehensive tutorial that covers Camunda Modeler, Operate, and the Java client.

--- a/versioned_docs/version-8.1/apis-clients/java-client/index.md
+++ b/versioned_docs/version-8.1/apis-clients/java-client/index.md
@@ -86,6 +86,10 @@ ZeebeClient client =
         .build();
 ```
 
+## Javadoc
+
+The official Java client library API documentation can be found [here](https://javadoc.io/doc/io.camunda/zeebe-client-java). These are standard Javadocs, so your favorite JVM IDE will be able to install them locally as well
+
 ## Next steps
 
 - [Getting Started Guide](https://github.com/camunda/camunda-platform-get-started): A comprehensive tutorial that covers Camunda Modeler, Operate, and the Java client.


### PR DESCRIPTION
## What is the purpose of the change

Related to https://github.com/camunda/developer-experience/issues/17. Eases finding the JavaDoc for the Zeebe Java client.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
