### PR TITLE
docs(operate): adjust Hot backup API docs

### DIFF
--- a/docs/self-managed/backup-restore/operate-tasklist-backup.md
+++ b/docs/self-managed/backup-restore/operate-tasklist-backup.md
@@ -166,11 +166,11 @@ For example, the request could look like this:
 curl 'http://localhost:8080/actuator/backups'
 ```
 
-Response will contain JSON with array of objects representing state of each backup (see Get backup state API endpoint).
+Response will contain JSON with array of objects representing state of each backup (see [get backup state API endpoint](#get-backup-state-API)).
 
 ## Delete backup API
 
-To delete all the Elasticsearch snapshots associated with the specific backup id, following endpoint may be used:
+To delete all the Elasticsearch snapshots associated with the specific backup id, the following endpoint may be used:
 
 ```
 DELETE actuator/backups/{backupId}

--- a/docs/self-managed/backup-restore/operate-tasklist-backup.md
+++ b/docs/self-managed/backup-restore/operate-tasklist-backup.md
@@ -166,7 +166,7 @@ For example, the request could look like this:
 curl 'http://localhost:8080/actuator/backups'
 ```
 
-Response will contain JSON with array of objects representing state of each backup (see [get backup state API endpoint](#get-backup-state-API)).
+Response will contain JSON with array of objects representing state of each backup (see [get backup state API endpoint](#get-backup-state-api)).
 
 ## Delete backup API
 


### PR DESCRIPTION
## What is the purpose of the change

* Main URL entry is renamed to `backups`
* Make endpoints description up-to-date
* Document that the endpoint is exposed on management port
* Document the ENV var to configure the snapshot repository

closes #1609

## Are there related marketing activities

-

## When should this change go live?

They can go live at any moment, the changes are already released in 8.2.0-alpha3

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
