### PR TITLE
clarify type and taskdefinition

### DIFF
--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -67,18 +67,14 @@ use [job workers](/components/concepts/job-workers.md) to implement your busines
 
 A job worker implementation can be defined using the `zeebe:taskDefinition` extension element.
 
-Business rule tasks with a job worker implementation behave exactly like [service
-tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). The differences between these task
+Business rule tasks with a job worker implementation behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). The differences between these task
 types are the visual representation (i.e. the task marker) and the semantics for the model.
 
 When a process instance enters a business rule task with alternative task implementation, it creates
 a corresponding job and waits for its completion. A job worker should request jobs of this job type
 and process them. When the job is completed, the process instance continues.
 
-A business rule task must define a [job
-type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a
-service task does. This specifies the type of job that workers should subscribe to (e.g.
-`calculate_risk`).
+A business rule task must define a [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a service task does. This is used as reference to specify which job workers request the respective business rule task job. For example, `order-items`. Note that `type` can be specified as any static value (`myType`) or as a FEEL [expression](../../../concepts/expressions.md) prefixed by `=` that evaluates to any FEEL string; for example, `= "order-" + priorityGroup`.
 
 Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to the job
 worker (e.g. the key of the decision to evaluate).

--- a/docs/components/modeler/bpmn/service-tasks/service-tasks.md
+++ b/docs/components/modeler/bpmn/service-tasks/service-tasks.md
@@ -14,11 +14,17 @@ A [job worker](/components/concepts/job-workers.md) can subscribe to the job typ
 
 ## Task definition
 
-A service task must have a `taskDefinition`; this specifies the type of job workers can subscribe to.
+A service task must have a `taskDefiniton`. The `taskDefiniton` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
 
-Optionally, a `taskDefinition` can specify the number of times the job is retried when a worker signals failure (default = 3).
+A `taskDefinition` specifies the following properties:
 
-Typically, the job type and the job retries are defined as static values (e.g. `order-items`) but they can also be defined as [expressions](/components/concepts/expressions.md) (e.g. `= "order-" + priorityGroup`). The expressions are evaluated on activating the service task and must result in a `string` for the job type and a `number` for the retries.
+- `type` (required): Used as reference to specify which job workers request the respective service task job. For example, `order-items`.
+  - `type` can be specified as any static value (`myType`) or as a FEEL [expression](../../../concepts/expressions.md) prefixed by `=` that evaluates to any FEEL string; for example, `= "order-" + priorityGroup`.
+- `retries` (optional): Specifies the number of times the job is retried when a worker signals failure. The default is three.
+
+The expressions are evaluated on activating the service task and must result in a `string` for the job type and a `number` for the retries.
+
+See an example in the form of the [XML representation](#xml-representation) below.
 
 ## Task headers
 

--- a/versioned_docs/version-8.0/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/versioned_docs/version-8.0/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -67,18 +67,14 @@ use [job workers](/components/concepts/job-workers.md) to implement your busines
 
 A job worker implementation can be defined using the `zeebe:taskDefinition` extension element.
 
-Business rule tasks with a job worker implementation behave exactly like [service
-tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). The differences between these task
+Business rule tasks with a job worker implementation behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). The differences between these task
 types are the visual representation (i.e. the task marker) and the semantics for the model.
 
 When a process instance enters a business rule task with alternative task implementation, it creates
 a corresponding job and waits for its completion. A job worker should request jobs of this job type
 and process them. When the job is completed, the process instance continues.
 
-A business rule task must define a [job
-type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a
-service task does. This specifies the type of job that workers should subscribe to (e.g.
-`calculate_risk`).
+A business rule task must define a [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a service task does. This is used as reference to specify which job workers request the respective business rule task job. For example, `order-items`. Note that `type` can be specified as any static value (`myType`) or as a FEEL [expression](../../../concepts/expressions.md) prefixed by `=` that evaluates to any FEEL string; for example, `= "order-" + priorityGroup`.
 
 Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to the job
 worker (e.g. the key of the decision to evaluate).

--- a/versioned_docs/version-8.0/components/modeler/bpmn/service-tasks/service-tasks.md
+++ b/versioned_docs/version-8.0/components/modeler/bpmn/service-tasks/service-tasks.md
@@ -14,11 +14,17 @@ A [job worker](/components/concepts/job-workers.md) can subscribe to the job typ
 
 ## Task definition
 
-A service task must have a `taskDefinition`; this specifies the type of job workers can subscribe to.
+A service task must have a `taskDefiniton`. The `taskDefiniton` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
 
-Optionally, a `taskDefinition` can specify the number of times the job is retried when a worker signals failure (default = 3).
+A `taskDefinition` specifies the following properties:
 
-Typically, the job type and the job retries are defined as static values (e.g. `order-items`) but they can also be defined as [expressions](/components/concepts/expressions.md) (e.g. `= "order-" + priorityGroup`). The expressions are evaluated on activating the service task and must result in a `string` for the job type and a `number` for the retries.
+- `type` (required): Used as reference to specify which job workers request the respective service task job. For example, `order-items`.
+  - `type` can be specified as any static value (`myType`) or as a FEEL [expression](../../../concepts/expressions.md) prefixed by `=` that evaluates to any FEEL string; for example, `= "order-" + priorityGroup`.
+- `retries` (optional): Specifies the number of times the job is retried when a worker signals failure. The default is three.
+
+The expressions are evaluated on activating the service task and must result in a `string` for the job type and a `number` for the retries.
+
+See an example in the form of the [XML representation](#xml-representation) below.
 
 ## Task headers
 

--- a/versioned_docs/version-8.1/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/versioned_docs/version-8.1/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -67,18 +67,14 @@ use [job workers](/components/concepts/job-workers.md) to implement your busines
 
 A job worker implementation can be defined using the `zeebe:taskDefinition` extension element.
 
-Business rule tasks with a job worker implementation behave exactly like [service
-tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). The differences between these task
+Business rule tasks with a job worker implementation behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). The differences between these task
 types are the visual representation (i.e. the task marker) and the semantics for the model.
 
 When a process instance enters a business rule task with alternative task implementation, it creates
 a corresponding job and waits for its completion. A job worker should request jobs of this job type
 and process them. When the job is completed, the process instance continues.
 
-A business rule task must define a [job
-type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a
-service task does. This specifies the type of job that workers should subscribe to (e.g.
-`calculate_risk`).
+A business rule task must define a [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a service task does. This is used as reference to specify which job workers request the respective business rule task job. For example, `order-items`. Note that `type` can be specified as any static value (`myType`) or as a FEEL [expression](../../../concepts/expressions.md) prefixed by `=` that evaluates to any FEEL string; for example, `= "order-" + priorityGroup`.
 
 Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to the job
 worker (e.g. the key of the decision to evaluate).

--- a/versioned_docs/version-8.1/components/modeler/bpmn/service-tasks/service-tasks.md
+++ b/versioned_docs/version-8.1/components/modeler/bpmn/service-tasks/service-tasks.md
@@ -14,11 +14,17 @@ A [job worker](/components/concepts/job-workers.md) can subscribe to the job typ
 
 ## Task definition
 
-A service task must have a `taskDefinition`; this specifies the type of job workers can subscribe to.
+A service task must have a `taskDefiniton`. The `taskDefiniton` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
 
-Optionally, a `taskDefinition` can specify the number of times the job is retried when a worker signals failure (default = 3).
+A `taskDefinition` specifies the following properties:
 
-Typically, the job type and the job retries are defined as static values (e.g. `order-items`) but they can also be defined as [expressions](/components/concepts/expressions.md) (e.g. `= "order-" + priorityGroup`). The expressions are evaluated on activating the service task and must result in a `string` for the job type and a `number` for the retries.
+- `type` (required): Used as reference to specify which job workers request the respective service task job. For example, `order-items`.
+  - `type` can be specified as any static value (`myType`) or as a FEEL [expression](../../../concepts/expressions.md) prefixed by `=` that evaluates to any FEEL string; for example, `= "order-" + priorityGroup`.
+- `retries` (optional): Specifies the number of times the job is retried when a worker signals failure. The default is three.
+
+The expressions are evaluated on activating the service task and must result in a `string` for the job type and a `number` for the retries.
+
+See an example in the form of the [XML representation](#xml-representation) below.
 
 ## Task headers
 


### PR DESCRIPTION
## What is the purpose of the change

Closes https://github.com/camunda/developer-experience/issues/36. In reference to [this Slack thread](https://camunda.slack.com/archives/C026U8GBNSW/p1674768047324169), docs required some clarification surrounding `type` and the worker.

Thank you @MaxTru for the assistance on this one!

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
