### PR TITLE
docs(regions): add to 8.1 & sidebars

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -648,6 +648,7 @@ module.exports = {
     "reference/release-policy",
     "reference/early-access",
     "reference/supported-environments",
+    "reference/regions",
     "reference/dependencies",
   ],
   "Self-Managed": [

--- a/versioned_docs/version-8.1/reference/regions.md
+++ b/versioned_docs/version-8.1/reference/regions.md
@@ -1,0 +1,22 @@
+---
+id: regions
+title: "Regions"
+description: "After creating a cluster, specify a region for that cluster. Read on for details of Google Cloud Platform regions currently supported in Camunda Platform 8 SaaS."
+---
+
+When you create a cluster in Camunda Platform 8 SaaS, you must specify a region for that cluster.
+
+Below, find a list of regions currently supported in Camunda Platform 8 SaaS.
+
+Currently, we only make these regions available for customers on the Enterprise Plan. These customers can discuss regions with their Customer Success Manager. Professional and Trial users are currently hosted on US Central.
+
+:::note
+Running on a Trial and want to try a different region, or interested in other regions or cloud providers? [Contact us](https://camunda.com/contact/) as we are able to make additional regions available on request.
+:::
+
+## Available Google Cloud Platform (GCP) regions
+
+- Europe West: europe-west1
+- US East: us-east1
+- US Central: us-central1
+- Australia Southeast: australia-southeast1

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -771,6 +771,7 @@
     "reference/release-policy",
     "reference/early-access",
     "reference/supported-environments",
+    "reference/regions",
     "reference/dependencies"
   ],
   "Self-Managed": [


### PR DESCRIPTION
## What is the purpose of the change

A few missing from adding the Regions page. Adds Regions to 8.1 and sidebars for both `Next` and `8.1`.

## Are there related marketing activities

No

## When should this change go live?

I promised @felix-mueller a special release 🙂 

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
