### PR TITLE
feat(connectors): consolidate third party notice links

### DIFF
--- a/docs/reference/dependencies.md
+++ b/docs/reference/dependencies.md
@@ -2099,41 +2099,11 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 
-### Connector Amazon Simple Notification Service (SNS)
+### Out of the box Connectors
 
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sns/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 
-### Connector Amazon Simple Queue Service (SQS)
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sqs/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector AWS Lambda
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-aws-lambda/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector Google Drive
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-google-drive/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector Kafka Producer
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-kafka/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector RabbitMQ
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-rabbitmq/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector REST
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-http-json/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector SendGrid
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sendgrid/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector Slack
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-slack/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Find up-to-date lists for the individual Connectors in the `THIRD_PARTY_NOTICES` in their respective directories in the [source code repository](https://github.com/camunda/connectors-bundle/tree/main/connectors).
 
 </TabItem>
 

--- a/docs/reference/dependencies.md
+++ b/docs/reference/dependencies.md
@@ -2099,7 +2099,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 
-### Out of the box Connectors
+### Out-of-the-box Connectors
 
 Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 

--- a/versioned_docs/version-8.0/reference/dependencies.md
+++ b/versioned_docs/version-8.0/reference/dependencies.md
@@ -1316,7 +1316,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 
-### Out of the box Connectors
+### Out-of-the-box Connectors
 
 Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 

--- a/versioned_docs/version-8.0/reference/dependencies.md
+++ b/versioned_docs/version-8.0/reference/dependencies.md
@@ -1316,37 +1316,11 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 
-### Connector Amazon Simple Notification Service (SNS)
+### Out of the box Connectors
 
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sns/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 
-### Connector Amazon Simple Queue Service (SQS)
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sqs/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector AWS Lambda
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-aws-lambda/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector Google Drive
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-google-drive/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector Kafka Producer
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-kafka/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector REST
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-http-json/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector SendGrid
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sendgrid/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector Slack
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-slack/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Find up-to-date lists for the individual Connectors in the `THIRD_PARTY_NOTICES` in their respective directories in the [source code repository](https://github.com/camunda/connectors-bundle/tree/main/connectors).
 
 </TabItem>
 

--- a/versioned_docs/version-8.1/reference/dependencies.md
+++ b/versioned_docs/version-8.1/reference/dependencies.md
@@ -2098,37 +2098,11 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 
-### Connector Amazon Simple Notification Service (SNS)
+### Out of the box Connectors
 
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sns/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 
-### Connector Amazon Simple Queue Service (SQS)
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sqs/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector AWS Lambda
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-aws-lambda/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector Google Drive
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-google-drive/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector Kafka Producer
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-kafka/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector REST
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-http-json/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector SendGrid
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sendgrid/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Connector Slack
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-slack/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Find up-to-date lists for the individual Connectors in the `THIRD_PARTY_NOTICES` in their respective directories in the [source code repository](https://github.com/camunda/connectors-bundle/tree/main/connectors).
 
 </TabItem>
 

--- a/versioned_docs/version-8.1/reference/dependencies.md
+++ b/versioned_docs/version-8.1/reference/dependencies.md
@@ -2098,7 +2098,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 
-### Out of the box Connectors
+### Out-of-the-box Connectors
 
 Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
 


### PR DESCRIPTION
## What is the purpose of the change

Consolidate the third-party notice links for Connectors so they don't have to be adjusted in the future with every new Connector.

closes https://github.com/camunda/team-connectors/issues/256

## Are there related marketing activities

n/a

## When should this change go live?

ASAP

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
