### PR TITLE
Unify naming

### DIFF
--- a/docs/apis-clients/java-client/index.md
+++ b/docs/apis-clients/java-client/index.md
@@ -34,7 +34,7 @@ If you build a Spring or Spring Boot application, you might want to use [Spring 
 In Java code, instantiate the client as follows:
 
 ```java
-  private static final String zeebeAPI = "[Zeebe API]";
+  private static final String zeebeAddress = "[Zeebe Address]";
   private static final String clientId = "[Client ID]";
   private static final String clientSecret = "[Client Secret]";
   private static final String oAuthAPI = "[OAuth API] ";
@@ -69,7 +69,7 @@ See [io.camunda.zeebe.client.ZeebeClientBuilder](https://javadoc.io/doc/io.camun
 Another (more compact) option is to pass in the connection settings via environment variables:
 
 ```bash
-export ZEEBE_ADDRESS='[Zeebe API]'
+export ZEEBE_ADDRESS='[Zeebe Address]'
 export ZEEBE_CLIENT_ID='[Client ID]'
 export ZEEBE_CLIENT_SECRET='[Client Secret]'
 export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'

--- a/versioned_docs/version-8.1/apis-clients/java-client/index.md
+++ b/versioned_docs/version-8.1/apis-clients/java-client/index.md
@@ -34,7 +34,7 @@ If you build a Spring or Spring Boot application, you might want to use [Spring 
 In Java code, instantiate the client as follows:
 
 ```java
-  private static final String zeebeAPI = "[Zeebe API]";
+  private static final String zeebeAddress = "[Zeebe Address]";
   private static final String clientId = "[Client ID]";
   private static final String clientSecret = "[Client Secret]";
   private static final String oAuthAPI = "[OAuth API] ";
@@ -69,7 +69,7 @@ See [io.camunda.zeebe.client.ZeebeClientBuilder](https://javadoc.io/doc/io.camun
 Another (more compact) option is to pass in the connection settings via environment variables:
 
 ```bash
-export ZEEBE_ADDRESS='[Zeebe API]'
+export ZEEBE_ADDRESS='[Zeebe Address]'
 export ZEEBE_CLIENT_ID='[Client ID]'
 export ZEEBE_CLIENT_SECRET='[Client Secret]'
 export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'


### PR DESCRIPTION
## What is the purpose of the change

The documentation usally uses `address` for this URL. Also, generated credential files use `ZEEBE_ADDRESS` as a name. Using `API` here can be confusing.

## Are there related marketing activities

No

## When should this change go live?

No

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
