### PR TITLE
docs(bpmn): improve bpmn coverage docs

### DIFF
--- a/docs/components/modeler/bpmn/bpmn-coverage.md
+++ b/docs/components/modeler/bpmn/bpmn-coverage.md
@@ -10,7 +10,9 @@ export const Highlight = ({children, color}) => (
 </span>
 );
 
-The following BPMN elements are supported by our modeling tools. Elements highlighted in <Highlight color="#11c399">green</Highlight> are supported for execution by Camunda 8. Click on an element to navigate to the documentation.
+The following BPMN elements are supported by our modeling tools. You can deploy all the BPMN elements shown below to
+Camunda 8. Elements highlighted in <Highlight color="#11c399">green</Highlight> are supported for execution by
+Camunda 8. Click on an element to navigate to the documentation.
 
 ## Participants
 

--- a/docs/components/modeler/bpmn/bpmn-coverage.md
+++ b/docs/components/modeler/bpmn/bpmn-coverage.md
@@ -11,8 +11,8 @@ export const Highlight = ({children, color}) => (
 );
 
 The following BPMN elements are supported by our modeling tools. You can deploy all the BPMN elements shown below to
-Camunda 8. Elements highlighted in <Highlight color="#11c399">green</Highlight> are supported for execution by
-Camunda 8. Click on an element to navigate to the documentation.
+Camunda Platform 8. Elements highlighted in <Highlight color="#11c399">green</Highlight> are supported for execution by
+Camunda Platform 8. Click on an element to navigate to the documentation.
 
 ## Participants
 


### PR DESCRIPTION
## What is the purpose of the change

Make it clear that the BPMN elements listed on the BPMN coverage page can also be deployed on the Camunda Platform 8 process engine.

closes #1687 

## Are there related marketing activities

/

## When should this change go live?

With version `8.2.0`.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
