### PR TITLE
Add section about message expiration

### DIFF
--- a/docs/components/concepts/messages.md
+++ b/docs/components/concepts/messages.md
@@ -49,6 +49,13 @@ zbctl publish message "Money collected" --correlationKey "order-123" --ttl 1h
    </p>
  </details>
 
+## Message expiration
+
+When a buffered message could not be correlated to a process instance in the
+given time-to-live, it gets removed from the buffer afterwards. Internally, the
+MessageObserver runs once a minute and exports an event, that the message
+expired.
+
 ## Message cardinality
 
 A message is correlated only _once_ to a process (based on the BPMN process id), across all versions of this process. If multiple subscriptions for the same process are opened (by multiple process instances or within one instance,) the message is correlated only to one of the subscriptions.

--- a/docs/components/concepts/messages.md
+++ b/docs/components/concepts/messages.md
@@ -54,6 +54,9 @@ zbctl publish message "Money collected" --correlationKey "order-123" --ttl 1h
 When a buffered message could not be correlated to a process instance in the
 given time-to-live, it gets removed from the buffer afterwards.
 
+As the expired messages are cleaned up in batches, there will be a configurable
+delay before the expiration is available.
+
 More details about the expired messages can be found in the exporters chapter
 of the Self-Managed section. (Link to be done).
 

--- a/docs/components/concepts/messages.md
+++ b/docs/components/concepts/messages.md
@@ -52,9 +52,10 @@ zbctl publish message "Money collected" --correlationKey "order-123" --ttl 1h
 ## Message expiration
 
 When a buffered message could not be correlated to a process instance in the
-given time-to-live, it gets removed from the buffer afterwards. Internally, the
-MessageObserver runs once a minute and exports an event, that the message
-expired.
+given time-to-live, it gets removed from the buffer afterwards.
+
+More details about the expired messages can be found in the exporters chapter
+of the Self-Managed section. (Link to be done).
 
 ## Message cardinality
 

--- a/versioned_docs/version-8.1/components/concepts/messages.md
+++ b/versioned_docs/version-8.1/components/concepts/messages.md
@@ -49,6 +49,13 @@ zbctl publish message "Money collected" --correlationKey "order-123" --ttl 1h
    </p>
  </details>
 
+## Message expiration
+
+When a buffered message could not be correlated to a process instance in the
+given time-to-live, it gets removed from the buffer afterwards. Internally, the
+MessageObserver runs once a minute and exports an event, that the message
+expired.
+
 ## Message cardinality
 
 A message is correlated only _once_ to a process (based on the BPMN process id), across all versions of this process. If multiple subscriptions for the same process are opened (by multiple process instances or within one instance,) the message is correlated only to one of the subscriptions.


### PR DESCRIPTION
## What is the purpose of the change

Add a section to describe what happens, if a message could not be correlated to a process during its time-to-live.

Resolves https://github.com/camunda/zeebe/issues/11410

## Are there related marketing activities

No

## When should this change go live?

With the next release of the docs.

## PR Checklist

- [X] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [X] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [X] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
