### PR TITLE
feat: make announcement bar dismissable

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -53,7 +53,7 @@ module.exports = {
         '📣 <b><a target="_blank" rel="noopener noreferrer" href="https://accounts.cloud.camunda.io/signup?uc=signup&utm_source=docs.camunda.io&utm_medium=referral&utm_content=banner">Sign-Up</a></b> for a free account to start orchestrating business processes today.',
       backgroundColor: "#14D890",
       textColor: "#000",
-      isCloseable: false,
+      isCloseable: true,
     },
     prism: {
       additionalLanguages: ["java", "protobuf"],

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -296,7 +296,10 @@ navbar .navbar .navbar__link[href*="self-managed"] {
 
 div[class^="announcementBar_"] {
   font-size: 120%;
-  padding: 1em;
+  padding: 1em 0;
+}
+div[class^="announcementBar_"] button {
+  align-self: center;
 }
 
 /* Styles for BPMN.io integration and callouts in these models */


### PR DESCRIPTION
## What is the purpose of the change

Adds the ability to dismiss the announcement bar. 

Note that the dismissal state [is persisted in browser Local Storage](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-common/src/contexts/announcementBar.tsx#L63). 

## What it looks like

<img width="1505" alt="image" src="https://user-images.githubusercontent.com/1627089/214946379-4582f5ef-2f65-4b7d-8a91-a867ba2d97a9.png">

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
