### PR TITLE
style: use orangemunda as primary color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -5,16 +5,18 @@
  * work well for content-centric websites.
  */
 
-/* You can override the default Infima variables here. */
+/*
+These colors are produced using #fc5d0d (orange-munda) in the primary color shades tool.
+See: https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima
+*/
 :root {
-  --ifm-color-primary: #ff1f00;
-  --ifm-color-primary-dark: #ff3800;
-  --ifm-color-primary-darker: #ff4700;
-  --ifm-color-primary-darkest: #ff5400;
-  --ifm-color-primary-light: #ff7000;
-  --ifm-color-primary-lighter: #ff7d00;
-  --ifm-color-primary-lightest: #ff8b00;
-  --ifm-code-font-size: 95%;
+  --ifm-color-primary: #fc5d0d;
+  --ifm-color-primary-dark: #ec5103;
+  --ifm-color-primary-darker: #de4c03;
+  --ifm-color-primary-darkest: #b73f02;
+  --ifm-color-primary-light: #fc6f27;
+  --ifm-color-primary-lighter: #fc7734;
+  --ifm-color-primary-lightest: #fd925c;
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
## What is the purpose of the change

The red color of the fonts, links, navigation, search, etc. used in the Docs is not the color I would expect to be used at Camunda. I would expect that we use Orangemunda `#FC5D0D` as our primary color.

It is unclear to me why `#ff1f00` was used as the primary color before. It might be related to contrast to improve accessibility. However, it may also simply be a leftover from the start of the camunda-platform-docs. I propose we switch, so the Docs fit our branding, unless we confirm we need increased contrast. In that case I wonder if there are other colors that might fit better. 

This pull request switches Infima's (the design system used by Docusaurus) primary colors to shades of `Orangemunda`. The shades are produced using Docusaurus' own tool for producing different shades.

<img width="50%" alt="How it is now (red)" title="How it is now (red)" src="https://user-images.githubusercontent.com/3511026/218555878-784a643f-cbbf-4fbe-9f75-2ac56075c4b7.png"><img width="50%" alt="How it will be after once merged (orangemunda)" title="How it will be after once merged (orangemunda)" src="https://user-images.githubusercontent.com/3511026/218555859-4601b898-92b5-446f-a33a-fedc219ec11d.png">
Left: How it is now (red) - Right: How it will be after once merged (orangemunda)

## Are there related marketing activities

_Are there any marketing activities related to the related feature or component? If so, please briefly describe them._

Orangemunda > Red

## When should this change go live?

_Does this change need to be released before a certain date or milestone? If so, when?_

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
