### PR TITLE
chore: enable Edit This Page links for optimize docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,6 +42,7 @@ module.exports = {
         routeBasePath: "optimize",
         beforeDefaultRemarkPlugins: [versionedLinks],
         sidebarPath: require.resolve("./optimize_sidebars.js"),
+        editUrl: "https://github.com/camunda/camunda-platform-docs/edit/main/",
       },
     ],
   ],


### PR DESCRIPTION
## What is the purpose of the change

Enables "Edit this page" links for Optimize documentation. I just noticed now, but these had been missing since we extracted those docs to support their own versions. 

When I configured the Optimize docs instance, I overlooked this `editUrl` setting 😅 

### Before this change

<img width="1786" alt="image" src="https://user-images.githubusercontent.com/1627089/216470683-aef1f80d-dbb3-4a18-889e-ceaa5a4f6d24.png">

### After this change

![image](https://user-images.githubusercontent.com/1627089/216470642-fcdc1f36-c893-4e9c-bb7a-d66149dad742.png)

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
