### PR TITLE
feat: explain in detail the arguments sent to token server

### DIFF
--- a/docs/apis-clients/operate-api/index.md
+++ b/docs/apis-clients/operate-api/index.md
@@ -31,8 +31,22 @@ To authorize in the cloud using a JWT token, take the steps in the following exa
 **Example:**
 
 1. Obtain a token to access the REST API.
-   You need `client_id`, `client_secret`, `audience`, and the URL of the authorization server. For more information on how to get these for Camunda Platform 8, look
-   at [Manage API Clients](/docs/components/console/manage-clusters/manage-api-clients/).
+
+   When you create an Operate [client](https://docs.camunda.io/docs/guides/setup-client-connection-credentials/), you get all the information needed to connect to Operate.
+
+   The following settings are needed:
+
+   | Name                     | Description                                     | Default value        |
+   | ------------------------ | ----------------------------------------------- | -------------------- |
+   | client id                | Name of your registered client                  | -                    |
+   | client secret            | Password for your registered client             | -                    |
+   | audience                 | Permission name; if not given use default value | `operate.camunda.io` |
+   | authorization server url | Token issuer server                             | -                    |
+
+For more information on how to get these values for Camunda Platform 8, look
+at [Manage API Clients](/docs/components/console/manage-clusters/manage-api-clients/).
+
+Send a token issue _POST_ request to the authorization server with the required settings:
 
 ```shell
 curl -X POST -H 'content-type: application/json' -d '{"client_id": "RgVdPv...", "client_secret":"eDS1~Hg...","audience":"operate.camunda.io","grant_type":"client_credentials"}' https://login.cloud.camunda.io/oauth/token

--- a/versioned_docs/version-8.1/apis-clients/operate-api/index.md
+++ b/versioned_docs/version-8.1/apis-clients/operate-api/index.md
@@ -31,8 +31,22 @@ To authorize in the cloud using a JWT token, take the steps in the following exa
 **Example:**
 
 1. Obtain a token to access the REST API.
-   You need `client_id`, `client_secret`, `audience`, and the URL of the authorization server. For more information on how to get these for Camunda Platform 8, look
-   at [Manage API Clients](/docs/components/console/manage-clusters/manage-api-clients/).
+
+   When you create an Operate [client](https://docs.camunda.io/docs/guides/setup-client-connection-credentials/), you get all the information needed to connect to Operate.
+
+   The following settings are needed:
+
+   | Name                     | Description                                     | Default value        |
+   | ------------------------ | ----------------------------------------------- | -------------------- |
+   | client id                | Name of your registered client                  | -                    |
+   | client secret            | Password for your registered client             | -                    |
+   | audience                 | Permission name; if not given use default value | `operate.camunda.io` |
+   | authorization server url | Token issuer server                             | -                    |
+
+For more information on how to get these values for Camunda Platform 8, look
+at [Manage API Clients](/docs/components/console/manage-clusters/manage-api-clients/).
+
+Send a token issue _POST_ request to the authorization server with the required settings:
 
 ```shell
 curl -X POST -H 'content-type: application/json' -d '{"client_id": "RgVdPv...", "client_secret":"eDS1~Hg...","audience":"operate.camunda.io","grant_type":"client_credentials"}' https://login.cloud.camunda.io/oauth/token


### PR DESCRIPTION
Part of https://github.com/camunda/developer-experience/issues/28

## What is the purpose of the change

Adds context to the arguments passed to the token server when authenticating for Operate API calls.

Inspired by the similar [Optimize docs](https://docs.camunda.io/optimize/apis-clients/optimize-api/optimize-api-authorization/#how-to-obtain-the-access-token-for-c8-saas-cloud-usage), which are more clear about what those values should be. 

### Why?

During https://github.com/camunda/developer-experience/issues/28, I had a hard time trying to figure out what the `audience` param should be. I tried a value from my secrets download before I found the value in the example curl request.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
