### PR TITLE
Document changes in Zeebe 8.2 in update guide

### DIFF
--- a/docs/guides/update-guide/810-to-820.md
+++ b/docs/guides/update-guide/810-to-820.md
@@ -15,5 +15,5 @@ No changes are required to update from 8.1 to 8.2.
 The default [backpressure](/self-managed/zeebe-deployment/operations/backpressure.md) algorithm changed from **Vegas** to **additive-increase/multiplicative-decrease (AIMD)**.
 
 :::note
-This may change the performance characteristics. If you have tuned your system for specific latency or throughput, we recommend you to reevaluate with the new version.
+This may change the performance characteristics. If you have tuned your system for specific latency or throughput, we recommend you reevaluate with the new version.
 :::

--- a/docs/guides/update-guide/810-to-820.md
+++ b/docs/guides/update-guide/810-to-820.md
@@ -1,12 +1,12 @@
 ---
 id: 810-to-820
 title: Update 8.1 to 8.2
-description: "Review which adjustments must be made to migrate from Camunda Platform 8.1.x to Camunda Platform 8.2.0"
+description: "Review which adjustments must be made to migrate from Camunda Platform 8.1.x to Camunda Platform 8.2.0."
 ---
 
 <span class="badge badge--primary">Intermediate</span>
 
-The following sections explain which adjustments must be made to migrate from Camunda Platform 8.1.x to 8.2.0 for each component of the system.
+The following sections explain which adjustments must be made to migrate from Camunda Platform 8.1.x to 8.2.0 for each component.
 
 ## Server
 
@@ -14,5 +14,8 @@ The following sections explain which adjustments must be made to migrate from Ca
 
 No changes are required to update from 8.1 to 8.2.
 
-The default [backpressure](/self-managed/zeebe-deployment/operations/backpressure.md) algorithm is changed from vegas to aimd.
-The aimd algorithm is improved in 8.2. This may change the performance characteristics.
+The default [backpressure](/self-managed/zeebe-deployment/operations/backpressure.md) algorithm changed from **Vegas** to **additive-increase/multiplicative-decrease (AIMD)**.
+
+:::note
+The AIMD algorithm improved in 8.2. This may change the performance characteristics.
+:::

--- a/docs/guides/update-guide/810-to-820.md
+++ b/docs/guides/update-guide/810-to-820.md
@@ -1,0 +1,18 @@
+---
+id: 810-to-820
+title: Update 8.1 to 8.2
+description: "Review which adjustments must be made to migrate from Camunda Platform 8.1.x to Camunda Platform 8.2.0"
+---
+
+<span class="badge badge--primary">Intermediate</span>
+
+The following sections explain which adjustments must be made to migrate from Camunda Platform 8.1.x to 8.2.0 for each component of the system.
+
+## Server
+
+### Zeebe
+
+No changes are required to update from 8.1 to 8.2.
+
+The default [backpressure](/self-managed/zeebe-deployment/operations/backpressure.md) algorithm is changed from vegas to aimd.
+The aimd algorithm is improved in 8.2. This may change the performance characteristics.

--- a/docs/guides/update-guide/810-to-820.md
+++ b/docs/guides/update-guide/810-to-820.md
@@ -17,5 +17,5 @@ No changes are required to update from 8.1 to 8.2.
 The default [backpressure](/self-managed/zeebe-deployment/operations/backpressure.md) algorithm changed from **Vegas** to **additive-increase/multiplicative-decrease (AIMD)**.
 
 :::note
-The AIMD algorithm improved in 8.2. This may change the performance characteristics.
+This may change the performance characteristics. If you have tuned your system for specific latency or throughput, we recommend you to reevaluate with the new version.
 :::

--- a/docs/guides/update-guide/810-to-820.md
+++ b/docs/guides/update-guide/810-to-820.md
@@ -8,9 +8,7 @@ description: "Review which adjustments must be made to migrate from Camunda Plat
 
 The following sections explain which adjustments must be made to migrate from Camunda Platform 8.1.x to 8.2.0 for each component.
 
-## Server
-
-### Zeebe
+## Zeebe
 
 No changes are required to update from 8.1 to 8.2.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -42,6 +42,7 @@ module.exports = {
             "guides/update-guide/connectors/030-to-040",
           ],
         },
+        "guides/update-guide/810-to-820",
         "guides/update-guide/800-to-810",
         "guides/update-guide/130-to-800",
         "guides/update-guide/120-to-130",


### PR DESCRIPTION
## What is the purpose of the change

Document changes in backpressure algorithm between 8.1 and 8.2

closes #1428 

## Are there related marketing activities

No

## When should this change go live?

With 8.2.0 release

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
