### PR TITLE
fix: add release notes and link to the blog post in the introduction of update guide

### DIFF
--- a/docs/guides/update-guide/introduction.md
+++ b/docs/guides/update-guide/introduction.md
@@ -20,8 +20,8 @@ There is a dedicated update guide for each version:
 
 Update from 8.0.x to 8.1.0
 
-[//]: # "TODO: As soon as the release will be created[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.0)"
-[//]: # "TODO: As soon as the release will be created[Release blog](https://camunda.com/blog/)"
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.0)
+[Release blog](https://camunda.com/blog/2022/10/camunda-platform-8-1-released-whats-new/)
 
 ### [Camunda Cloud 1.3 to Camunda Platform 8.0](../130-to-800)
 

--- a/versioned_docs/version-8.1/guides/update-guide/introduction.md
+++ b/versioned_docs/version-8.1/guides/update-guide/introduction.md
@@ -20,8 +20,8 @@ There is a dedicated update guide for each version:
 
 Update from 8.0.x to 8.1.0
 
-[//]: # "TODO: As soon as the release will be created[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.0)"
-[//]: # "TODO: As soon as the release will be created[Release blog](https://camunda.com/blog/)"
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.0)
+[Release blog](https://camunda.com/blog/2022/10/camunda-platform-8-1-released-whats-new/)
 
 ### [Camunda Cloud 1.3 to Camunda Platform 8.0](../130-to-800)
 


### PR DESCRIPTION
## What is the purpose of the change

I've just found out that the Introduction section misses links to Release Notes and the Blog Post.

## Are there related marketing activities

No.

## When should this change go live?

Better sonner, than later, I guess that this is some kind of minor bug.

## PR Checklist

- [X] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [X] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [X] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [X] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
