### PR TITLE
Document Zeebe S3 backup store compression config

### DIFF
--- a/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -52,6 +52,32 @@ Alternatively, you can configure backup store using environment variables:
 
 The same configuration must be provided to all brokers in a cluster.
 
+#### Backup Compression
+
+Backups can be quite large, depending on your usage of Zeebe.
+To reduce S3 storage costs and upload times, you can enable backup compression.
+Zeebe compresses backup data just before uploading to S3 and buffers the compressed files in a temporary directory.
+Compression and buffering of compressed files can have a negative effect if Zeebe is heavily resource constrained.
+
+You can enable compression by specifying a compression algorithm to use.
+We recommend using [zstd] as it provides a good trade off between compression ratio and resource usage.
+More compression algorithms are available, check [commons-compress] for a full list.
+
+```yaml
+zeebe:
+  broker:
+    data:
+      backup:
+        store: s3
+        s3:
+          compression: zstd
+```
+
+Alternatively, you can configure backup compression using an environment variable: `ZEEBE_BROKER_DATA_BACKUP_S3_COMPRESSION`.
+
+[zstd]: https://github.com/facebook/zstd
+[commons-compress]: https://commons.apache.org/proper/commons-compress/
+
 ## Create backup API
 
 The following request can be used to start a backup.

--- a/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -52,16 +52,15 @@ Alternatively, you can configure backup store using environment variables:
 
 The same configuration must be provided to all brokers in a cluster.
 
-#### Backup Compression
+#### Backup compression
 
-Backups can be quite large, depending on your usage of Zeebe.
-To reduce S3 storage costs and upload times, you can enable backup compression.
-Zeebe compresses backup data just before uploading to S3 and buffers the compressed files in a temporary directory.
-Compression and buffering of compressed files can have a negative effect if Zeebe is heavily resource constrained.
+Backups can be large depending on your usage of Zeebe. To reduce S3 storage costs and upload times, you can enable backup compression.
 
-You can enable compression by specifying a compression algorithm to use.
-We recommend using [zstd] as it provides a good trade off between compression ratio and resource usage.
-More compression algorithms are available, check [commons-compress] for a full list.
+Zeebe compresses backup data immediately before uploading to S3 and buffers the compressed files in a temporary directory. Compression and buffering of compressed files can have a negative effect if Zeebe is heavily resource constrained.
+
+You can enable compression by specifying a compression algorithm to use. We recommend using [zstd] as it provides a good trade off between compression ratio and resource usage.
+
+More compression algorithms are available; check [commons-compress] for a full list.
 
 ```yaml
 zeebe:

--- a/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -31,13 +31,13 @@ zeebe:
     data:
       backup:
         store: S3
-          s3:
-            bucketName:
-            basePath:
-            region:
-            endpoint:
-            accessKey:
-            secretKey:
+        s3:
+          bucketName:
+          basePath:
+          region:
+          endpoint:
+          accessKey:
+          secretKey:
 ```
 
 Alternatively, you can configure backup store using environment variables:

--- a/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -150,12 +150,12 @@ zeebe:
     data:
       backup:
         store: S3
-          s3:
-            bucketName:
-            region:
-            endpoint:
-            accessKey:
-            secretKey:
+        s3:
+          bucketName:
+          region:
+          endpoint:
+          accessKey:
+          secretKey:
 ```
 
 Alternatively, you can configure backup store using environment variables:


### PR DESCRIPTION
## What is the purpose of the change
* Documents a new feature available in Zeebe's S3 Backup Store.
* Fixes wrongly indented configuration example

I tried to find a good balance between keeping the docs brief and on point while also mentioning reasons to enable backup compression and trade offs to consider.

closes #1522 

## When should this change go live?

The feature becomes available with 8.2.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
