### PR TITLE
docs(web-modeler): move description of WebSocket component to different section

### DIFF
--- a/docs/self-managed/modeler/web-modeler/configuration.md
+++ b/docs/self-managed/modeler/web-modeler/configuration.md
@@ -91,8 +91,6 @@ Web Modeler integrates with Identity and Keycloak for authentication and authori
 
 #### WebSocket
 
-The [WebSocket](https://en.wikipedia.org/wiki/WebSocket) server shipped with Web Modeler Self-Managed is based on the [laravel-websockets](https://laravel.com/docs/9.x/broadcasting#open-source-alternatives-php) open source package and implements the [Pusher Channels Protocol](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/).
-
 The `webapp` component sends certain events (e.g. "user opened diagram", "user left diagram") to the [WebSocket server](#configuration-of-the-websocket-component) and can also react to such events (e.g. show a notification in the UI that a user left the diagram).
 
 | Environment variable      | Description                                                                                                                                   | Example value        | Default value |
@@ -108,6 +106,8 @@ The `webapp` component sends certain events (e.g. "user opened diagram", "user l
 | `CLIENT_PUSHER_FORCE_TLS` | Enable TLS encryption for WebSocket connections initiated by the browser.                                                                     | `true`               | `false`       |
 
 ### Configuration of the `websocket` component
+
+The [WebSocket](https://en.wikipedia.org/wiki/WebSocket) server shipped with Web Modeler Self-Managed is based on the [laravel-websockets](https://laravel.com/docs/9.x/broadcasting#open-source-alternatives-php) open source package and implements the [Pusher Channels Protocol](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/).
 
 | Environment variable | Description                                                                                              | Example value |
 | -------------------- | -------------------------------------------------------------------------------------------------------- | ------------- |


### PR DESCRIPTION
## What is the purpose of the change
Follow-up PR for #1597 that moves the description of the Web Modeler WebSocket component to the correct section of the "Configuration" page.

## Are there related marketing activities
no

## When should this change go live?
It can go live any time.

## PR Checklist
- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.