### PR TITLE
Update zeebe backup docs

### DIFF
--- a/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -16,9 +16,9 @@ The backups are stored to an external data storage. [S3](https://aws.amazon.com/
 
 To use the backup feature in Zeebe, the following configurations must be provided:
 
-- Enable backups by setting the flag `ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEBACKUP` to `true`.
-- Ensure the configuration `MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE` includes the endpoint "backups". Set `MANAGEMENT_ENDPOINTS_BACKUPS_ENABLED` to `true`.
-  For additional configurations such as security, refer to the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/2.7.x/reference/htmlsingle/#actuator.endpoints).
+- Ensure the configuration `MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE` includes the endpoint "backups". By default, this is set to "\*" which included backups.
+- Set `MANAGEMENT_ENDPOINTS_BACKUPS_ENABLED` to `true`.
+- For additional configurations such as security, refer to the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/2.7.x/reference/htmlsingle/#actuator.endpoints).
 - An external S3-compatible storage must be configured as the backup store.
 
 ### Configure S3 backup store
@@ -98,8 +98,9 @@ POST actuator/backups
 }
 ```
 
-A `backupId` is an integer and must be greater than the id of previous backups.
+A `backupId` is an integer and must be greater than the id of previous backups that are completed, failed or deleted.
 Zeebe does not take two backups with the same ids. If a backup fails, a new `backupId` must be provided to trigger a new backup.
+The `backupId` cannot be reused, even if the backup corresponding to the backup id is deleted.
 
 <details>
   <summary>Example request</summary>

--- a/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/docs/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -98,7 +98,7 @@ POST actuator/backups
 }
 ```
 
-A `backupId` is an integer and must be greater than the id of previous backups that are completed, failed or deleted.
+A `backupId` is an integer and must be greater than the id of previous backups that are completed, failed, or deleted.
 Zeebe does not take two backups with the same ids. If a backup fails, a new `backupId` must be provided to trigger a new backup.
 The `backupId` cannot be reused, even if the backup corresponding to the backup id is deleted.
 

--- a/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
+++ b/versioned_docs/version-8.1/self-managed/backup-restore/zeebe-backup-and-restore.md
@@ -34,7 +34,9 @@ To take a backup of the cluster, backup storage must be configured.
 POST http://{zeebe-gateway}:9600/actuator/backups/{backupId}
 ```
 
-A `backupId` is an integer and must be greater than the id of previous backups. Zeebe does not take two backups with the same ids. If a backup fails, a new `backupId` must be provided to trigger a new backup.
+A `backupId` is an integer and must be greater than the id of previous backups that are completed, failed, or deleted.
+Zeebe does not take two backups with the same ids. If a backup fails, a new `backupId` must be provided to trigger a new backup.
+The `backupId` cannot be reused, even if the backup corresponding to the backup id is deleted.
 
 ##### Response
 
@@ -139,7 +141,7 @@ When restoring, provide the same configuration (node id, data directory, cluster
 ## Configuration
 
 - Enable backups by setting the flag `ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEBACKUP` to `true`.
-- The backup management API is available via management port of the gateway. Ensure the configuration `MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE` include "backups". Set `MANAGEMENT_ENDPOINTS_BACKUPS_ENABLED` to `true`.
+- The backup management API is available via management port of the gateway. Ensure the configuration `MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE` include "backups". By default, this is set to "\*" which included backups. Set `MANAGEMENT_ENDPOINTS_BACKUPS_ENABLED` to `true`.
 - Backup is stored in an external storage. This must be configured before starting the Zeebe cluster.
 
 Configure backup store in the configuration file as follows.


### PR DESCRIPTION
## What is the purpose of the change

- Backup is not an experimental feature anymore. So the configuration to enable/disable it is removed. (https://github.com/camunda/zeebe/pull/11780)
- Some smaller improvements to the documentation based on the feedback.

## Are there related marketing activities

No.

## When should this change go live?

With 8.2.0 release

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
