### PR TITLE
fix(ci): resolve build-docs failures by pinning the bitnami/apache image to a known working version

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -35,7 +35,7 @@ jobs:
           sed -i '/SERVER_PORT/d;/SERVER_NAME/d' build/.htaccess
       - name: Run web server
         run: |
-          docker run -d --name webserver -v "$PWD/build":/app -p 8888:8080 bitnami/apache:latest
+          docker run -d --name webserver -v "$PWD/build":/app -p 8888:8080 bitnami/apache:2.4.54
           echo "container_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' webserver)" >> $GITHUB_ENV
       - name: Download sitemap from production
         run: curl -sL https://docs.camunda.io/sitemap.xml | grep -oP '<loc>\K.*?(?=</loc>)' | sed "s!https://docs.camunda.io!http://${{ env.container_ip }}:8080!g" > sitemap.prod.txt
@@ -45,7 +45,6 @@ jobs:
         uses: nev7n/wait_for_response@v1
         with:
           url: "http://${{ env.container_ip }}:8080/"
-          timeout: 60000
       - name: Check internal links
         # disable action until https://github.com/tylerbutler/linkcheck-bin/issues/1 is released
         #uses: filiph/linkcheck@v2.0.20

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: nev7n/wait_for_response@v1
         with:
           url: "http://${{ env.container_ip }}:8080/"
+          timeout: 60000
       - name: Check internal links
         # disable action until https://github.com/tylerbutler/linkcheck-bin/issues/1 is released
         #uses: filiph/linkcheck@v2.0.20


### PR DESCRIPTION
Pins the bitnami/apache image to a known working version ([2.4.54](https://hub.docker.com/layers/bitnami/apache/2.4.54/images/sha256-f04551fd50664c04d363694516b4f52743fb57b91c516ed7282d582c11da1489?context=explore)).

## Why?

The `build-docs` action started failing when one of the `2.4.55.*` tags was released as `latest`. I'm not exactly sure which one, and I can't see any documentation on [the docker image page](https://hub.docker.com/r/bitnami/apache) that suggests breaking changes with those versions.

### What was failing?

[`build-docs` got to the step where it waits for a local server to be reachable (so that it can do link checking), and the wait would time out and fail the build](https://github.com/camunda/camunda-platform-docs/actions/runs/4045969704/jobs/6958155381). 

Running locally, I was able to get to `localhost:8888` with the docker image running....but not the IP at which `build-docs` is trying to hit it (http://172.17.0.2:8080/). I am not sure if I _should_ be able to hit this URL locally, but I _think_ I should. 

## Is this tracked with bitnami?

I'm not sure. There are a few recent issues related to this update, but I'm not sure if they're the same issue as us: https://github.com/bitnami/containers/issues/22226 looks the most promising. 

I don't feel confident in my ability to describe the problem in a new issue, nor to find out if that issue is really the source of our failures.

## Follow-up work

- I'll merge main into any open PRs so that they can build-docs successfully.