### PR TITLE
feat(security): allow self-signed certificates for ES connection

### DIFF
--- a/optimize/self-managed/optimize-deployment/configuration/service-config.yaml
+++ b/optimize/self-managed/optimize-deployment/configuration/service-config.yaml
@@ -310,6 +310,8 @@ es:
       certificate_authorities: []
       # used to enable or disable TLS/SSL for the HTTP connection
       enabled: false
+      # used to specify that the certificate was self-signed
+      selfSigned: false
 
   # Maximum time a request to elasticsearch should last, before a timeout
   # triggers.

--- a/optimize/self-managed/optimize-deployment/configuration/system-configuration.md
+++ b/optimize/self-managed/optimize-deployment/configuration/system-configuration.md
@@ -171,6 +171,7 @@ Define a secured connection to be able to communicate with a secured Elasticsear
 | es.security.ssl.enabled                 | false         | Used to enable or disable TLS/SSL for the HTTP connection.                                                                                                                                                                                            |
 | es.security.ssl.certificate             |               | The path to a PEM encoded file containing the certificate (or certificate chain) that will be presented to clients when they connect.                                                                                                                 |
 | es.security.ssl.certificate_authorities | [ ]           | A list of paths to PEM encoded CA certificate files that should be trusted, e.g. ['/path/to/ca.crt']. <br /><br />Note: if you are using a public CA that is already trusted by the Java runtime, you do not need to set the certificate_authorities. |
+| es.security.ssl.selfSigned              | false         | Used to specify that the certificate was self-signed.                                                                                                                                                                                                 |
 
 #### Elasticsearch backup settings
 


### PR DESCRIPTION
relates to OPT-6790

## What is the purpose of the change

Certificates can now be self-signed and this config flag is used to determine it, so should be added to config

## Are there related marketing activities

N/A

## When should this change go live?

It will be part of 8.2 release and not backported, so nothing needed before

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
