### PR TITLE
feat: darker shade of orange to meet WCAG minimum contrast requirements

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,17 +6,17 @@
  */
 
 /*
-These colors are produced using #fc5d0d (orange-munda) in the primary color shades tool.
+These colors are produced using a slightly darker version of #fc5d0d (orange-munda) in the primary color shades tool.
 See: https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima
 */
 :root {
-  --ifm-color-primary: #fc5d0d;
-  --ifm-color-primary-dark: #ec5103;
-  --ifm-color-primary-darker: #de4c03;
-  --ifm-color-primary-darkest: #b73f02;
-  --ifm-color-primary-light: #fc6f27;
-  --ifm-color-primary-lighter: #fc7734;
-  --ifm-color-primary-lightest: #fd925c;
+  --ifm-color-primary: #c54302;
+  --ifm-color-primary-dark: #b13c02;
+  --ifm-color-primary-darker: #a73902;
+  --ifm-color-primary-darkest: #8a2f01;
+  --ifm-color-primary-light: #d94a02;
+  --ifm-color-primary-lighter: #e34d02;
+  --ifm-color-primary-lightest: #fc5806;
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
A follow-up to #1698 

## What is the purpose of the change

Shifts the primary brand color to a slightly darker shade of orange, to meet WCAG minimum contrast guidelines. 

See [this comment](https://github.com/camunda/camunda-platform-docs/pull/1698#issuecomment-1433808640) for more details on how I arrived at this specific shade.

What it looks like: 

<img width="1690" alt="image" src="https://user-images.githubusercontent.com/1627089/219783486-d694915b-8056-4903-a7ff-68599d10f852.png">


## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
