### PR TITLE
improvement: rename sync-board workflow to add-to-project for precision

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -1,4 +1,4 @@
-name: sync-board
+name: add-to-project
 
 # FYI secrets.ADD_TO_PROJECT_PAT is a personal access token belonging to @akeller.
 


### PR DESCRIPTION
A follow-up to #1605.

## What is the purpose of the change

Renames the `sync-board` workflow to `add-to-project`. The name `sync-board` was intentionally vague, because we thought we could use it to do more things....but #1605 proved that it wasn't really usable for even closely related workflows. 

This new name is more precise and descriptive about what the workflow is doing.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
