### PR TITLE
Rectify information on EBS-CSI driver

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
@@ -19,9 +19,9 @@ Here is a recommended start to run Camunda Platform 8:
 - Volume type: `SSD gp3`
 
 :::caution
-To use `SSD gp3` volume type on 1.22 or an earlier cluster, you need to install
+To use `SSD gp3` volume type on an EKS cluster, you need to install
 [Amazon EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html).
-If you are already on 1.23 or later, the driver is already installed.
+If you are on 1.22 or an earlier cluster be sure to install this driver to your cluster before updating the cluster to 1.23 to avoid potential workload interruptions.
 
 The next step is to create a new
 [StorageClass](https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html)

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
@@ -21,7 +21,7 @@ Here is a recommended start to run Camunda Platform 8:
 :::caution
 To use `SSD gp3` volume type on an EKS cluster, you need to install
 [Amazon EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html).
-If you are on 1.22 or an earlier cluster, be sure to install this driver to your cluster before updating the cluster to 1.23, to avoid potential workload interruptions.
+If you are on 1.22 or an earlier cluster, be sure to install this driver to your cluster before updating the cluster to 1.23 to avoid potential workload interruptions.
 
 The next step is to create a new
 [StorageClass](https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html)

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
@@ -19,9 +19,9 @@ Here is a recommended start to run Camunda Platform 8:
 - Volume type: `SSD gp3`
 
 :::caution
-To use `SSD gp3` volume type on 1.22 or an earlier cluster, you need to install
+To use `SSD gp3` volume type on an EKS cluster, you need to install
 [Amazon EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html).
-If you are already on 1.23 or later, the driver is already installed.
+If you are on 1.22 or an earlier cluster, be sure to install this driver to your cluster before updating the cluster to 1.23, to avoid potential workload interruptions.
 
 The next step is to create a new
 [StorageClass](https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html)


### PR DESCRIPTION
## What is the purpose of the change

Our docs mentions - If you are already on 1.23 or later, the driver is already installed. But, as per the official EKS documentation, the add-on is not installed automatically. But , Refer EKS docs, "The Amazon EBS CSI driver isn't installed when you first create a cluster. To use the driver, you must add it as an Amazon EKS add-on or as a self-managed add-on." - https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html "If you plan to deploy workloads that use Amazon EBS volumes in a new 1.23 cluster, install the Amazon EBS CSI driver in your cluster before deploying the workloads your cluster. "- https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.23 I have just installed C8 using helm profiles on a 1.23 Version EKS cluster and I had to add it manually.

## Are there related marketing activities

No

## When should this change go live?

This is already existing info on was, so this should ideally go live at the soonest possible.
## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.

