### PR TITLE
feat: initialize & configure playwright, and write a single regression/smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ yarn-debug.log*
 yarn-error.log*
 node_modules
 /camunda-cloud-documentation.iml
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,11 @@
         "unist-util-visit": "^4.1.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.28.0",
         "husky": "^8.0.1",
         "jest": "^29.3.1",
         "lint-staged": "^13.0.3",
+        "playwright": "^1.28.0",
         "prettier": "2.7.1"
       }
     },
@@ -3851,6 +3853,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
+      "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.28.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@polka/url": {
@@ -12693,6 +12711,34 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.28.0.tgz",
+      "integrity": "sha512-kyOXGc5y1mgi+hgEcCIyE1P1+JumLrxS09nFHo5sdJNzrucxPRAGwM4A2X3u3SDOfdgJqx61yIoR6Av+5plJPg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.28.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
+      "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
@@ -19622,6 +19668,16 @@
         "fastq": "^1.6.0"
       }
     },
+    "@playwright/test": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
+      "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "playwright-core": "1.28.0"
+      }
+    },
     "@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -26113,6 +26169,21 @@
           "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
         }
       }
+    },
+    "playwright": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.28.0.tgz",
+      "integrity": "sha512-kyOXGc5y1mgi+hgEcCIyE1P1+JumLrxS09nFHo5sdJNzrucxPRAGwM4A2X3u3SDOfdgJqx61yIoR6Av+5plJPg==",
+      "dev": true,
+      "requires": {
+        "playwright-core": "1.28.0"
+      }
+    },
+    "playwright-core": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
+      "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
+      "dev": true
     },
     "postcss": {
       "version": "8.4.16",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format:check": "prettier --check .",
     "prepare": "husky install",
     "test": "jest",
+    "test:regression": "playwright test spec/",
     "test:watch": "jest --watch"
   },
   "dependencies": {
@@ -47,9 +48,11 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.28.0",
     "husky": "^8.0.1",
     "jest": "^29.3.1",
     "lint-staged": "^13.0.3",
+    "playwright": "^1.28.0",
     "prettier": "2.7.1"
   },
   "lint-staged": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,108 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+import { devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: "./spec",
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "list",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+    baseURL: "https://docs.camunda.io",
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  // projects: [
+  //   {
+  //     name: "chromium",
+  //     use: {
+  //       ...devices["Desktop Chrome"],
+  //     },
+  //   },
+
+  // {
+  //   name: 'firefox',
+  //   use: {
+  //     ...devices['Desktop Firefox'],
+  //   },
+  // },
+
+  // {
+  //   name: 'webkit',
+  //   use: {
+  //     ...devices['Desktop Safari'],
+  //   },
+  // },
+
+  /* Test against mobile viewports. */
+  // {
+  //   name: 'Mobile Chrome',
+  //   use: {
+  //     ...devices['Pixel 5'],
+  //   },
+  // },
+  // {
+  //   name: 'Mobile Safari',
+  //   use: {
+  //     ...devices['iPhone 12'],
+  //   },
+  // },
+
+  /* Test against branded browsers. */
+  // {
+  //   name: 'Microsoft Edge',
+  //   use: {
+  //     channel: 'msedge',
+  //   },
+  // },
+  // {
+  //   name: 'Google Chrome',
+  //   use: {
+  //     channel: 'chrome',
+  //   },
+  // },
+  // ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+};
+
+export default config;

--- a/spec/regression/smoke.spec.ts
+++ b/spec/regression/smoke.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test";
+
+test("homepage has title and links to intro page", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page).toHaveTitle(
+    /Camunda Platform 8 Docs \| Camunda Platform 8 Docs/
+  );
+  await expect(page.locator("h1.hero__title")).toHaveText(
+    "Camunda Platform 8 Docs"
+  );
+});


### PR DESCRIPTION
## What is the purpose of the change

Part of #1171.

Installs & configures playwright, and introduces a single smoke test against the production site. 

For now the test would not be triggered by anything; but I'm PR'ing it in this state so that I can set this work aside for now. It's progress, and I don't want to throw it away.

### What it looks like when I run the test locally

<img width="649" alt="image" src="https://user-images.githubusercontent.com/1627089/205403749-91179f85-7b67-4b17-8711-25b27a1ec5a4.png">

## Follow-up work (not included in this PR)

* Schedule test(s) to run after a production deploy
* Write more tests to cover things described in #1171 
* Get the URL from an environment variable?

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
