### PR TITLE
[HOLD] Spike: can we identify all changed files in a PR?

### DIFF
--- a/.github/workflows/report-changed-files.yaml
+++ b/.github/workflows/report-changed-files.yaml
@@ -1,10 +1,17 @@
 name: report-changed-files
 
 on:
+  push:
+    branches:
+      - "**"
+      - "!main"
+    tags-ignore:
+      - "*"
   pull_request:
 
 jobs:
   report-changed-files:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/report-changed-files.yaml
+++ b/.github/workflows/report-changed-files.yaml
@@ -1,0 +1,20 @@
+name: report-changed-files
+
+on:
+  pull_request:
+
+jobs:
+  report-changed-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+      - name: List all changed files
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "$file was changed"
+          done

--- a/.github/workflows/report-changed-files.yaml
+++ b/.github/workflows/report-changed-files.yaml
@@ -1,17 +1,10 @@
 name: report-changed-files
 
 on:
-  push:
-    branches:
-      - "**"
-      - "!main"
-    tags-ignore:
-      - "*"
   pull_request:
 
 jobs:
   report-changed-files:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -7,6 +7,8 @@ keywords: ["backpressure", "back-pressure", "back pressure"]
 
 [Zeebe](../components/zeebe/zeebe-overview.md) clients use [gRPC](https://grpc.io/) to communicate with the cluster.
 
+Once upon a time I lived in a box.
+
 ## Gateway service
 
 The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file can be found in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto).


### PR DESCRIPTION
DO NOT MERGE! I'm messing around.

Part of #1659. 

## Findings

1. ✅ The first two commits indicate that for the `pull_request` trigger, [we can see all the files changed in this PR](https://github.com/camunda/camunda-platform-docs/actions/runs/4087332378/jobs/7047706462). 
2. ❌ The third commit indicates that for the `push` trigger, [we only see the files changed in the most recent commit](https://github.com/camunda/camunda-platform-docs/actions/runs/4087332378/jobs/7047706462). 

* I might not be using the `fetch-depth` property of https://github.com/actions/checkout correctly. We might be able to fix number 2 above by passing the correct value of that field. I'm not finding very clear docs on what values for that field will accomplish what I'm looking for.
* I don't really know why we need to run `build-docs` on `push`. The workflow was configured that way _before_ we added the `pull_request` trigger, but it's possible that we can remove the `push` trigger now that we're also running on `pull_request`.
   * I have a vague recollection of someone once telling me that some people like to see the results of `build_docs` _before_ they open a PR. That's the only scenario I can think of where we would still need to run on `push`. 
   * I've scheduled a post to #ask-documentation for Monday to find out if there are people who like to do that. I kind of suspect they don't exist, because the build takes so dang long these days and I can't imagine they'd wait for green before opening the PR. 
   * This could also be a case of moving cheese for a few people for the sake of bettering the overall experience. If removing the `push` trigger enables us to speed up build times for everyone, that's a pretty significant net gain that might exceed the needs and wants of a couple people. 

3. ✅ [This PR](https://github.com/camunda/camunda-platform-docs/pull/1674) demonstrates that the `pull_request` trigger, on forked PRs, would also give [the full list of files changed in the PR](https://github.com/camunda/camunda-platform-docs/actions/runs/4087550133/jobs/7048196117).