### PR TITLE
oops: update broken link in v8.1 also

### DIFF
--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -114,7 +114,7 @@ v3.8.1+g5cb9af4
 If you're running on Helm 3.0.0 up to 3.1.3, you need to add these values to your `values.yaml` file, or save them to a new file locally, e.g. `openshift.yaml`:
 
 :::note
-These values are also available in the [Camunda Platform Helm chart repository](https://github.com/camunda/camunda-platform-helm/blob/main/openshift/values.yaml).
+These values are also available in the [Camunda Platform Helm chart repository](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform/openshift).
 :::
 
 ```yaml


### PR DESCRIPTION
## What is the purpose of the change

Updates a link in v8.1, [which should have also been updated in #1699](https://github.com/camunda/camunda-platform-docs/pull/1699#issuecomment-1431786715)

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
