### PR TITLE
feat: run sync-board task for forked PRs

### DIFF
--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -3,6 +3,8 @@ name: sync-board
 # FYI secrets.ADD_TO_PROJECT_PAT is a personal access token belonging to @akeller.
 
 on:
+  pull_request:
+    types: [review_requested]
   pull_request_target:
     types: [review_requested]
 

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   sync-board:
+    # For internal PRs, this is triggered on `pull_request`;
+    #   for external/forked PRs, it is triggered on both `pull_request` and `pull_request_target`.
+    #   This first check prevents forked PRs from running on `pull_request`, because they'll fail in that context.
     if: |
       (github.event_name == 'pull_request_target' || !github.event.pull_request.head.repo.fork)
       && (github.event.requested_reviewer.login == 'akeller' || github.event.requested_reviewer.login == 'christinaausley')

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -3,19 +3,12 @@ name: sync-board
 # FYI secrets.ADD_TO_PROJECT_PAT is a personal access token belonging to @akeller.
 
 on:
-  pull_request:
-    types: [review_requested]
   pull_request_target:
     types: [review_requested]
 
 jobs:
   sync-board:
-    # For internal PRs, this is triggered on `pull_request`;
-    #   for external/forked PRs, it is triggered on both `pull_request` and `pull_request_target`.
-    #   This first check prevents forked PRs from running on `pull_request`, because they'll fail in that context.
-    if: |
-      (github.event_name == 'pull_request_target' || !github.event.pull_request.head.repo.fork)
-      && (github.event.requested_reviewer.login == 'akeller' || github.event.requested_reviewer.login == 'christinaausley')
+    if: github.event.requested_reviewer.login == 'akeller' || github.event.requested_reviewer.login == 'christinaausley'
     runs-on: ubuntu-latest
     steps:
       - name: Get project IDs for later steps

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -3,7 +3,7 @@ name: sync-board
 # FYI secrets.ADD_TO_PROJECT_PAT is a personal access token belonging to @akeller.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [review_requested]
 
 jobs:

--- a/.github/workflows/sync-board.yaml
+++ b/.github/workflows/sync-board.yaml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   sync-board:
-    if: github.event.requested_reviewer.login == 'akeller' || github.event.requested_reviewer.login == 'christinaausley'
+    if: |
+      (github.event_name == 'pull_request_target' || !github.event.pull_request.head.repo.fork)
+      && (github.event.requested_reviewer.login == 'akeller' || github.event.requested_reviewer.login == 'christinaausley')
     runs-on: ubuntu-latest
     steps:
       - name: Get project IDs for later steps


### PR DESCRIPTION
Resolves https://github.com/camunda/camunda-platform-docs/issues/1240. See also [this conversation](https://github.com/camunda/camunda-platform-docs/pull/1371#issuecomment-1277163771).

## What is the purpose of the change

Updates the `sync_board` workflow so that it triggers on `pull_request_target` instead of `pull_request`. This grants the workflow the access it needs in order to assign items to the DX board on forked PRs.

Note that at one point I specified both `pull_request_target` and `pull_request` triggers, but as [pointed out in this thread](https://github.com/camunda/camunda-platform-docs/pull/1557#discussion_r1040793859) this was an unnecessary response to the workflow not running on this PR. 

## Security concerns

By running on `pull_request_target`, I think we're giving this workflow access at whatever level [the personal access token](https://github.com/camunda/camunda-platform-docs/blob/d6ddf402195a2e04a92731c1e5fdfe372acc8ec4/.github/workflows/sync-board.yaml#L16) has access. Do we want this? A malicious PR might, for instance, update `sync-board` to use the `delete` mutations from the GitHub CLI to basically drop our project. 

I briefly investigated whether we could change the token to be one of them fancy new-fangled [fine-grained tokens](https://github.blog/changelog/2022-10-18-introducing-fine-grained-personal-access-tokens/)...but it looks like [those do not work with the GraphQL API](https://github.com/cli/cli/issues/6680) yet. 

## Proof that it works on external PRs

[This workflow ran properly](https://github.com/camunda/camunda-platform-docs/actions/runs/3624289678/jobs/6111097448) for [a forked PR](https://github.com/camunda/camunda-platform-docs/pull/1558):

![image](https://user-images.githubusercontent.com/1627089/205753137-d59d8309-e1ac-46b5-b34f-f92640c4470e.png)


## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
