### PR TITLE
Indentation of S3 backup properties

### DIFF
--- a/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -150,12 +150,12 @@ zeebe:
     data:
       backup:
         store: S3
-          s3:
-            bucketName:
-            region:
-            endpoint:
-            accessKey:
-            secretKey:
+        s3:
+          bucketName:
+          region:
+          endpoint:
+          accessKey:
+          secretKey:
 ```
 
 Alternatively, you can configure backup store using environment variables:


### PR DESCRIPTION
According to https://raw.githubusercontent.com/camunda/zeebe/5811219ca30027a6b496b521b11744a1f8b7d99d/dist/src/main/config/broker.yaml.template the s3 and store properties under data backup are indented at the same level. Tested succesfully on a local installation.

## What is the purpose of the change

_Briefly describe the change you are making, this helps the reviewer by providing an overview._

## Are there related marketing activities

_Are there any marketing activities related to the related feature or component? If so, please briefly describe them._

## When should this change go live?

_Does this change need to be released before a certain date or milestone? If so, when?_

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
