### PR TITLE
docs(connctors): clarified connector exec retries

### DIFF
--- a/docs/components/connectors/use-connectors.md
+++ b/docs/components/connectors/use-connectors.md
@@ -33,7 +33,7 @@ Each Connector defines its own set of properties you can fill in. Find the detai
 
 ### Retries
 
-By default, connector execution is repeated `3` times in case when execution fails. If you wish to change default retries value, you would need to edit BPMN XML file and set `retries` attribute at the `zeebe:taskDefinition`. For example:
+By default, Connector execution is repeated `3` times if execution fails. To change the default retries value, edit the BPMN XML file and set the `retries` attribute at the `zeebe:taskDefinition`. For example:
 
 ```xml
 ...

--- a/docs/components/connectors/use-connectors.md
+++ b/docs/components/connectors/use-connectors.md
@@ -31,6 +31,16 @@ Fields in the properties panel marked with an equals sign inside a circle indica
 
 Each Connector defines its own set of properties you can fill in. Find the details for Connectors provided by Camunda in the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) documentation.
 
+### Retries
+
+By default, connector execution is repeated `3` times in case when execution fails. If you wish to change default retries value, you would need to edit BPMN XML file and set `retries` attribute at the `zeebe:taskDefinition`. For example:
+
+```xml
+...
+<zeebe:taskDefinition type="io.camunda:http-json:1" retries="12" />
+...
+```
+
 ## Inbound Connector
 
 ### Creating the BPMN start event

--- a/versioned_docs/version-8.0/components/connectors/use-connectors.md
+++ b/versioned_docs/version-8.0/components/connectors/use-connectors.md
@@ -33,7 +33,7 @@ Each Connector defines its own set of properties you can fill in. Find the detai
 
 ### Retries
 
-By default, connector execution is repeated `3` times in case when execution fails. If you wish to change default retries value, you would need to edit BPMN XML file and set `retries` attribute at the `zeebe:taskDefinition`. For example:
+By default, Connector execution is repeated `3` times if execution fails. To change the default retries value, edit the BPMN XML file and set the `retries` attribute at the `zeebe:taskDefinition`. For example:
 
 ```xml
 ...

--- a/versioned_docs/version-8.0/components/connectors/use-connectors.md
+++ b/versioned_docs/version-8.0/components/connectors/use-connectors.md
@@ -31,6 +31,16 @@ Fields in the properties panel marked with an equals sign inside a circle indica
 
 Each Connector defines its own set of properties you can fill in. Find the details for Connectors provided by Camunda in the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) documentation.
 
+### Retries
+
+By default, connector execution is repeated `3` times in case when execution fails. If you wish to change default retries value, you would need to edit BPMN XML file and set `retries` attribute at the `zeebe:taskDefinition`. For example:
+
+```xml
+...
+<zeebe:taskDefinition type="io.camunda:http-json:1" retries="12" />
+...
+```
+
 ## Inbound Connector
 
 ### Creating the BPMN start event

--- a/versioned_docs/version-8.1/components/connectors/use-connectors.md
+++ b/versioned_docs/version-8.1/components/connectors/use-connectors.md
@@ -33,7 +33,7 @@ Each Connector defines its own set of properties you can fill in. Find the detai
 
 ### Retries
 
-By default, connector execution is repeated `3` times in case when execution fails. If you wish to change default retries value, you would need to edit BPMN XML file and set `retries` attribute at the `zeebe:taskDefinition`. For example:
+By default, Connector execution is repeated `3` times if execution fails. To change the default retries value, edit the BPMN XML file and set the `retries` attribute at the `zeebe:taskDefinition`. For example:
 
 ```xml
 ...

--- a/versioned_docs/version-8.1/components/connectors/use-connectors.md
+++ b/versioned_docs/version-8.1/components/connectors/use-connectors.md
@@ -31,6 +31,16 @@ Fields in the properties panel marked with an equals sign inside a circle indica
 
 Each Connector defines its own set of properties you can fill in. Find the details for Connectors provided by Camunda in the [out-of-the-box Connectors](./out-of-the-box-connectors/available-connectors-overview.md) documentation.
 
+### Retries
+
+By default, connector execution is repeated `3` times in case when execution fails. If you wish to change default retries value, you would need to edit BPMN XML file and set `retries` attribute at the `zeebe:taskDefinition`. For example:
+
+```xml
+...
+<zeebe:taskDefinition type="io.camunda:http-json:1" retries="12" />
+...
+```
+
 ## Inbound Connector
 
 ### Creating the BPMN start event


### PR DESCRIPTION
## What is the purpose of the change

Clarified connector exec retries

## Are there related marketing activities

No

## When should this change go live?

Any time.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
