### PR TITLE
feat(connectors): move secrets handling to Connector guide

### DIFF
--- a/docs/components/connectors/use-connectors.md
+++ b/docs/components/connectors/use-connectors.md
@@ -29,6 +29,36 @@ Fields in the properties panel marked with an equals sign inside a circle indica
 
 Each Connector defines its own set of properties you can fill in. Find the details for Connectors provided by Camunda in the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) documentation.
 
+## Using secrets
+
+You can use sensitive information in your Connectors without exposing it in your BPMN processes by referencing secrets.
+Use the Console component to [create and manage secrets](../console/manage-clusters/manage-secrets.md).
+
+You can reference a secret like `MY_API_KEY` with `secrets.MY_API_KEY` in any Connector field in the properties panel that supports this.
+Each of the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) details which fields support secrets.
+
+Keep in mind that secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
+
+```
+= { myHeader: "secrets.MY_API_KEY"}
+```
+
+Using the secrets placeholder syntax, you can use secrets in any part of a text, like in the following FEEL expression.
+This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`:
+
+```
+= "https://" + baseUrl + "/{{secrets.TENANT_ID}}/accounting"
+```
+
+The engine will resolve the `baseUrl` variable and pass on the secrets placeholder to the Connector. Assuming the `baseUrl` variable resolves to `my.company.domain`,
+the Connector receives the input `"https://my.company.domain/{{secrets.TENANT_ID}}/accounting"`. The Connector then replaces the secrets placeholder upon execution.
+For further details on how secrets are implemented in Connectors, consult our [Connector SDK documentation](./custom-built-connectors/connector-sdk.md#secrets).
+
+:::note Warning
+`secrets.*` is a reserved syntax. Don't use this for other purposes than referencing your secrets in Connector fields.
+Using this in other areas can lead to unexpected results and incidents.
+:::
+
 ## BPMN errors
 
 Being able to deal with exceptional cases is a common requirement for business process models. Read more about our general best practices around this topic in [dealing with exceptions](/components/best-practices/development/dealing-with-problems-and-exceptions.md).

--- a/docs/components/connectors/use-connectors.md
+++ b/docs/components/connectors/use-connectors.md
@@ -37,21 +37,23 @@ Use the Console component to [create and manage secrets](../console/manage-clust
 You can reference a secret like `MY_API_KEY` with `secrets.MY_API_KEY` in any Connector field in the properties panel that supports this.
 Each of the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) details which fields support secrets.
 
-Keep in mind that secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
+Secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
 
 ```
 = { myHeader: "secrets.MY_API_KEY"}
 ```
 
-Using the secrets placeholder syntax, you can use secrets in any part of a text, like in the following FEEL expression.
-This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`:
+Using the secrets placeholder syntax, you can use secrets in any part of a text, like in the following FEEL expression:
 
 ```
 = "https://" + baseUrl + "/{{secrets.TENANT_ID}}/accounting"
 ```
 
+This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`.
+
 The engine will resolve the `baseUrl` variable and pass on the secrets placeholder to the Connector. Assuming the `baseUrl` variable resolves to `my.company.domain`,
 the Connector receives the input `"https://my.company.domain/{{secrets.TENANT_ID}}/accounting"`. The Connector then replaces the secrets placeholder upon execution.
+
 For further details on how secrets are implemented in Connectors, consult our [Connector SDK documentation](./custom-built-connectors/connector-sdk.md#secrets).
 
 :::note Warning

--- a/docs/components/console/manage-clusters/manage-secrets.md
+++ b/docs/components/console/manage-clusters/manage-secrets.md
@@ -27,27 +27,4 @@ To create a new secret, go to your cluster and take the following steps:
 
 ![secrets-view](./img/cluster-detail-secrets-view.png)
 
-Now you can reference your secret with `secrets.MY_API_KEY` in any Connector field in the properties panel that supports this.
-Each of the [out-of-the-box Connectors](../../connectors/out-of-the-box-connectors/available-connectors-overview.md) details which fields support secrets.
-
-Keep in mind that secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
-
-```
-= { myHeader: "secrets.MY_API_KEY"}
-```
-
-Using the secrets placeholder syntax, you can use secret in any part of a text, like in the following FEEL expression.
-This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`:
-
-```
-= "https://" + baseUrl + "/{{secrets.TENANT_ID}}/accounting"
-```
-
-The engine will resolve the `baseUrl` variable and pass on the secrets placeholder to the Connector. Assuming the `baseUrl` variable resolves to `my.company.domain`,
-the Connector receives the input `"https://my.company.domain/{{secrets.TENANT_ID}}/accounting"`. The Connector then replaces the secrets placeholder upon execution.
-For further details on how secrets are implemented in Connectors, consult our [Connector SDK documentation](../../connectors/custom-built-connectors/connector-sdk.md#secrets).
-
-:::note Warning
-`secrets.*` is a reserved syntax. Don't use this for other purposes than referencing your secrets in Connector fields.
-Using this in other areas can lead to unexpected results and incidents.
-:::
+Now you can reference your secret in any Connector as described in the [Connectors guide](../../connectors/use-connectors.md#using-secrets).

--- a/versioned_docs/version-8.0/components/connectors/use-connectors.md
+++ b/versioned_docs/version-8.0/components/connectors/use-connectors.md
@@ -29,6 +29,36 @@ Fields in the properties panel marked with an equals sign inside a circle indica
 
 Each Connector defines its own set of properties you can fill in. Find the details for Connectors provided by Camunda in the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) documentation.
 
+## Using secrets
+
+You can use sensitive information in your Connectors without exposing it in your BPMN processes by referencing secrets.
+Use the Console component to [create and manage secrets](../console/manage-clusters/manage-secrets.md).
+
+You can reference a secret like `MY_API_KEY` with `secrets.MY_API_KEY` in any Connector field in the properties panel that supports this.
+Each of the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) details which fields support secrets.
+
+Keep in mind that secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
+
+```
+= { myHeader: "secrets.MY_API_KEY"}
+```
+
+Using the secrets placeholder syntax, you can use secrets in any part of a text, like in the following FEEL expression.
+This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`:
+
+```
+= "https://" + baseUrl + "/{{secrets.TENANT_ID}}/accounting"
+```
+
+The engine will resolve the `baseUrl` variable and pass on the secrets placeholder to the Connector. Assuming the `baseUrl` variable resolves to `my.company.domain`,
+the Connector receives the input `"https://my.company.domain/{{secrets.TENANT_ID}}/accounting"`. The Connector then replaces the secrets placeholder upon execution.
+For further details on how secrets are implemented in Connectors, consult our [Connector SDK documentation](./custom-built-connectors/connector-sdk.md#secrets).
+
+:::note Warning
+`secrets.*` is a reserved syntax. Don't use this for other purposes than referencing your secrets in Connector fields.
+Using this in other areas can lead to unexpected results and incidents.
+:::
+
 ## BPMN errors
 
 Being able to deal with exceptional cases is a common requirement for business process models. Read more about our general best practices around this topic in [dealing with exceptions](/components/best-practices/development/dealing-with-problems-and-exceptions.md).

--- a/versioned_docs/version-8.0/components/connectors/use-connectors.md
+++ b/versioned_docs/version-8.0/components/connectors/use-connectors.md
@@ -37,21 +37,23 @@ Use the Console component to [create and manage secrets](../console/manage-clust
 You can reference a secret like `MY_API_KEY` with `secrets.MY_API_KEY` in any Connector field in the properties panel that supports this.
 Each of the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) details which fields support secrets.
 
-Keep in mind that secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
+Secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
 
 ```
 = { myHeader: "secrets.MY_API_KEY"}
 ```
 
-Using the secrets placeholder syntax, you can use secrets in any part of a text, like in the following FEEL expression.
-This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`:
+Using the secrets placeholder syntax, you can use secrets in any part of a text, like in the following FEEL expression:
 
 ```
 = "https://" + baseUrl + "/{{secrets.TENANT_ID}}/accounting"
 ```
 
+This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`.
+
 The engine will resolve the `baseUrl` variable and pass on the secrets placeholder to the Connector. Assuming the `baseUrl` variable resolves to `my.company.domain`,
 the Connector receives the input `"https://my.company.domain/{{secrets.TENANT_ID}}/accounting"`. The Connector then replaces the secrets placeholder upon execution.
+
 For further details on how secrets are implemented in Connectors, consult our [Connector SDK documentation](./custom-built-connectors/connector-sdk.md#secrets).
 
 :::note Warning

--- a/versioned_docs/version-8.0/components/console/manage-clusters/manage-secrets.md
+++ b/versioned_docs/version-8.0/components/console/manage-clusters/manage-secrets.md
@@ -27,27 +27,4 @@ To create a new secret, go to your cluster and take the following steps:
 
 ![secrets-view](./img/cluster-detail-secrets-view.png)
 
-Now you can reference your secret with `secrets.MY_API_KEY` in any Connector field in the properties panel that supports this.
-Each of the [out-of-the-box Connectors](../../connectors/out-of-the-box-connectors/available-connectors-overview.md) details which fields support secrets.
-
-Keep in mind that secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
-
-```
-= { myHeader: "secrets.MY_API_KEY"}
-```
-
-Using the secrets placeholder syntax, you can use secret in any part of a text, like in the following FEEL expression.
-This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`:
-
-```
-= "https://" + baseUrl + "/{{secrets.TENANT_ID}}/accounting"
-```
-
-The engine will resolve the `baseUrl` variable and pass on the secrets placeholder to the Connector. Assuming the `baseUrl` variable resolves to `my.company.domain`,
-the Connector receives the input `"https://my.company.domain/{{secrets.TENANT_ID}}/accounting"`. The Connector then replaces the secrets placeholder upon execution.
-For further details on how secrets are implemented in Connectors, consult our [Connector SDK documentation](../../connectors/custom-built-connectors/connector-sdk.md#secrets).
-
-:::note Warning
-`secrets.*` is a reserved syntax. Don't use this for other purposes than referencing your secrets in Connector fields.
-Using this in other areas can lead to unexpected results and incidents.
-:::
+Now you can reference your secret in any Connector as described in the [Connectors guide](../../connectors/use-connectors.md#using-secrets).

--- a/versioned_docs/version-8.1/components/connectors/use-connectors.md
+++ b/versioned_docs/version-8.1/components/connectors/use-connectors.md
@@ -29,6 +29,36 @@ Fields in the properties panel marked with an equals sign inside a circle indica
 
 Each Connector defines its own set of properties you can fill in. Find the details for Connectors provided by Camunda in the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) documentation.
 
+## Using secrets
+
+You can use sensitive information in your Connectors without exposing it in your BPMN processes by referencing secrets.
+Use the Console component to [create and manage secrets](../console/manage-clusters/manage-secrets.md).
+
+You can reference a secret like `MY_API_KEY` with `secrets.MY_API_KEY` in any Connector field in the properties panel that supports this.
+Each of the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) details which fields support secrets.
+
+Keep in mind that secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
+
+```
+= { myHeader: "secrets.MY_API_KEY"}
+```
+
+Using the secrets placeholder syntax, you can use secrets in any part of a text, like in the following FEEL expression.
+This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`:
+
+```
+= "https://" + baseUrl + "/{{secrets.TENANT_ID}}/accounting"
+```
+
+The engine will resolve the `baseUrl` variable and pass on the secrets placeholder to the Connector. Assuming the `baseUrl` variable resolves to `my.company.domain`,
+the Connector receives the input `"https://my.company.domain/{{secrets.TENANT_ID}}/accounting"`. The Connector then replaces the secrets placeholder upon execution.
+For further details on how secrets are implemented in Connectors, consult our [Connector SDK documentation](./custom-built-connectors/connector-sdk.md#secrets).
+
+:::note Warning
+`secrets.*` is a reserved syntax. Don't use this for other purposes than referencing your secrets in Connector fields.
+Using this in other areas can lead to unexpected results and incidents.
+:::
+
 ## BPMN errors
 
 Being able to deal with exceptional cases is a common requirement for business process models. Read more about our general best practices around this topic in [dealing with exceptions](/components/best-practices/development/dealing-with-problems-and-exceptions.md).

--- a/versioned_docs/version-8.1/components/connectors/use-connectors.md
+++ b/versioned_docs/version-8.1/components/connectors/use-connectors.md
@@ -37,21 +37,23 @@ Use the Console component to [create and manage secrets](../console/manage-clust
 You can reference a secret like `MY_API_KEY` with `secrets.MY_API_KEY` in any Connector field in the properties panel that supports this.
 Each of the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) details which fields support secrets.
 
-Keep in mind that secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
+Secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
 
 ```
 = { myHeader: "secrets.MY_API_KEY"}
 ```
 
-Using the secrets placeholder syntax, you can use secrets in any part of a text, like in the following FEEL expression.
-This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`:
+Using the secrets placeholder syntax, you can use secrets in any part of a text, like in the following FEEL expression:
 
 ```
 = "https://" + baseUrl + "/{{secrets.TENANT_ID}}/accounting"
 ```
 
+This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`.
+
 The engine will resolve the `baseUrl` variable and pass on the secrets placeholder to the Connector. Assuming the `baseUrl` variable resolves to `my.company.domain`,
 the Connector receives the input `"https://my.company.domain/{{secrets.TENANT_ID}}/accounting"`. The Connector then replaces the secrets placeholder upon execution.
+
 For further details on how secrets are implemented in Connectors, consult our [Connector SDK documentation](./custom-built-connectors/connector-sdk.md#secrets).
 
 :::note Warning

--- a/versioned_docs/version-8.1/components/console/manage-clusters/manage-secrets.md
+++ b/versioned_docs/version-8.1/components/console/manage-clusters/manage-secrets.md
@@ -27,27 +27,4 @@ To create a new secret, go to your cluster and take the following steps:
 
 ![secrets-view](./img/cluster-detail-secrets-view.png)
 
-Now you can reference your secret with `secrets.MY_API_KEY` in any Connector field in the properties panel that supports this.
-Each of the [out-of-the-box Connectors](../../connectors/out-of-the-box-connectors/available-connectors-overview.md) details which fields support secrets.
-
-Keep in mind that secrets are **not variables** and must be wrapped in double quotes as follows when used in a FEEL expression:
-
-```
-= { myHeader: "secrets.MY_API_KEY"}
-```
-
-Using the secrets placeholder syntax, you can use secret in any part of a text, like in the following FEEL expression.
-This example assumes there is a process variable `baseUrl` and a configured secret `TENANT_ID`:
-
-```
-= "https://" + baseUrl + "/{{secrets.TENANT_ID}}/accounting"
-```
-
-The engine will resolve the `baseUrl` variable and pass on the secrets placeholder to the Connector. Assuming the `baseUrl` variable resolves to `my.company.domain`,
-the Connector receives the input `"https://my.company.domain/{{secrets.TENANT_ID}}/accounting"`. The Connector then replaces the secrets placeholder upon execution.
-For further details on how secrets are implemented in Connectors, consult our [Connector SDK documentation](../../connectors/custom-built-connectors/connector-sdk.md#secrets).
-
-:::note Warning
-`secrets.*` is a reserved syntax. Don't use this for other purposes than referencing your secrets in Connector fields.
-Using this in other areas can lead to unexpected results and incidents.
-:::
+Now you can reference your secret in any Connector as described in the [Connectors guide](../../connectors/use-connectors.md#using-secrets).


### PR DESCRIPTION
## What is the purpose of the change

Move the secrets handling part from Console to the "Use Connectors" guide.

## Are there related marketing activities

n/a

## When should this change go live?

As soon as possible

## PR Checklist

- [X] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [X] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [X] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [X] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
