### PR TITLE
docs(desktop-modeler/flags): clarify `--zeebe-ssl-certificate`

### DIFF
--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -26,20 +26,20 @@ Flags passed as command line arguments take precedence over those configured via
 
 ## Available Flags
 
-| flag                         | default value                       |
-| ---------------------------- | ----------------------------------- |
-| "disable-plugins"            | false                               |
-| "disable-adjust-origin"      | false                               |
-| "disable-cmmn"               | true                                |
-| "disable-dmn"                | false                               |
-| "disable-form"               | false                               |
-| "disable-platform"           | false                               |
-| "disable-zeebe"              | false                               |
-| "disable-remote-interaction" | false                               |
-| "single-instance"            | false                               |
-| "user-data-dir"              | [Electron default](../search-paths) |
-| "display-version"            | `undefined`                         |
-| "zeebe-ssl-certificate"      | `undefined`                         |
+| flag                                               | default value                       |
+| -------------------------------------------------- | ----------------------------------- |
+| "disable-plugins"                                  | false                               |
+| "disable-adjust-origin"                            | false                               |
+| "disable-cmmn"                                     | true                                |
+| "disable-dmn"                                      | false                               |
+| "disable-form"                                     | false                               |
+| "disable-platform"                                 | false                               |
+| "disable-zeebe"                                    | false                               |
+| "disable-remote-interaction"                       | false                               |
+| "single-instance"                                  | false                               |
+| "user-data-dir"                                    | [Electron default](../search-paths) |
+| ["display-version"](#custom-display-version-label) | `undefined`                         |
+| ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
 
 ## Examples
 
@@ -72,12 +72,14 @@ To display a custom version information in the status bar of the app, configure 
 
 ### Zeebe SSL certificate
 
-To use a self-signed certificate to connect to Camunda Platform 8 Self-Managed, configure your `flags.json` like this:
+> ℹ️ The Modeler will read trusted certificates from your operating systems trust store.
+
+Provide an additional root certificate that the modeler should use to validate secured connections to a Camunda Platform 8 Self-Managed installation. In case your server certificate is signed by a signing authority, configure the CA certificate here, not the server certificate.
+
+Configure your `flags.json` like this:
 
 ```js
 {
-    "zeebe-ssl-certificate": "/Users/local/certificate.pem"
+    "zeebe-ssl-certificate": "/Users/local/trusted-custom-root.pem"
 }
 ```
-
-As a result, the app will use the certificate to securely connect to the gateway.

--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -72,14 +72,16 @@ To display a custom version information in the status bar of the app, configure 
 
 ### Zeebe SSL certificate
 
-> ℹ️ The Modeler will read trusted certificates from your operating systems trust store.
+> :information_source: The Modeler will read trusted certificates from your operating system's trust store.
 
-Provide an additional root certificate that the modeler should use to validate secured connections to a Camunda Platform 8 Self-Managed installation. In case your server certificate is signed by a signing authority, configure the CA certificate here, not the server certificate.
-
-Configure your `flags.json` like this:
+Provide additional certificates to validate secured connections to a Camunda Platform 8 installation. Configure your `flags.json` like this:
 
 ```js
 {
     "zeebe-ssl-certificate": "/Users/local/trusted-custom-root.pem"
 }
 ```
+
+Additional information adapted from the [upstream documentation](https://nodejs.org/docs/latest/api/tls.html#tlscreatesecurecontextoptions):
+
+> The peer (Camunda Platform 8) certificate must be chainable to a CA trusted by the app for the connection to be authenticated. When using certificates that are not chainable to a well-known CA, the certificate's CA must be explicitly specified as trusted or the connection will fail to authenticate. If the peer uses a certificate that doesn't match or chain to one of the default CAs, provide a CA certificate that the peer's certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided.

--- a/versioned_docs/version-8.0/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.0/components/modeler/desktop-modeler/flags/flags.md
@@ -26,19 +26,20 @@ Flags passed as command line arguments take precedence over those configured via
 
 ## Available Flags
 
-| flag                         | default value                       |
-| ---------------------------- | ----------------------------------- |
-| "disable-plugins"            | false                               |
-| "disable-adjust-origin"      | false                               |
-| "disable-cmmn"               | true                                |
-| "disable-dmn"                | false                               |
-| "disable-form"               | false                               |
-| "disable-platform"           | false                               |
-| "disable-zeebe"              | false                               |
-| "disable-remote-interaction" | false                               |
-| "single-instance"            | false                               |
-| "user-data-dir"              | [Electron default](../search-paths) |
-| "display-version"            | `undefined`                         |
+| flag                                               | default value                       |
+| -------------------------------------------------- | ----------------------------------- |
+| "disable-plugins"                                  | false                               |
+| "disable-adjust-origin"                            | false                               |
+| "disable-cmmn"                                     | true                                |
+| "disable-dmn"                                      | false                               |
+| "disable-form"                                     | false                               |
+| "disable-platform"                                 | false                               |
+| "disable-zeebe"                                    | false                               |
+| "disable-remote-interaction"                       | false                               |
+| "single-instance"                                  | false                               |
+| "user-data-dir"                                    | [Electron default](../search-paths) |
+| ["display-version"](#custom-display-version-label) | `undefined`                         |
+| ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
 
 ## Examples
 
@@ -68,3 +69,17 @@ To display a custom version information in the status bar of the app, configure 
 ```
 
 ![Custom version info](./img/display-version.png)
+
+### Zeebe SSL certificate
+
+> ℹ️ The Modeler will read trusted certificates from your operating systems trust store.
+
+Provide an additional root certificate that the modeler should use to validate secured connections to a Camunda Platform 8 Self-Managed installation. In case your server certificate is signed by a signing authority, configure the CA certificate here, not the server certificate.
+
+Configure your `flags.json` like this:
+
+```js
+{
+    "zeebe-ssl-certificate": "/Users/local/trusted-custom-root.pem"
+}
+```

--- a/versioned_docs/version-8.0/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.0/components/modeler/desktop-modeler/flags/flags.md
@@ -72,14 +72,16 @@ To display a custom version information in the status bar of the app, configure 
 
 ### Zeebe SSL certificate
 
-> ℹ️ The Modeler will read trusted certificates from your operating systems trust store.
+> :information_source: The Modeler will read trusted certificates from your operating system's trust store.
 
-Provide an additional root certificate that the modeler should use to validate secured connections to a Camunda Platform 8 Self-Managed installation. In case your server certificate is signed by a signing authority, configure the CA certificate here, not the server certificate.
-
-Configure your `flags.json` like this:
+Provide additional certificates to validate secured connections to a Camunda Platform 8 installation. Configure your `flags.json` like this:
 
 ```js
 {
     "zeebe-ssl-certificate": "/Users/local/trusted-custom-root.pem"
 }
 ```
+
+Additional information adapted from the [upstream documentation](https://nodejs.org/docs/latest/api/tls.html#tlscreatesecurecontextoptions):
+
+> The peer (Camunda Platform 8) certificate must be chainable to a CA trusted by the app for the connection to be authenticated. When using certificates that are not chainable to a well-known CA, the certificate's CA must be explicitly specified as trusted or the connection will fail to authenticate. If the peer uses a certificate that doesn't match or chain to one of the default CAs, provide a CA certificate that the peer's certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided.

--- a/versioned_docs/version-8.1/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.1/components/modeler/desktop-modeler/flags/flags.md
@@ -26,20 +26,20 @@ Flags passed as command line arguments take precedence over those configured via
 
 ## Available Flags
 
-| flag                         | default value                       |
-| ---------------------------- | ----------------------------------- |
-| "disable-plugins"            | false                               |
-| "disable-adjust-origin"      | false                               |
-| "disable-cmmn"               | true                                |
-| "disable-dmn"                | false                               |
-| "disable-form"               | false                               |
-| "disable-platform"           | false                               |
-| "disable-zeebe"              | false                               |
-| "disable-remote-interaction" | false                               |
-| "single-instance"            | false                               |
-| "user-data-dir"              | [Electron default](../search-paths) |
-| "display-version"            | `undefined`                         |
-| "zeebe-ssl-certificate"      | `undefined`                         |
+| flag                                               | default value                       |
+| -------------------------------------------------- | ----------------------------------- |
+| "disable-plugins"                                  | false                               |
+| "disable-adjust-origin"                            | false                               |
+| "disable-cmmn"                                     | true                                |
+| "disable-dmn"                                      | false                               |
+| "disable-form"                                     | false                               |
+| "disable-platform"                                 | false                               |
+| "disable-zeebe"                                    | false                               |
+| "disable-remote-interaction"                       | false                               |
+| "single-instance"                                  | false                               |
+| "user-data-dir"                                    | [Electron default](../search-paths) |
+| ["display-version"](#custom-display-version-label) | `undefined`                         |
+| ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
 
 ## Examples
 
@@ -72,12 +72,14 @@ To display a custom version information in the status bar of the app, configure 
 
 ### Zeebe SSL certificate
 
-To use a self-signed certificate to connect to Camunda Platform 8 Self-Managed, configure your `flags.json` like this:
+> ℹ️ The Modeler will read trusted certificates from your operating systems trust store.
+
+Provide an additional root certificate that the modeler should use to validate secured connections to a Camunda Platform 8 Self-Managed installation. In case your server certificate is signed by a signing authority, configure the CA certificate here, not the server certificate.
+
+Configure your `flags.json` like this:
 
 ```js
 {
-    "zeebe-ssl-certificate": "/Users/local/certificate.pem"
+    "zeebe-ssl-certificate": "/Users/local/trusted-custom-root.pem"
 }
 ```
-
-As a result, the app will use the certificate to securely connect to the gateway.

--- a/versioned_docs/version-8.1/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.1/components/modeler/desktop-modeler/flags/flags.md
@@ -72,14 +72,16 @@ To display a custom version information in the status bar of the app, configure 
 
 ### Zeebe SSL certificate
 
-> ℹ️ The Modeler will read trusted certificates from your operating systems trust store.
+> :information_source: The Modeler will read trusted certificates from your operating system's trust store.
 
-Provide an additional root certificate that the modeler should use to validate secured connections to a Camunda Platform 8 Self-Managed installation. In case your server certificate is signed by a signing authority, configure the CA certificate here, not the server certificate.
-
-Configure your `flags.json` like this:
+Provide additional certificates to validate secured connections to a Camunda Platform 8 installation. Configure your `flags.json` like this:
 
 ```js
 {
     "zeebe-ssl-certificate": "/Users/local/trusted-custom-root.pem"
 }
 ```
+
+Additional information adapted from the [upstream documentation](https://nodejs.org/docs/latest/api/tls.html#tlscreatesecurecontextoptions):
+
+> The peer (Camunda Platform 8) certificate must be chainable to a CA trusted by the app for the connection to be authenticated. When using certificates that are not chainable to a well-known CA, the certificate's CA must be explicitly specified as trusted or the connection will fail to authenticate. If the peer uses a certificate that doesn't match or chain to one of the default CAs, provide a CA certificate that the peer's certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided.


### PR DESCRIPTION
## What is the purpose of the change

Better describe the intended purpose of `--zeebe-ssl-certificate`.

Handle some pain points documented in https://github.com/camunda/camunda-modeler/issues/3326#issuecomment-1405764329 and following.


## Are there related marketing activities

None.

## When should this change go live?

Once engineering approved.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
