### PR TITLE
docs(optimize): call out that the readiness endpoint does not want an Authorization header

### DIFF
--- a/optimize/apis-clients/optimize-api/health-readiness.md
+++ b/optimize/apis-clients/optimize-api/health-readiness.md
@@ -6,6 +6,10 @@ description: "The REST API to check the readiness of Optimize."
 
 The purpose of Health-Readiness REST API is to return information indicating whether Optimize is ready to be used.
 
+:::note
+The Health-Readiness REST API does not require an [`Authorization` header](./optimize-api-authorization.md), and rejects requests that include one.
+:::
+
 ## Method & HTTP target resource
 
 GET `/api/readyz`

--- a/optimize_versioned_docs/version-3.8.0/apis-clients/optimize-api/health-readiness.md
+++ b/optimize_versioned_docs/version-3.8.0/apis-clients/optimize-api/health-readiness.md
@@ -6,6 +6,10 @@ description: "The REST API to check the readiness of Optimize."
 
 The purpose of Health-Readiness REST API is to return information indicating whether Optimize is ready to be used.
 
+:::note
+The Health-Readiness REST API does not require an [`Authorization` header](./optimize-api-authorization.md), and rejects requests that include one.
+:::
+
 ## Method & HTTP target resource
 
 GET `/api/readyz`

--- a/optimize_versioned_docs/version-3.9.0/apis-clients/optimize-api/health-readiness.md
+++ b/optimize_versioned_docs/version-3.9.0/apis-clients/optimize-api/health-readiness.md
@@ -6,6 +6,10 @@ description: "The REST API to check the readiness of Optimize."
 
 The purpose of Health-Readiness REST API is to return information indicating whether Optimize is ready to be used.
 
+:::note
+The Health-Readiness REST API does not require an [`Authorization` header](./optimize-api-authorization.md), and rejects requests that include one.
+:::
+
 ## Method & HTTP target resource
 
 GET `/api/readyz`


### PR DESCRIPTION
## What is the purpose of the change

Adds an admonition to vNext and v3.9.0 Optimize API docs readiness endpoint, calling out that this endpoint does not work with an `Authorization` header.

This is in response to [my API exploration findings](https://github.com/camunda/developer-experience/issues/31#issuecomment-1438778116), where I got stuck for a bit because I was trying to send the header in a `/readyz` request, and getting a confusing error.


### What it looks like

![image](https://user-images.githubusercontent.com/1627089/221047238-c2871f2a-d30c-4549-9701-f16876bdb09f.png)

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
