### PR TITLE
Add user task scheduling docs section

### DIFF
--- a/docs/components/modeler/bpmn/assets/react-components/iso-8601-date-time.md
+++ b/docs/components/modeler/bpmn/assets/react-components/iso-8601-date-time.md
@@ -1,0 +1,5 @@
+A specific point in time defined as ISO 8601 combined date and time representation. It must contain timezone information, either `Z` for UTC or a zone offset. Optionally, it can contain a zone id.
+
+- `2019-10-01T12:00:00Z` - UTC time
+- `2019-10-02T08:09:40+02:00` - UTC plus two hours zone offset
+- `2019-10-02T08:09:40+02:00[Europe/Berlin]` - UTC plus two hours zone offset at Berlin

--- a/docs/components/modeler/bpmn/timer-events/timer-events.md
+++ b/docs/components/modeler/bpmn/timer-events/timer-events.md
@@ -43,11 +43,9 @@ If the expression belongs to a timer start event of the process, it is evaluated
 
 ### Time date
 
-A specific point in time defined as ISO 8601 combined date and time representation. It must contain timezone information, either `Z` for UTC or a zone offset. Optionally, it can contain a zone id.
+import ISO8601DateTime from '../assets/react-components/iso-8601-date-time.md'
 
-- `2019-10-01T12:00:00Z` - UTC time
-- `2019-10-02T08:09:40+02:00` - UTC plus two hours zone offset
-- `2019-10-02T08:09:40+02:00[Europe/Berlin]` - UTC plus two hours zone offset at Berlin
+<ISO8601DateTime/>
 
 ### Time duration
 

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -55,6 +55,29 @@ The unique identifier depends on the authentication method used to login to Task
 For example, say you log into Tasklist using Camunda Platform 8 login with email using your email address `foo@bar.com`. Every time a user task activates with `assignee` set to value `foo@bar.com`, Tasklist automatically assigns it to you. You'll be able to find your new task under the task dropdown option `Claimed by me`.
 :::
 
+## Scheduling
+
+User tasks support specifying a task schedule using the `zeebe:taskSchedule` extension element.
+This can be used to define **when** users interact with a given task. One or both of the following
+attributes can be specified simultaneously:
+
+- `dueDate`: Specifies the due date of the user task.
+- `followUpDate`: Specifies the follow-up date of the user task.
+
+You can define the due date and follow-up date as static values (e.g. `2023-02-28T13:13:10+02:00`), but you can also use
+[expressions](/components/concepts/expressions.md) (e.g. `= schedule.dueDate` and `= now() + duration("PT15S")`). The
+expressions are evaluated on activating the user task and must result in a `string` conforming to an ISO 8601 combined
+date and time representation.
+
+:::note
+An ISO 8601 combined date and time representation must contain timezone information, either `Z` for UTC or a zone offset.
+Optionally, it can contain a zone id. The following examples represent valid ISO 8601 `strings`:
+
+- `2019-10-01T12:00:00Z` - UTC time
+- `2019-10-02T08:09:40+02:00` - UTC plus two hours zone offset
+- `2019-10-02T08:09:40+02:00[Europe/Berlin]` - UTC plus two hours zone offset at Berlin
+  :::
+
 ## Variable mappings
 
 By default, all job variables are merged into the process instance. This

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -74,14 +74,11 @@ You can define the due date and follow-up date as static values (e.g. `2023-02-2
 expressions are evaluated on activating the user task and must result in a `string` conforming to an ISO 8601 combined
 date and time representation.
 
-:::note
-An ISO 8601 combined date and time representation must contain timezone information, either `Z` for UTC or a zone offset.
-Optionally, it can contain a zone id. The following examples represent valid ISO 8601 `strings`:
+import ISO8601DateTime from '../assets/react-components/iso-8601-date-time.md'
 
-- `2019-10-01T12:00:00Z` - UTC time
-- `2019-10-02T08:09:40+02:00` - UTC plus two hours zone offset
-- `2019-10-02T08:09:40+02:00[Europe/Berlin]` - UTC plus two hours zone offset at Berlin
-  :::
+:::info
+<ISO8601DateTime/>
+:::
 
 ## Variable mappings
 

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -64,6 +64,11 @@ attributes can be specified simultaneously:
 - `dueDate`: Specifies the due date of the user task.
 - `followUpDate`: Specifies the follow-up date of the user task.
 
+:::note
+For example, you can use the `followUpDate` to define the latest time a user should start working on a task, and then
+use the `dueDate` to provide a deadline when the user task should be finished.
+:::
+
 You can define the due date and follow-up date as static values (e.g. `2023-02-28T13:13:10+02:00`), but you can also use
 [expressions](/components/concepts/expressions.md) (e.g. `= schedule.dueDate` and `= now() + duration("PT15S")`). The
 expressions are evaluated on activating the user task and must result in a `string` conforming to an ISO 8601 combined
@@ -95,7 +100,7 @@ as configuration parameters for the worker.
 
 ### XML representation
 
-A user task with a user task form and an assignment definition:
+A user task with a user task form, an assignment definition, and a task schedule:
 
 ```xml
 <bpmn:process id="controlProcess" name="Control Process" isExecutable="true">
@@ -107,6 +112,7 @@ A user task with a user task form and an assignment definition:
   <bpmn:userTask id="Activity_025dulo" name="Configure">
     <bpmn:extensionElements>
       <zeebe:assignmentDefinition assignee="= default_controller" candidateGroups="controllers, auditors" />
+      <zeebe:taskSchedule dueDate="= task_finished_deadline" followUpDate="= now() + duration('P2D')"/>
       <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_2g7iho6" />
     </bpmn:extensionElements>
   </bpmn:userTask>

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -31,7 +31,7 @@ extension element of the process element.
 ## Assignments
 
 User tasks support specifying assignments, using the `zeebe:AssignmentDefinition` extension element.
-This can be used to define which user the task can be assigned to. One or both of the following
+This can be used to define which user the task can be assigned to. One or all of the following
 attributes can be specified simultaneously:
 
 - `assignee`: Specifies the user assigned to the task. [Tasklist](/components/tasklist/introduction-to-tasklist.md) will claim the task for this user.


### PR DESCRIPTION
## What is the purpose of the change

With https://github.com/camunda/product-hub/issues/215, Camunda Platform 8 supports user task scheduling with the `dueDate` and `followUpDate` attributes.

## Are there related marketing activities

/

## When should this change go live?

With version `8.2.0`.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.

## Related issue

closes #1733 
