### PR TITLE
fix: correctly tag note in receive task docs

### DIFF
--- a/docs/components/modeler/bpmn/receive-tasks/receive-tasks.md
+++ b/docs/components/modeler/bpmn/receive-tasks/receive-tasks.md
@@ -12,7 +12,7 @@ When a receive task is entered, a corresponding message subscription is created.
 
 A message can be published using one of the Zeebe clients. When the message is correlated, the receive task is completed and the process instance continues.
 
-:::inote
+:::note
 An alternative to receive tasks is [a message intermediate catch event](../message-events/message-events.md), which behaves the same way but can be used together with event-based gateways.
 :::
 

--- a/versioned_docs/version-1.3/components/modeler/bpmn/receive-tasks/receive-tasks.md
+++ b/versioned_docs/version-1.3/components/modeler/bpmn/receive-tasks/receive-tasks.md
@@ -12,7 +12,7 @@ When a receive task is entered, a corresponding message subscription is created.
 
 A message can be published using one of the Zeebe clients. When the message is correlated, the receive task is completed and the process instance continues.
 
-:::inote
+:::note
 An alternative to receive tasks is [a message intermediate catch event](../message-events/message-events.md), which behaves the same way but can be used together with event-based gateways.
 :::
 

--- a/versioned_docs/version-8.0/components/modeler/bpmn/receive-tasks/receive-tasks.md
+++ b/versioned_docs/version-8.0/components/modeler/bpmn/receive-tasks/receive-tasks.md
@@ -12,7 +12,7 @@ When a receive task is entered, a corresponding message subscription is created.
 
 A message can be published using one of the Zeebe clients. When the message is correlated, the receive task is completed and the process instance continues.
 
-:::inote
+:::note
 An alternative to receive tasks is [a message intermediate catch event](../message-events/message-events.md), which behaves the same way but can be used together with event-based gateways.
 :::
 

--- a/versioned_docs/version-8.1/components/modeler/bpmn/receive-tasks/receive-tasks.md
+++ b/versioned_docs/version-8.1/components/modeler/bpmn/receive-tasks/receive-tasks.md
@@ -12,7 +12,7 @@ When a receive task is entered, a corresponding message subscription is created.
 
 A message can be published using one of the Zeebe clients. When the message is correlated, the receive task is completed and the process instance continues.
 
-:::inote
+:::note
 An alternative to receive tasks is [a message intermediate catch event](../message-events/message-events.md), which behaves the same way but can be used together with event-based gateways.
 :::
 


### PR DESCRIPTION
## What is the purpose of the change

This fixes a typo I noticed in the Receive Task docs:

![image](https://user-images.githubusercontent.com/28307541/221198569-70ec7152-ca20-487b-abec-73b7d5275272.png)


## Are there related marketing activities

No.

## When should this change go live?

-

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
