### PR TITLE
feat: prevent hold PRs from merging

### DIFF
--- a/.github/workflows/enforce-labels.yaml
+++ b/.github/workflows/enforce-labels.yaml
@@ -1,0 +1,12 @@
+name: Enforce PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: yogevbd/enforce-label-action@2.1.0
+        with:
+          BANNED_LABELS: "hold"


### PR DESCRIPTION
collaboration with @christinaausley!

## What is the purpose of the change

This PR adds a check of labels so that anything with a `hold` label gets a failed check.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
