### PR TITLE
chore: fix move-to-done for external PRs

### DIFF
--- a/.github/workflows/move-to-done.yaml
+++ b/.github/workflows/move-to-done.yaml
@@ -3,7 +3,7 @@ name: move-to-done
 # FYI secrets.ADD_TO_PROJECT_PAT is a personal access token belonging to @akeller.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
## What is the purpose of the change

Updates the `move-to-done` workflow to run on `pull_request_target`, instead of `pull_request`, so that external/forked PRs can use the github token.

(Because when running on `pull_request`, [they fail](https://github.com/camunda/camunda-platform-docs/actions/runs/4319043727/jobs/7538049888).)


## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
