### PR TITLE
docs: fix sidebar links

### DIFF
--- a/howtos/documentation-guidelines.md
+++ b/howtos/documentation-guidelines.md
@@ -54,9 +54,9 @@ Specific Optimize versions are aligned with Camunda Platform versions as follows
 
 | Instance   | Version(s)               | Sidebars path                                                                             |
 | ---------- | ------------------------ | ----------------------------------------------------------------------------------------- |
-| `docs`     | Next                     | [/docs/sidebars.js](../docs/sidebars.js)                                                  |
+| `docs`     | Next                     | [/docs/sidebars.js](../sidebars.js)                                                       |
 | `docs`     | 8.1, 8.0, 1.3, ...       | [/versioned_sidebars/version-\*-sidebars.json](../versioned_sidebars/)                    |
-| `optimize` | Next                     | [/optimize/sidebars.js](../optimize/sidebars.js)                                          |
+| `optimize` | Next                     | [/optimize/sidebars.js](../optimize_sidebars.js)                                          |
 | `optimize` | 3.9.0, 3.8.0, 3.7.0, ... | [/optimize_versioned_sidebars/version-\*-sidebars.json/](../optimize_versioned_sidebars/) |
 
 ### Sidebar items


### PR DESCRIPTION
## What is the purpose of the change

Corrects a couple links in the documentation-guidelines. Both were leading to 404 pages.

## When should this change go live?

Whenever!

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
