### PR TITLE
ci(linkcheck): use github action instead of downloading tar, and ignore connection failures for cron-based workflow

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -46,10 +46,10 @@ jobs:
         with:
           url: "http://${{ env.container_ip }}:8080/"
       - name: Check internal links
-        uses: filiph/linkcheck@v2.0.23
+        uses: filiph/linkcheck@2.0.23
         with:
           arguments: "-i sitemap.prod.txt"
       - name: Check product links
-        uses: filiph/linkcheck@v2.0.23
+        uses: filiph/linkcheck@2.0.23
         with:
           arguments: "-i product-links.prod.txt"

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -46,13 +46,10 @@ jobs:
         with:
           url: "http://${{ env.container_ip }}:8080/"
       - name: Check internal links
-        # disable action until https://github.com/tylerbutler/linkcheck-bin/issues/1 is released
-        #uses: filiph/linkcheck@v2.0.20
-        #with:
-        #  arguments: '-i sitemap.prod.txt'
-        run: |
-          curl -sL https://github.com/filiph/linkcheck/releases/download/2.0.20/linkcheck-2.0.20-linux-x64.tar.gz | tar xvzf - linkcheck/linkcheck --strip 1
-          # Check links from production sitemap to ensure no publish links are broken
-          ./linkcheck -i sitemap.prod.txt
-          # Check links from other products to ensure no links are broken
-          ./linkcheck -i product-links.prod.txt
+        uses: filiph/linkcheck@v2.0.23
+        with:
+          arguments: "-i sitemap.prod.txt"
+      - name: Check product links
+        uses: filiph/linkcheck@v2.0.23
+        with:
+          arguments: "-i product-links.prod.txt"

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Check internal links
         uses: filiph/linkcheck@v2.0.23
         with:
-          arguments: "-i sitemap.prod.txt"
+          arguments: "--connection-failures-as-warnings -i sitemap.prod.txt"
       - name: Check product links
         uses: filiph/linkcheck@v2.0.23
         with:
-          arguments: "-i product-links.prod.txt"
+          arguments: "--connection-failures-as-warnings -i product-links.prod.txt"

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -19,10 +19,10 @@ jobs:
       - name: Prepare product links
         run: grep 'https://docs.camunda.io' product-links.txt | sed "s!https://docs.camunda.io!${{ matrix.url }}!g" > product-links.prod.txt
       - name: Check internal links
-        uses: filiph/linkcheck@v2.0.23
+        uses: filiph/linkcheck@2.0.23
         with:
           arguments: "--connection-failures-as-warnings -i sitemap.prod.txt"
       - name: Check product links
-        uses: filiph/linkcheck@v2.0.23
+        uses: filiph/linkcheck@2.0.23
         with:
           arguments: "--connection-failures-as-warnings -i product-links.prod.txt"

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -18,14 +18,11 @@ jobs:
         run: curl -sL https://docs.camunda.io/sitemap.xml | grep -oP '<loc>\K.*?(?=</loc>)' | sed "s!https://docs.camunda.io!${{ matrix.url }}!g" > sitemap.prod.txt
       - name: Prepare product links
         run: grep 'https://docs.camunda.io' product-links.txt | sed "s!https://docs.camunda.io!${{ matrix.url }}!g" > product-links.prod.txt
-        # disable action until https://github.com/tylerbutler/linkcheck-bin/issues/1 is released
-        #uses: filiph/linkcheck@v2.0.20
-        #with:
-        #  arguments: '-i sitemap.prod.txt'
-      - name: Check internal links from sitemap
-        run: |
-          curl -sL https://github.com/filiph/linkcheck/releases/download/2.0.20/linkcheck-2.0.20-linux-x64.tar.gz | tar xvzf - linkcheck/linkcheck --strip 1
-          # Check links from production sitemap to ensure no publish links are broken
-          ./linkcheck -i sitemap.prod.txt
-          # Check links from other products to ensure no links are broken
-          ./linkcheck -i product-links.prod.txt
+      - name: Check internal links
+        uses: filiph/linkcheck@v2.0.23
+        with:
+          arguments: "-i sitemap.prod.txt"
+      - name: Check product links
+        uses: filiph/linkcheck@v2.0.23
+        with:
+          arguments: "-i product-links.prod.txt"


### PR DESCRIPTION
## What is the purpose of the change

1. Swaps a tarball download of https://github.com/filiph/linkcheck for its github action
   I noticed some comments in the actions that indicate we were waiting for a specific release to switch back to the github action. That release has been shipped, so we should switch back to the github action to simplify the workflow definitions.
2. On the cron-based `link-check` workflow, reports connection failures as warnings instead of errors
   Our cron-based link-check workflow fails more often than it succeeds, and it appears to be mostly a result of "connection failures" for certain pages. Since we just ignore those failing workflows anyway, we can tell the linkcheck tool not to bother reporting them as errors, and hopefully get to more successful runs than failed ones.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
