### PR TITLE
adjust deployment glossary link

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -52,7 +52,7 @@ A correlation is an attribute within a message used to match this message agains
 
 A process cannot execute unless it is known by the broker. Deployment is the process of pushing or deploying processes to the broker.
 
-- [Zeebe Deployment](/self-managed/about-self-managed.md)
+- [Zeebe Deployment](/apis-clients/grpc.md#deployresource-rpc)
 
 ### Event
 

--- a/versioned_docs/version-8.0/reference/glossary.md
+++ b/versioned_docs/version-8.0/reference/glossary.md
@@ -52,7 +52,7 @@ A correlation is an attribute within a message used to match this message agains
 
 A process cannot execute unless it is known by the broker. Deployment is the process of pushing or deploying processes to the broker.
 
-- [Zeebe Deployment](/self-managed/about-self-managed.md)
+- [Zeebe Deployment](/apis-clients/grpc.md#deployresource-rpc)
 
 ### Event
 

--- a/versioned_docs/version-8.1/reference/glossary.md
+++ b/versioned_docs/version-8.1/reference/glossary.md
@@ -52,7 +52,7 @@ A correlation is an attribute within a message used to match this message agains
 
 A process cannot execute unless it is known by the broker. Deployment is the process of pushing or deploying processes to the broker.
 
-- [Zeebe Deployment](/self-managed/about-self-managed.md)
+- [Zeebe Deployment](/apis-clients/grpc.md#deployresource-rpc)
 
 ### Event
 


### PR DESCRIPTION
## What is the purpose of the change

Based on [Slack discussion](https://camunda.slack.com/archives/C026U8GBNSW/p1677835374614279), the [Deployment](https://docs.camunda.io/docs/reference/glossary/#deployment) link in the glossary routes to https://docs.camunda.io/docs/self-managed/about-self-managed/. This has been adjusted to https://docs.camunda.io/docs/apis-clients/grpc/#deployresource-rpc .

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
