### PR TITLE
fix(zeebe): remove trailing slash from rebalance url

### DIFF
--- a/docs/self-managed/zeebe-deployment/operations/rebalancing.md
+++ b/docs/self-managed/zeebe-deployment/operations/rebalancing.md
@@ -15,7 +15,7 @@ When a Zeebe cluster uses an uneven leader distribution, caused by losing a lead
 The gateway exposes an HTTP API to request rebalancing. You can use it by `POST`ing to the `/actuator/rebalance` endpoint on the monitoring port of the gateway:
 
 ```bash
-curl -X POST https://{zeebe-gateway}:9600/actuator/rebalance/
+curl -X POST https://{zeebe-gateway}:9600/actuator/rebalance
 ```
 
 The result of this operation is always `200 OK` with no body, even when rebalancing is [not supported](#limitations) by the current configuration or when not all leaders have been contacted.

--- a/versioned_docs/version-1.3/self-managed/zeebe-deployment/operations/rebalancing.md
+++ b/versioned_docs/version-1.3/self-managed/zeebe-deployment/operations/rebalancing.md
@@ -14,7 +14,7 @@ When a Zeebe cluster uses an uneven leader distribution, caused by losing a lead
 The gateway exposes an HTTP API to request rebalancing. You can use it by `POST`ing to the `/actuator/rebalance` endpoint on the monitoring port of the gateway:
 
 ```bash
-curl -X POST https://{zeebe-gateway}:9600/actuator/rebalance/
+curl -X POST https://{zeebe-gateway}:9600/actuator/rebalance
 ```
 
 The result of this operation is always `200 OK` with no body, even when rebalancing is [not supported](#limitations) by the current configuration or when not all leaders have been contacted.

--- a/versioned_docs/version-8.0/self-managed/zeebe-deployment/operations/rebalancing.md
+++ b/versioned_docs/version-8.0/self-managed/zeebe-deployment/operations/rebalancing.md
@@ -14,7 +14,7 @@ When a Zeebe cluster uses an uneven leader distribution, caused by losing a lead
 The gateway exposes an HTTP API to request rebalancing. You can use it by `POST`ing to the `/actuator/rebalance` endpoint on the monitoring port of the gateway:
 
 ```bash
-curl -X POST https://{zeebe-gateway}:9600/actuator/rebalance/
+curl -X POST https://{zeebe-gateway}:9600/actuator/rebalance
 ```
 
 The result of this operation is always `200 OK` with no body, even when rebalancing is [not supported](#limitations) by the current configuration or when not all leaders have been contacted.

--- a/versioned_docs/version-8.1/self-managed/zeebe-deployment/operations/rebalancing.md
+++ b/versioned_docs/version-8.1/self-managed/zeebe-deployment/operations/rebalancing.md
@@ -14,7 +14,7 @@ When a Zeebe cluster uses an uneven leader distribution, caused by losing a lead
 The gateway exposes an HTTP API to request rebalancing. You can use it by `POST`ing to the `/actuator/rebalance` endpoint on the monitoring port of the gateway:
 
 ```bash
-curl -X POST https://{zeebe-gateway}:9600/actuator/rebalance/
+curl -X POST https://{zeebe-gateway}:9600/actuator/rebalance
 ```
 
 The result of this operation is always `200 OK` with no body, even when rebalancing is [not supported](#limitations) by the current configuration or when not all leaders have been contacted.


### PR DESCRIPTION
## What is the purpose of the change

_Briefly describe the change you are making, this helps the reviewer by providing an overview._

Removes the trailing slash from Zeebe's rebalance URL. By upgrading Spring Boot to version 3.x in Zeebe, any request with a trailing will fail with 404.

related to https://github.com/camunda/zeebe/pull/11103

## Are there related marketing activities

_Are there any marketing activities related to the related feature or component? If so, please briefly describe them._

## When should this change go live?

_Does this change need to be released before a certain date or milestone? If so, when?_

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
