### PR TITLE
docs(platform-deployment): add docker back to development list

### DIFF
--- a/docs/self-managed/platform-deployment/overview.md
+++ b/docs/self-managed/platform-deployment/overview.md
@@ -65,7 +65,8 @@ We support the following deployment options (the sequence expresses preference) 
 2. [**Helm/Kubernetes**](./helm-kubernetes/overview.md)
    - [Cloud or on-prem cluster](./helm-kubernetes/overview.md#kubernetes-environments) with one of managed offering like EKS, GKE, etc.
    - [Local cluster](./helm-kubernetes/guides/local-kubernetes-cluster.md) with KIND.
-3. [**Manual**](./manual.md) as a last resort if you only need the Zeebe broker. We don't recommend setting up the whole toolchain in this fashion.
+3. [**Docker**](./docker.md) including [Docker Compose](./docker.md#docker-compose), which is **only** recommended for development.
+4. [**Manual**](./manual.md) as a last resort if you only need the Zeebe broker. We don't recommend setting up the whole toolchain in this fashion.
 
 ## Getting help
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/overview.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/overview.md
@@ -65,7 +65,8 @@ We support the following deployment options (the sequence expresses preference) 
 2. [**Helm/Kubernetes**](./helm-kubernetes/overview.md)
    - [Cloud or on-prem cluster](./helm-kubernetes/overview.md#kubernetes-environments) with one of managed offering like EKS, GKE, etc.
    - [Local cluster](./helm-kubernetes/guides/local-kubernetes-cluster.md) with KIND.
-3. [**Manual**](./manual.md) as a last resort if you only need the Zeebe broker. We don't recommend setting up the whole toolchain in this fashion.
+3. [**Docker**](./docker.md) including [Docker Compose](./docker.md#docker-compose), which is **only** recommended for development.
+4. [**Manual**](./manual.md) as a last resort if you only need the Zeebe broker. We don't recommend setting up the whole toolchain in this fashion.
 
 ## Getting help
 


### PR DESCRIPTION
## What is the purpose of the change

Docker (and Docker Compose) was inadvertently dropped from the list of development options. This PR adds it back.

## Are there related marketing activities

No

## When should this change go live?

There is no associated release, but this could be considered a bug fix.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
