### PR TITLE
fix: run the enforce-labels action more frequently to avoid unmergeable PRs

### DIFF
--- a/.github/workflows/enforce-labels.yaml
+++ b/.github/workflows/enforce-labels.yaml
@@ -2,7 +2,7 @@ name: Enforce PR labels
 
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
   enforce-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What is the purpose of the change

Run the `enforce-labels` check more frequently! 

When @christinaausley and I introduced that workflow, I specifically remember removing several events from the list of triggers because I didn't know why they were there.

The new list of events comes directly from [the workflow's example](https://github.com/yogevbd/enforce-label-action).

Now I know why they are there! It's to avoid situations like [this PR](https://github.com/camunda/camunda-platform-docs/pull/1582), where a force-push reset all of the checks, and it wasn't mergeable until a label was removed/added again.

## When should this change go live?

Doesn't matter!

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
