### PR TITLE
feat(modeler/desktop-modeler): use windows path example

### DIFF
--- a/versioned_docs/version-8.1/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.1/components/modeler/desktop-modeler/flags/flags.md
@@ -74,11 +74,13 @@ To display a custom version information in the status bar of the app, configure 
 
 > :information_source: The Modeler will read trusted certificates from your operating system's trust store.
 
-Provide additional certificates to validate secured connections to a Camunda Platform 8 installation. Configure your `flags.json` like this:
+Provide additional certificates to validate secured connections to a Camunda Platform 8 installation. 
+
+Configure your `flags.json` like this:
 
 ```js
 {
-    "zeebe-ssl-certificate": "/Users/local/trusted-custom-root.pem"
+    "zeebe-ssl-certificate": "C:\\path\\to\\certs\\trusted-custom-roots.pem"
 }
 ```
 


### PR DESCRIPTION
## What is the purpose of the change

This proposes to using a Windows path to document `zeebe-ssl-certificate` flag, as it is apparently hardest to configure.

Related to https://github.com/camunda/camunda-modeler/issues/3466

## Are there related marketing activities

No.

## When should this change go live?

No specific time slot (any time).

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
