### PR TITLE
chore:replace slack link

### DIFF
--- a/docs/components/zeebe/open-source/get-help-get-involved.md
+++ b/docs/components/zeebe/open-source/get-help-get-involved.md
@@ -14,7 +14,7 @@ The Zeebe team monitors the forum closely, and we do our best to respond to all 
 
 ### Public Slack group
 
-Join our [public Slack group](https://camunda-slack-invite.herokuapp.com/), where you can ask questions, share community contributions, and connect with other Zeebe users.
+Join our [public Slack group](https://camunda.com/slack), where you can ask questions, share community contributions, and connect with other Zeebe users.
 
 ### Create an issue in GitHub
 

--- a/docs/self-managed/platform-deployment/overview.md
+++ b/docs/self-managed/platform-deployment/overview.md
@@ -72,4 +72,4 @@ We support the following deployment options (the sequence expresses preference) 
 If you have questions or feedback about deployment with Zeebe, we encourage you to visit:
 
 - [User forum](https://forum.camunda.io/)
-- [Public Slack channel](https://camunda-slack-invite.herokuapp.com/)
+- [Public Slack channel](https://camunda.com/slack)

--- a/docs/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/docs/self-managed/zeebe-deployment/zeebe-installation.md
@@ -21,5 +21,5 @@ New to BPMN and want to learn more before moving forward? [Visit our Get Started
 If you have questions or feedback, we encourage you to visit the following:
 
 - [User forum](https://forum.camunda.io/)
-- [Public Slack channel](https://camunda-slack-invite.herokuapp.com/)
+- [Public Slack channel](https://camunda.com/slack)
 - [GitHub issue tracker](https://github.com/camunda/zeebe/issues)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -132,7 +132,7 @@ module.exports = {
           items: [
             {
               label: "Slack",
-              href: "https://camunda-slack-invite.herokuapp.com/",
+              href: "https://camunda.com/slack",
             },
             {
               label: "Twitter",

--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -7,7 +7,7 @@ description: Contact Camunda, submit feedback, or find support using the Camunda
 
 There are various channels where you can reach us.
 
-- We encourage everyone to participate in our **community** via the [Camunda Platform community forum](https://forum.camunda.io/) or [Slack](https://camunda-cloud.slack.com/), where you can exchange ideas with other Zeebe and Camunda Platform 8 users, as well as the product developers. If you are joining our Slack for the first time, you will need to get an [invite](https://camunda-slack-invite.herokuapp.com/) first.
+- We encourage everyone to participate in our **community** via the [Camunda Platform community forum](https://forum.camunda.io/) or [Slack](https://camunda-cloud.slack.com/), where you can exchange ideas with other Zeebe and Camunda Platform 8 users, as well as the product developers. If you are joining our Slack for the first time, you will need to get an [invite](https://camunda.com/slack) first.
 
 - We welcome your **bug** reports and **feature requests** through our community channels mentioned above.
 

--- a/versioned_docs/version-8.0/components/zeebe/open-source/get-help-get-involved.md
+++ b/versioned_docs/version-8.0/components/zeebe/open-source/get-help-get-involved.md
@@ -14,7 +14,7 @@ The Zeebe team monitors the forum closely, and we do our best to respond to all 
 
 ### Public Slack group
 
-Join our [public Slack group](https://camunda-slack-invite.herokuapp.com/), where you can ask questions, share community contributions, and connect with other Zeebe users.
+Join our [public Slack group](https://camunda.com/slack), where you can ask questions, share community contributions, and connect with other Zeebe users.
 
 ### Create an issue in GitHub
 

--- a/versioned_docs/version-8.0/self-managed/platform-deployment/platform-8-deployment.md
+++ b/versioned_docs/version-8.0/self-managed/platform-deployment/platform-8-deployment.md
@@ -64,4 +64,4 @@ We support the following deployment options (the sequence expresses preference) 
 If you have questions or feedback about deployment with Zeebe, we encourage you to visit:
 
 - [User forum](https://forum.camunda.io/)
-- [Public Slack channel](https://camunda-slack-invite.herokuapp.com/)
+- [Public Slack channel](https://camunda.com/slack)

--- a/versioned_docs/version-8.0/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/versioned_docs/version-8.0/self-managed/zeebe-deployment/zeebe-installation.md
@@ -21,5 +21,5 @@ New to BPMN and want to learn more before moving forward? [Visit our Get Started
 If you have questions or feedback, we encourage you to visit the following:
 
 - [User forum](https://forum.camunda.io/)
-- [Public Slack channel](https://camunda-slack-invite.herokuapp.com/)
+- [Public Slack channel](https://camunda.com/slack)
 - [GitHub issue tracker](https://github.com/camunda/zeebe/issues)

--- a/versioned_docs/version-8.1/components/zeebe/open-source/get-help-get-involved.md
+++ b/versioned_docs/version-8.1/components/zeebe/open-source/get-help-get-involved.md
@@ -14,7 +14,7 @@ The Zeebe team monitors the forum closely, and we do our best to respond to all 
 
 ### Public Slack group
 
-Join our [public Slack group](https://camunda-slack-invite.herokuapp.com/), where you can ask questions, share community contributions, and connect with other Zeebe users.
+Join our [public Slack group](https://camunda.com/slack), where you can ask questions, share community contributions, and connect with other Zeebe users.
 
 ### Create an issue in GitHub
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/overview.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/overview.md
@@ -72,4 +72,4 @@ We support the following deployment options (the sequence expresses preference) 
 If you have questions or feedback about deployment with Zeebe, we encourage you to visit:
 
 - [User forum](https://forum.camunda.io/)
-- [Public Slack channel](https://camunda-slack-invite.herokuapp.com/)
+- [Public Slack channel](https://camunda.com/slack)

--- a/versioned_docs/version-8.1/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/versioned_docs/version-8.1/self-managed/zeebe-deployment/zeebe-installation.md
@@ -21,5 +21,5 @@ New to BPMN and want to learn more before moving forward? [Visit our Get Started
 If you have questions or feedback, we encourage you to visit the following:
 
 - [User forum](https://forum.camunda.io/)
-- [Public Slack channel](https://camunda-slack-invite.herokuapp.com/)
+- [Public Slack channel](https://camunda.com/slack)
 - [GitHub issue tracker](https://github.com/camunda/zeebe/issues)


### PR DESCRIPTION
## What is the purpose of the change
Update all references to camunda-slack-invite.herokuapp.com/ to the new link, http://camunda.com/slack
Fixes #1708 
## Are there related marketing activities
No

## When should this change go live?
You decide 

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
