### PR TITLE
docs(optimize): update optimize clustering to reflect that history clean up is disabled by default

### DIFF
--- a/optimize/self-managed/optimize-deployment/configuration/clustering.md
+++ b/optimize/self-managed/optimize-deployment/configuration/clustering.md
@@ -34,6 +34,9 @@ engines:
     name: default
     rest: 'http://localhost:8080/engine-rest'
     importEnabled: true
+
+historyCleanup:
+  enabled: true
 ...
 ```
 
@@ -46,14 +49,11 @@ engines:
     name: default
     rest: 'http://localhost:8080/engine-rest'
     importEnabled: false
-
-historyCleanup:
-  enabled: false
 ...
 ```
 
 :::note
-The second non-importing instance has the [history cleanup disabled](./system-configuration.md#history-cleanup-settings). It is strongly recommended to do this for all non-importing Optimize instances in the cluster to prevent any conflicts when the [history cleanup](../history-cleanup/) is performed.
+The importing instance has the [history cleanup enabled](./system-configuration.md#history-cleanup-settings). It is strongly recommended all non-importing Optimize instances in the cluster do not enable history cleanup to prevent any conflicts when the [history cleanup](../history-cleanup/) is performed.
 :::
 
 ### 1.1 Import - event based process import


### PR DESCRIPTION

## What is the purpose of the change

_This update changes the example for setting up Optimize in a clustered environment, to reflect that history cleanup is disabled by default. This should be reflected back to 3.1_

## When should this change go live?

_ASAP to reduce confusion for customers_

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
