### PR TITLE
feat: move items to Done when they're assigned to someone

### DIFF
--- a/.github/workflows/move-to-done.yaml
+++ b/.github/workflows/move-to-done.yaml
@@ -1,0 +1,15 @@
+name: Move completed items to done
+
+on:
+  pull_request:
+    types: [assigned]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Developer Experience
+          column: ✅ Done
+          repo-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
HOLD! because we're testing it out

## What is the purpose of the change

Eventually: move completed items to Done when they are merged.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
