### PR TITLE
fix(connectors): edit Connector Runtime link

### DIFF
--- a/docs/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/docs/components/connectors/custom-built-connectors/connector-sdk.md
@@ -850,7 +850,7 @@ can invoke the Connectors. The Connector SDK provides a
 
 The SDK comes with a pre-packaged runtime environment that allows you to run select Connector runtimes
 as local job workers out-of-the-box. You can find this Java application on
-[Maven Central](https://search.maven.org/artifact/io.camunda/spring-zeebe-connector-runtime).
+[Maven Central](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime).
 
 Refer to the [Self-Managed installation guide](/self-managed/connectors-deployment/install-and-start.md) for details on how to
 set up this runtime environment.

--- a/docs/self-managed/platform-deployment/manual.md
+++ b/docs/self-managed/platform-deployment/manual.md
@@ -149,7 +149,7 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://search.maven.org/artifact/io.camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
+The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
 
 To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:

--- a/versioned_docs/version-8.0/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.0/components/connectors/custom-built-connectors/connector-sdk.md
@@ -850,7 +850,7 @@ can invoke the Connectors. The Connector SDK provides a
 
 The SDK comes with a pre-packaged runtime environment that allows you to run select Connector runtimes
 as local job workers out-of-the-box. You can find this Java application on
-[Maven Central](https://search.maven.org/artifact/io.camunda/spring-zeebe-connector-runtime).
+[Maven Central](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime).
 
 Refer to the [Self-Managed installation guide](/self-managed/connectors-deployment/install-and-start.md) for details on how to
 set up this runtime environment.

--- a/versioned_docs/version-8.0/self-managed/platform-deployment/local.md
+++ b/versioned_docs/version-8.0/self-managed/platform-deployment/local.md
@@ -149,7 +149,7 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://search.maven.org/artifact/io.camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
+The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
 
 To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:

--- a/versioned_docs/version-8.1/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.1/components/connectors/custom-built-connectors/connector-sdk.md
@@ -850,7 +850,7 @@ can invoke the Connectors. The Connector SDK provides a
 
 The SDK comes with a pre-packaged runtime environment that allows you to run select Connector runtimes
 as local job workers out-of-the-box. You can find this Java application on
-[Maven Central](https://search.maven.org/artifact/io.camunda/spring-zeebe-connector-runtime).
+[Maven Central](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime).
 
 Refer to the [Self-Managed installation guide](/self-managed/connectors-deployment/install-and-start.md) for details on how to
 set up this runtime environment.

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/manual.md
@@ -149,7 +149,7 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://search.maven.org/artifact/io.camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
+The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
 
 To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:


### PR DESCRIPTION
## What is the purpose of the change

The previous link caused ambiguity because artifact `-with-dependencies` (which is mentioned a few lines below on the page) was not discoverable via Sonatype.
We should use a direct link to Maven repo instead, since all artifacts are visible there right away.

## Are there related marketing activities

_Are there any marketing activities related to the related feature or component? If so, please briefly describe them._

## When should this change go live?

As soon as possible

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
