### PR TITLE
chore(self-managed): update using existing keycloak guide

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak.md
@@ -8,18 +8,9 @@ Camunda Platform 8 Self-Managed has two different types of applications: Camunda
 
 This guide steps through using an existing Keycloak instance, which is part of [Camunda Identity](../../../identity/what-is-identity.md). By default, [Helm chart deployment](../deploy.md) creates a new Keycloak instance, but it's possible to use an existing Keycloak instance either inside the same Kubernetes cluster or outside of it.
 
-:::warning
-Given Identity uses a Keycloak admin account, it could override the existing Keycloak configuration. Ensure you back up the Keycloak and test the deployment with a non-production environment first.
-:::
-
 ## Preparation
 
-Create a Kubernetes `Secret` with the existing Keycloak admin password. See an example of how to create this secret below:
-
-```sh
-kubectl create secret generic stage-keycloak \
-    --from-literal=admin-password='<EXISTING_KEYCLOAK_ADMIN_PASSWORD>'
-```
+Configure your existing Keycloak realm according to the following guide: [Connect to an existing Keycloak instance](../../../identity/user-guide/connect-to-an-existing-keycloak.md).
 
 ## Values file
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak.md
@@ -8,18 +8,9 @@ Camunda Platform 8 Self-Managed has two different types of applications: Camunda
 
 This guide steps through using an existing Keycloak instance, which is part of [Camunda Identity](../../../identity/what-is-identity.md). By default, [Helm chart deployment](../deploy.md) creates a new Keycloak instance, but it's possible to use an existing Keycloak instance either inside the same Kubernetes cluster or outside of it.
 
-:::warning
-Given Identity uses a Keycloak admin account, it could override the existing Keycloak configuration. Ensure you back up the Keycloak and test the deployment with a non-production environment first.
-:::
-
 ## Preparation
 
-Create a Kubernetes `Secret` with the existing Keycloak admin password. See an example of how to create this secret below:
-
-```sh
-kubectl create secret generic stage-keycloak \
-    --from-literal=admin-password='<EXISTING_KEYCLOAK_ADMIN_PASSWORD>'
-```
+Configure your existing Keycloak realm according to the following guide: [Connect to an existing Keycloak instance](../../../identity/user-guide/connect-to-an-existing-keycloak.md).
 
 ## Values file
 


### PR DESCRIPTION
## What is the purpose of the change

Include the Identity guide to configuring existing Keycloak, which needed to be done before deploying the Camunda Platform 8 Self-Managed with disabled embedded Keycloak.

Thanks to @dlavrenuek for the suggestion :rocket: 

## Are there related marketing activities

No.

## When should this change go live?

No specific time, as soon as possible.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory.
- [x] My changes do not require an Engineering review.
- [x] My changes do not require a technical writer review.