### PR TITLE
chore(connectors): add missing sdk migration guides

### DIFF
--- a/docs/guides/update-guide/connectors/040-to-050.md
+++ b/docs/guides/update-guide/connectors/040-to-050.md
@@ -1,0 +1,19 @@
+---
+id: 040-to-050
+title: Update 0.4 to 0.5
+description: "Review which adjustments must be made to migrate from Connector SDK 0.4.x to 0.5.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--beginner">Beginner</span>
+
+No manual adjustment necessary to migrate from
+[Connector SDK](/components/connectors/custom-built-connectors/connector-sdk.md)
+0.4.x to 0.5.0.
+
+With SDK version 0.5.0, we introduced minor changes:
+
+- Removing Spring Zeebe dependency management
+- Managing the GCP Secret Provider module version

--- a/docs/guides/update-guide/connectors/050-to-060.md
+++ b/docs/guides/update-guide/connectors/050-to-060.md
@@ -1,0 +1,21 @@
+---
+id: 050-to-060
+title: Update 0.5 to 0.6
+description: "Review which adjustments must be made to migrate from Connector SDK 0.5.x to 0.6.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--beginner">Beginner</span>
+
+No manual adjustment necessary to migrate from
+[Connector SDK](/components/connectors/custom-built-connectors/connector-sdk.md)
+0.5.x to 0.6.0.
+
+With SDK version 0.6.0, we introduced the following changes:
+
+- Replacing secrects in parent classes
+- Supporting intermediate inbound events
+- Defining interfaces for inbound connectors
+- Fixing failing datetime serialization

--- a/docs/guides/update-guide/connectors/introduction.md
+++ b/docs/guides/update-guide/connectors/introduction.md
@@ -9,6 +9,18 @@ Connector runtimes to a newer version of the
 
 There is a dedicated update guide for each version:
 
+### [Connector SDK 0.5 to 0.6](../050-to-060)
+
+Update from 0.5.x to 0.6.0
+
+[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.6.0)
+
+### [Connector SDK 0.4 to 0.5](../040-to-050)
+
+Update from 0.4.x to 0.5.0
+
+[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.5.0)
+
 ### [Connector SDK 0.3 to 0.4](../030-to-040)
 
 Update from 0.3.x to 0.4.0

--- a/sidebars.js
+++ b/sidebars.js
@@ -40,6 +40,8 @@ module.exports = {
             "guides/update-guide/connectors/010-to-020",
             "guides/update-guide/connectors/020-to-030",
             "guides/update-guide/connectors/030-to-040",
+            "guides/update-guide/connectors/040-to-050",
+            "guides/update-guide/connectors/050-to-060",
           ],
         },
         "guides/update-guide/810-to-820",

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/040-to-050.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/040-to-050.md
@@ -1,0 +1,19 @@
+---
+id: 040-to-050
+title: Update 0.4 to 0.5
+description: "Review which adjustments must be made to migrate from Connector SDK 0.4.x to 0.5.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--beginner">Beginner</span>
+
+No manual adjustment necessary to migrate from
+[Connector SDK](/components/connectors/custom-built-connectors/connector-sdk.md)
+0.4.x to 0.5.0.
+
+With SDK version 0.5.0, we introduced minor changes:
+
+- Removing Spring Zeebe dependency management
+- Managing the GCP Secret Provider module version

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/050-to-060.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/050-to-060.md
@@ -1,0 +1,21 @@
+---
+id: 050-to-060
+title: Update 0.5 to 0.6
+description: "Review which adjustments must be made to migrate from Connector SDK 0.5.x to 0.6.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--beginner">Beginner</span>
+
+No manual adjustment necessary to migrate from
+[Connector SDK](/components/connectors/custom-built-connectors/connector-sdk.md)
+0.5.x to 0.6.0.
+
+With SDK version 0.6.0, we introduced the following changes:
+
+- Replacing secrects in parent classes
+- Supporting intermediate inbound events
+- Defining interfaces for inbound connectors
+- Fixing failing datetime serialization

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/introduction.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/introduction.md
@@ -9,6 +9,18 @@ Connector runtimes to a newer version of the
 
 There is a dedicated update guide for each version:
 
+### [Connector SDK 0.5 to 0.6](../050-to-060)
+
+Update from 0.5.x to 0.6.0
+
+[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.6.0)
+
+### [Connector SDK 0.4 to 0.5](../040-to-050)
+
+Update from 0.4.x to 0.5.0
+
+[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.5.0)
+
 ### [Connector SDK 0.3 to 0.4](../030-to-040)
 
 Update from 0.3.x to 0.4.0

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/040-to-050.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/040-to-050.md
@@ -1,0 +1,19 @@
+---
+id: 040-to-050
+title: Update 0.4 to 0.5
+description: "Review which adjustments must be made to migrate from Connector SDK 0.4.x to 0.5.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--beginner">Beginner</span>
+
+No manual adjustment necessary to migrate from
+[Connector SDK](/components/connectors/custom-built-connectors/connector-sdk.md)
+0.4.x to 0.5.0.
+
+With SDK version 0.5.0, we introduced minor changes:
+
+- Removing Spring Zeebe dependency management
+- Managing the GCP Secret Provider module version

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/050-to-060.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/050-to-060.md
@@ -1,0 +1,21 @@
+---
+id: 050-to-060
+title: Update 0.5 to 0.6
+description: "Review which adjustments must be made to migrate from Connector SDK 0.5.x to 0.6.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--beginner">Beginner</span>
+
+No manual adjustment necessary to migrate from
+[Connector SDK](/components/connectors/custom-built-connectors/connector-sdk.md)
+0.5.x to 0.6.0.
+
+With SDK version 0.6.0, we introduced the following changes:
+
+- Replacing secrects in parent classes
+- Defining interfaces for inbound connectors
+- Supporting intermediate events
+- Fixing failing datetime serialization

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/introduction.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/introduction.md
@@ -9,6 +9,18 @@ Connector runtimes to a newer version of the
 
 There is a dedicated update guide for each version:
 
+### [Connector SDK 0.5 to 0.6](../050-to-060)
+
+Update from 0.5.x to 0.6.0
+
+[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.6.0)
+
+### [Connector SDK 0.4 to 0.5](../040-to-050)
+
+Update from 0.4.x to 0.5.0
+
+[Release notes](https://github.com/camunda/connector-sdk/releases/tag/0.5.0)
+
 ### [Connector SDK 0.3 to 0.4](../030-to-040)
 
 Update from 0.3.x to 0.4.0

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -31,7 +31,9 @@
             "guides/update-guide/connectors/introduction",
             "guides/update-guide/connectors/010-to-020",
             "guides/update-guide/connectors/020-to-030",
-            "guides/update-guide/connectors/030-to-040"
+            "guides/update-guide/connectors/030-to-040",
+            "guides/update-guide/connectors/040-to-050",
+            "guides/update-guide/connectors/050-to-060"
           ]
         },
         "guides/update-guide/130-to-800",

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -31,7 +31,9 @@
             "guides/update-guide/connectors/introduction",
             "guides/update-guide/connectors/010-to-020",
             "guides/update-guide/connectors/020-to-030",
-            "guides/update-guide/connectors/030-to-040"
+            "guides/update-guide/connectors/030-to-040",
+            "guides/update-guide/connectors/040-to-050",
+            "guides/update-guide/connectors/050-to-060"
           ]
         },
         "guides/update-guide/800-to-810",


### PR DESCRIPTION
## What is the purpose of the change

SDK migration guides were missing. Although these does not require any manual change from the user, we should include these for uniformity.

## When should this change go live?

Any time. Preferably asap.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.


## Relates to

https://github.com/camunda/team-connectors/issues/339 
