### PR TITLE
docs(connectors): added docs for GitLab connector

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -16,6 +16,7 @@ This section gives an overview of the **out-of-the-box Connectors** available in
 - [Camunda Operate Connector](operate.md) - Fetch process execution data from [Camunda Operate](https://camunda.com/platform/operate/).
 - [Easy Post Connector](aws-lambda.md) - Create addresses, parcels, and shipments, as well as purchase and verify shipments with [EasyPost](https://www.easypost.com/) from your BPMN process.
 - [GitHub Connector](github.md) - Manage [GitHub](https://github.com/) issues and releases from your BPMN process.
+- [GitLab Connector](gitlab.md) - Manage [GitLab](https://about.gitlab.com/) issues and releases from your BPMN process.
 - [Google Drive Connector](googledrive.md) - Create folders or files from a [Google Drive](https://www.google.com/drive/) template from your BPMN process.
 - [Google Maps Platform Connector](google-maps-platform.md) - Validate addresses, retrieve postal addresses, and calculate distances with [Google Maps Platform Service](https://mapsplatform.google.com/) from your BPMN process.
 - [GraphQL Connector](graphql.md) - Execute a [GraphQL](https://graphql.org/) query or mutation from your BPMN process.

--- a/docs/components/connectors/out-of-the-box-connectors/gitlab.md
+++ b/docs/components/connectors/out-of-the-box-connectors/gitlab.md
@@ -1,0 +1,96 @@
+---
+id: gitlab
+title: GitLab Connector
+sidebar_label: GitLab Connector
+description: Manage GitLab issues and releases from your BPMN process.
+---
+
+The **GitLab Connector** allows you to connect your BPMN service with [GitLab](https://about.gitlab.com/).
+
+## Prerequisites
+
+To use the **GitLab Connector**, you need to have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
+or a service account on whose behalf a BPMN process will be executed.
+
+:::note
+It is highly recommended not to expose your GitLab access token credentials as plain text. Instead, use Camunda secrets.
+See an article on how to [manage secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create an GitLab Connector Task
+
+To use the **GitLab Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](../use-connectors.md) to learn more.
+
+## Fill in the endpoint and authentication
+
+In the section **HTTP Endpoint** provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
+
+## Select operation you wish to execute
+
+The **GitLab Connector** currently supports the following operations.
+
+### Issues
+
+#### Get an issue by ID
+
+- **GitLab API:** [Single project issue](https://docs.gitlab.com/ee/api/issues.html#single-project-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
+
+#### Create an issue
+
+- **GitLab API:** [New issue](https://docs.gitlab.com/ee/api/issues.html#new-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Title:** The title of an issue.
+- **Description:** The description of an issue.
+
+#### Delete an issue
+
+- **GitLab API:** [Delete an issue](https://docs.gitlab.com/ee/api/issues.html#delete-an-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
+
+#### Comment to an issue
+
+- **GitLab API:** [Create a new issue note](https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
+- **Note text:** The content of a note.
+- **Level of confidentiality:** Indicates whether an issue has to be marked as **internal** or not.
+
+#### Search issues
+
+- **GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
+- **Scope:** Return issues for the given scope: **Created by me**, **Assigned to me** or **all**.
+- **State:** Return all issues or just those that are **opened** or **closed**.
+- **Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
+- **Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.
+- **Author ID:** Return issues created by the given user ID.
+- **Contains text:** Search issues against their **Title** and **Description**.
+
+### Releases
+
+#### List all releases by a project ID
+
+- **GitLab API:** [List releases](https://docs.gitlab.com/ee/api/releases/#list-releases).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+
+#### Get release by a tag name
+
+- **GitLab API:** [Get a release by a tag name](https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Tag name:** The Git tag the release is associated with.
+
+#### Create a release
+
+- **GitLab API:** [Create a release](https://docs.gitlab.com/ee/api/releases/#create-a-release).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Tag name:** The tag where the release is created from.
+- **Ref:** A commit SHA, another tag name, or a branch name.
+- **Release name:** The release name.
+- **Description:** The description of the release.
+
+## Handle Connector response
+
+The **GitLab Connector** is a protocol connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+handling response is still applicable [as described](./rest.md#response).

--- a/docs/components/connectors/out-of-the-box-connectors/gitlab.md
+++ b/docs/components/connectors/out-of-the-box-connectors/gitlab.md
@@ -2,30 +2,30 @@
 id: gitlab
 title: GitLab Connector
 sidebar_label: GitLab Connector
-description: Manage GitLab issues and releases from your BPMN process.
+description: Manage GitLab issues and releases from your BPMN process. Learn about creating a GitLab Connector task and get started.
 ---
 
 The **GitLab Connector** allows you to connect your BPMN service with [GitLab](https://about.gitlab.com/).
 
 ## Prerequisites
 
-To use the **GitLab Connector**, you need to have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
+To use the **GitLab Connector**, you must have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
 or a service account on whose behalf a BPMN process will be executed.
 
 :::note
 It is highly recommended not to expose your GitLab access token credentials as plain text. Instead, use Camunda secrets.
-See an article on how to [manage secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
+See our documentation on [managing secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
-## Create an GitLab Connector Task
+## Create a GitLab Connector task
 
 To use the **GitLab Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](../use-connectors.md) to learn more.
 
 ## Fill in the endpoint and authentication
 
-In the section **HTTP Endpoint** provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
+In the **HTTP Endpoint** section, provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
 
-## Select operation you wish to execute
+## Select operation to execute
 
 The **GitLab Connector** currently supports the following operations.
 
@@ -56,12 +56,12 @@ The **GitLab Connector** currently supports the following operations.
 - **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
 - **Issue ID:** The internal ID of a project’s issue.
 - **Note text:** The content of a note.
-- **Level of confidentiality:** Indicates whether an issue has to be marked as **internal** or not.
+- **Level of confidentiality:** Indicates if an issue has to be marked as **internal** or not.
 
 #### Search issues
 
 - **GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
-- **Scope:** Return issues for the given scope: **Created by me**, **Assigned to me** or **all**.
+- **Scope:** Return issues for the given scope: **Created by me**, **Assigned to me**, or **all**.
 - **State:** Return all issues or just those that are **opened** or **closed**.
 - **Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
 - **Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -683,6 +683,10 @@ module.exports = {
               "components/connectors/out-of-the-box-connectors/github-webhook/"
             ),
             docsLink(
+              "GitLab Connector",
+              "components/connectors/out-of-the-box-connectors/gitlab/"
+            ),
+            docsLink(
               "Google Drive Connector",
               "components/connectors/out-of-the-box-connectors/googledrive/"
             ),

--- a/sidebars.js
+++ b/sidebars.js
@@ -249,6 +249,7 @@ module.exports = {
             "components/connectors/out-of-the-box-connectors/easy-post",
             "components/connectors/out-of-the-box-connectors/github",
             "components/connectors/out-of-the-box-connectors/github-webhook",
+            "components/connectors/out-of-the-box-connectors/gitlab",
             "components/connectors/out-of-the-box-connectors/googledrive",
             "components/connectors/out-of-the-box-connectors/google-maps-platform",
             "components/connectors/out-of-the-box-connectors/graphql",

--- a/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -16,6 +16,7 @@ This section gives an overview of the **out-of-the-box Connectors** available in
 - [Camunda Operate Connector](operate.md) - Fetch process execution data from [Camunda Operate](https://camunda.com/platform/operate/).
 - [Easy Post Connector](aws-lambda.md) - Create addresses, parcels, and shipments, as well as purchase and verify shipments with [EasyPost](https://www.easypost.com/) from your BPMN process.
 - [GitHub Connector](github.md) - Manage [GitHub](https://github.com/) issues and releases from your BPMN process.
+- [GitLab Connector](gitlab.md) - Manage [GitLab](https://about.gitlab.com/) issues and releases from your BPMN process.
 - [Google Drive Connector](googledrive.md) - Create folders or files from a [Google Drive](https://www.google.com/drive/) template from your BPMN process.
 - [Google Maps Platform Connector](google-maps-platform.md) - Validate addresses, retrieve postal addresses, and calculate distances with [Google Maps Platform Service](https://mapsplatform.google.com/) from your BPMN process.
 - [GraphQL Connector](graphql.md) - Execute a [GraphQL](https://graphql.org/) query or mutation from your BPMN process.

--- a/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/gitlab.md
+++ b/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/gitlab.md
@@ -1,0 +1,96 @@
+---
+id: gitlab
+title: GitLab Connector
+sidebar_label: GitLab Connector
+description: Manage GitLab issues and releases from your BPMN process.
+---
+
+The **GitLab Connector** allows you to connect your BPMN service with [GitLab](https://about.gitlab.com/).
+
+## Prerequisites
+
+To use the **GitLab Connector**, you need to have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
+or a service account on whose behalf a BPMN process will be executed.
+
+:::note
+It is highly recommended not to expose your GitLab access token credentials as plain text. Instead, use Camunda secrets.
+See an article on how to [manage secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create an GitLab Connector Task
+
+To use the **GitLab Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](../use-connectors.md) to learn more.
+
+## Fill in the endpoint and authentication
+
+In the section **HTTP Endpoint** provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
+
+## Select operation you wish to execute
+
+The **GitLab Connector** currently supports the following operations.
+
+### Issues
+
+#### Get an issue by ID
+
+**GitLab API:** [Single project issue](https://docs.gitlab.com/ee/api/issues.html#single-project-issue).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Issue ID:** The internal ID of a project’s issue.
+
+#### Create an issue
+
+**GitLab API:** [New issue](https://docs.gitlab.com/ee/api/issues.html#new-issue).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Title:** The title of an issue.
+**Description:** The description of an issue.
+
+#### Delete an issue
+
+**GitLab API:** [Delete an issue](https://docs.gitlab.com/ee/api/issues.html#delete-an-issue).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Issue ID:** The internal ID of a project’s issue.
+
+#### Comment to an issue
+
+**GitLab API:** [Create a new issue note](https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Issue ID:** The internal ID of a project’s issue.
+**Note text:** The content of a note.
+**Level of confidentiality:** Indicates whether an issue has to be marked as **internal** or not.
+
+#### Search issues
+
+**GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
+**Scope:** Return issues for the given scope: **Created by me**, **Assigned to me** or **all**.
+**State:** Return all issues or just those that are **opened** or **closed**.
+**Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
+**Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.
+**Author ID:** Return issues created by the given user ID.
+**Contains text:** Search issues against their **Title** and **Description**.
+
+### Releases
+
+#### List all releases by a project ID
+
+**GitLab API:** [List releases](https://docs.gitlab.com/ee/api/releases/#list-releases).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+
+#### Get release by a tag name
+
+**GitLab API:** [Get a release by a tag name](https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Tag name:** The Git tag the release is associated with.
+
+#### Create a release
+
+**GitLab API:** [Create a release](https://docs.gitlab.com/ee/api/releases/#create-a-release).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Tag name:** The tag where the release is created from.
+**Ref:** A commit SHA, another tag name, or a branch name.
+**Release name:** The release name.
+**Description:** The description of the release.
+
+## Handle Connector response
+
+The **GitLab Connector** is a protocol connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+handling response is still applicable [as described](./rest.md#response).

--- a/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/gitlab.md
+++ b/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/gitlab.md
@@ -2,30 +2,30 @@
 id: gitlab
 title: GitLab Connector
 sidebar_label: GitLab Connector
-description: Manage GitLab issues and releases from your BPMN process.
+description: Manage GitLab issues and releases from your BPMN process. Learn about creating a GitLab Connector task and get started.
 ---
 
 The **GitLab Connector** allows you to connect your BPMN service with [GitLab](https://about.gitlab.com/).
 
 ## Prerequisites
 
-To use the **GitLab Connector**, you need to have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
+To use the **GitLab Connector**, you must have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
 or a service account on whose behalf a BPMN process will be executed.
 
 :::note
 It is highly recommended not to expose your GitLab access token credentials as plain text. Instead, use Camunda secrets.
-See an article on how to [manage secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
+See our documentation on [managing secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
-## Create an GitLab Connector Task
+## Create a GitLab Connector task
 
 To use the **GitLab Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](../use-connectors.md) to learn more.
 
 ## Fill in the endpoint and authentication
 
-In the section **HTTP Endpoint** provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
+In the **HTTP Endpoint** section, provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
 
-## Select operation you wish to execute
+## Select operation to execute
 
 The **GitLab Connector** currently supports the following operations.
 
@@ -33,62 +33,62 @@ The **GitLab Connector** currently supports the following operations.
 
 #### Get an issue by ID
 
-**GitLab API:** [Single project issue](https://docs.gitlab.com/ee/api/issues.html#single-project-issue).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Issue ID:** The internal ID of a project’s issue.
+- **GitLab API:** [Single project issue](https://docs.gitlab.com/ee/api/issues.html#single-project-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
 
 #### Create an issue
 
-**GitLab API:** [New issue](https://docs.gitlab.com/ee/api/issues.html#new-issue).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Title:** The title of an issue.
-**Description:** The description of an issue.
+- **GitLab API:** [New issue](https://docs.gitlab.com/ee/api/issues.html#new-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Title:** The title of an issue.
+- **Description:** The description of an issue.
 
 #### Delete an issue
 
-**GitLab API:** [Delete an issue](https://docs.gitlab.com/ee/api/issues.html#delete-an-issue).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Issue ID:** The internal ID of a project’s issue.
+- **GitLab API:** [Delete an issue](https://docs.gitlab.com/ee/api/issues.html#delete-an-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
 
 #### Comment to an issue
 
-**GitLab API:** [Create a new issue note](https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Issue ID:** The internal ID of a project’s issue.
-**Note text:** The content of a note.
-**Level of confidentiality:** Indicates whether an issue has to be marked as **internal** or not.
+- **GitLab API:** [Create a new issue note](https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
+- **Note text:** The content of a note.
+- **Level of confidentiality:** Indicates if an issue has to be marked as **internal** or not.
 
 #### Search issues
 
-**GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
-**Scope:** Return issues for the given scope: **Created by me**, **Assigned to me** or **all**.
-**State:** Return all issues or just those that are **opened** or **closed**.
-**Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
-**Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.
-**Author ID:** Return issues created by the given user ID.
-**Contains text:** Search issues against their **Title** and **Description**.
+- **GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
+- **Scope:** Return issues for the given scope: **Created by me**, **Assigned to me**, or **all**.
+- **State:** Return all issues or just those that are **opened** or **closed**.
+- **Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
+- **Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.
+- **Author ID:** Return issues created by the given user ID.
+- **Contains text:** Search issues against their **Title** and **Description**.
 
 ### Releases
 
 #### List all releases by a project ID
 
-**GitLab API:** [List releases](https://docs.gitlab.com/ee/api/releases/#list-releases).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **GitLab API:** [List releases](https://docs.gitlab.com/ee/api/releases/#list-releases).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
 
 #### Get release by a tag name
 
-**GitLab API:** [Get a release by a tag name](https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Tag name:** The Git tag the release is associated with.
+- **GitLab API:** [Get a release by a tag name](https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Tag name:** The Git tag the release is associated with.
 
 #### Create a release
 
-**GitLab API:** [Create a release](https://docs.gitlab.com/ee/api/releases/#create-a-release).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Tag name:** The tag where the release is created from.
-**Ref:** A commit SHA, another tag name, or a branch name.
-**Release name:** The release name.
-**Description:** The description of the release.
+- **GitLab API:** [Create a release](https://docs.gitlab.com/ee/api/releases/#create-a-release).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Tag name:** The tag where the release is created from.
+- **Ref:** A commit SHA, another tag name, or a branch name.
+- **Release name:** The release name.
+- **Description:** The description of the release.
 
 ## Handle Connector response
 

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -13,9 +13,10 @@ This section gives an overview of the **out-of-the-box Connectors** available in
 - [Amazon SNS Connector](aws-sns.md) - Send messages to [Amazon Simple Notification Service](https://aws.amazon.com/sns/) from your BPMN process.
 - [Amazon SQS Connector](aws-sqs.md) - Send messages to [Amazon Simple Queue Service](https://aws.amazon.com/sqs/) from your BPMN process.
 - [AWS Lambda Connector](aws-lambda.md) - Invoke [AWS Lambda Functions](https://aws.amazon.com/lambda/) from your BPMN process.
-- [GitHub Connector](github.md) - Manage [GitHub](https://github.com/) issues and releases from your BPMN process.
 - [Camunda Operate Connector](operate.md) - Fetch process execution data from [Camunda Operate](https://camunda.com/platform/operate/).
 - [Easy Post Connector](aws-lambda.md) - Create addresses, parcels, and shipments, as well as purchase and verify shipments with [EasyPost](https://www.easypost.com/) from your BPMN process.
+- [GitHub Connector](github.md) - Manage [GitHub](https://github.com/) issues and releases from your BPMN process.
+- [GitLab Connector](gitlab.md) - Manage [GitLab](https://about.gitlab.com/) issues and releases from your BPMN process.
 - [Google Drive Connector](googledrive.md) - Create folders or files from a [Google Drive](https://www.google.com/drive/) template from your BPMN process.
 - [Google Maps Platform Connector](google-maps-platform.md) - Validate addresses, retrieve postal addresses, and calculate distances with [Google Maps Platform Service](https://mapsplatform.google.com/) from your BPMN process.
 - [GraphQL Connector](graphql.md) - Execute a [GraphQL](https://graphql.org/) query or mutation from your BPMN process.

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/gitlab.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/gitlab.md
@@ -1,0 +1,96 @@
+---
+id: gitlab
+title: GitLab Connector
+sidebar_label: GitLab Connector
+description: Manage GitLab issues and releases from your BPMN process.
+---
+
+The **GitLab Connector** allows you to connect your BPMN service with [GitLab](https://about.gitlab.com/).
+
+## Prerequisites
+
+To use the **GitLab Connector**, you need to have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
+or a service account on whose behalf a BPMN process will be executed.
+
+:::note
+It is highly recommended not to expose your GitLab access token credentials as plain text. Instead, use Camunda secrets.
+See an article on how to [manage secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create an GitLab Connector Task
+
+To use the **GitLab Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](../use-connectors.md) to learn more.
+
+## Fill in the endpoint and authentication
+
+In the section **HTTP Endpoint** provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
+
+## Select operation you wish to execute
+
+The **GitLab Connector** currently supports the following operations.
+
+### Issues
+
+#### Get an issue by ID
+
+**GitLab API:** [Single project issue](https://docs.gitlab.com/ee/api/issues.html#single-project-issue).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Issue ID:** The internal ID of a project’s issue.
+
+#### Create an issue
+
+**GitLab API:** [New issue](https://docs.gitlab.com/ee/api/issues.html#new-issue).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Title:** The title of an issue.
+**Description:** The description of an issue.
+
+#### Delete an issue
+
+**GitLab API:** [Delete an issue](https://docs.gitlab.com/ee/api/issues.html#delete-an-issue).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Issue ID:** The internal ID of a project’s issue.
+
+#### Comment to an issue
+
+**GitLab API:** [Create a new issue note](https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Issue ID:** The internal ID of a project’s issue.
+**Note text:** The content of a note.
+**Level of confidentiality:** Indicates whether an issue has to be marked as **internal** or not.
+
+#### Search issues
+
+**GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
+**Scope:** Return issues for the given scope: **Created by me**, **Assigned to me** or **all**.
+**State:** Return all issues or just those that are **opened** or **closed**.
+**Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
+**Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.
+**Author ID:** Return issues created by the given user ID.
+**Contains text:** Search issues against their **Title** and **Description**.
+
+### Releases
+
+#### List all releases by a project ID
+
+**GitLab API:** [List releases](https://docs.gitlab.com/ee/api/releases/#list-releases).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+
+#### Get release by a tag name
+
+**GitLab API:** [Get a release by a tag name](https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Tag name:** The Git tag the release is associated with.
+
+#### Create a release
+
+**GitLab API:** [Create a release](https://docs.gitlab.com/ee/api/releases/#create-a-release).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Tag name:** The tag where the release is created from.
+**Ref:** A commit SHA, another tag name, or a branch name.
+**Release name:** The release name.
+**Description:** The description of the release.
+
+## Handle Connector response
+
+The **GitLab Connector** is a protocol connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+handling response is still applicable [as described](./rest.md#response).

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/gitlab.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/gitlab.md
@@ -2,30 +2,30 @@
 id: gitlab
 title: GitLab Connector
 sidebar_label: GitLab Connector
-description: Manage GitLab issues and releases from your BPMN process.
+description: Manage GitLab issues and releases from your BPMN process. Learn about creating a GitLab Connector task and get started.
 ---
 
 The **GitLab Connector** allows you to connect your BPMN service with [GitLab](https://about.gitlab.com/).
 
 ## Prerequisites
 
-To use the **GitLab Connector**, you need to have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
+To use the **GitLab Connector**, you must have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
 or a service account on whose behalf a BPMN process will be executed.
 
 :::note
 It is highly recommended not to expose your GitLab access token credentials as plain text. Instead, use Camunda secrets.
-See an article on how to [manage secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
+See our documentation on [managing secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
-## Create an GitLab Connector Task
+## Create a GitLab Connector task
 
 To use the **GitLab Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](../use-connectors.md) to learn more.
 
 ## Fill in the endpoint and authentication
 
-In the section **HTTP Endpoint** provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
+In the **HTTP Endpoint** section, provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
 
-## Select operation you wish to execute
+## Select operation to execute
 
 The **GitLab Connector** currently supports the following operations.
 
@@ -33,62 +33,62 @@ The **GitLab Connector** currently supports the following operations.
 
 #### Get an issue by ID
 
-**GitLab API:** [Single project issue](https://docs.gitlab.com/ee/api/issues.html#single-project-issue).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Issue ID:** The internal ID of a project’s issue.
+- **GitLab API:** [Single project issue](https://docs.gitlab.com/ee/api/issues.html#single-project-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
 
 #### Create an issue
 
-**GitLab API:** [New issue](https://docs.gitlab.com/ee/api/issues.html#new-issue).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Title:** The title of an issue.
-**Description:** The description of an issue.
+- **GitLab API:** [New issue](https://docs.gitlab.com/ee/api/issues.html#new-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Title:** The title of an issue.
+- **Description:** The description of an issue.
 
 #### Delete an issue
 
-**GitLab API:** [Delete an issue](https://docs.gitlab.com/ee/api/issues.html#delete-an-issue).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Issue ID:** The internal ID of a project’s issue.
+- **GitLab API:** [Delete an issue](https://docs.gitlab.com/ee/api/issues.html#delete-an-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
 
 #### Comment to an issue
 
-**GitLab API:** [Create a new issue note](https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Issue ID:** The internal ID of a project’s issue.
-**Note text:** The content of a note.
-**Level of confidentiality:** Indicates whether an issue has to be marked as **internal** or not.
+- **GitLab API:** [Create a new issue note](https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
+- **Note text:** The content of a note.
+- **Level of confidentiality:** Indicates if an issue has to be marked as **internal** or not.
 
 #### Search issues
 
-**GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
-**Scope:** Return issues for the given scope: **Created by me**, **Assigned to me** or **all**.
-**State:** Return all issues or just those that are **opened** or **closed**.
-**Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
-**Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.
-**Author ID:** Return issues created by the given user ID.
-**Contains text:** Search issues against their **Title** and **Description**.
+- **GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
+- **Scope:** Return issues for the given scope: **Created by me**, **Assigned to me**, or **all**.
+- **State:** Return all issues or just those that are **opened** or **closed**.
+- **Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
+- **Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.
+- **Author ID:** Return issues created by the given user ID.
+- **Contains text:** Search issues against their **Title** and **Description**.
 
 ### Releases
 
 #### List all releases by a project ID
 
-**GitLab API:** [List releases](https://docs.gitlab.com/ee/api/releases/#list-releases).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **GitLab API:** [List releases](https://docs.gitlab.com/ee/api/releases/#list-releases).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
 
 #### Get release by a tag name
 
-**GitLab API:** [Get a release by a tag name](https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Tag name:** The Git tag the release is associated with.
+- **GitLab API:** [Get a release by a tag name](https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Tag name:** The Git tag the release is associated with.
 
 #### Create a release
 
-**GitLab API:** [Create a release](https://docs.gitlab.com/ee/api/releases/#create-a-release).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Tag name:** The tag where the release is created from.
-**Ref:** A commit SHA, another tag name, or a branch name.
-**Release name:** The release name.
-**Description:** The description of the release.
+- **GitLab API:** [Create a release](https://docs.gitlab.com/ee/api/releases/#create-a-release).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Tag name:** The tag where the release is created from.
+- **Ref:** A commit SHA, another tag name, or a branch name.
+- **Release name:** The release name.
+- **Description:** The description of the release.
 
 ## Handle Connector response
 

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -16,6 +16,7 @@ This section gives an overview of the **out-of-the-box Connectors** available in
 - [Camunda Operate Connector](operate.md) - Fetch process execution data from [Camunda Operate](https://camunda.com/platform/operate/).
 - [Easy Post Connector](aws-lambda.md) - Create addresses, parcels, and shipments, as well as purchase and verify shipments with [EasyPost](https://www.easypost.com/) from your BPMN process.
 - [GitHub Connector](github.md) - Manage [GitHub](https://github.com/) issues and releases from your BPMN process.
+- [GitLab Connector](gitlab.md) - Manage [GitLab](https://about.gitlab.com/) issues and releases from your BPMN process.
 - [Google Drive Connector](googledrive.md) - Create folders or files from a [Google Drive](https://www.google.com/drive/) template from your BPMN process.
 - [Google Maps Platform Connector](google-maps-platform.md) - Validate addresses, retrieve postal addresses, and calculate distances with [Google Maps Platform Service](https://mapsplatform.google.com/) from your BPMN process.
 - [GraphQL Connector](graphql.md) - Execute a [GraphQL](https://graphql.org/) query or mutation from your BPMN process.

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/gitlab.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/gitlab.md
@@ -1,0 +1,96 @@
+---
+id: gitlab
+title: GitLab Connector
+sidebar_label: GitLab Connector
+description: Manage GitLab issues and releases from your BPMN process.
+---
+
+The **GitLab Connector** allows you to connect your BPMN service with [GitLab](https://about.gitlab.com/).
+
+## Prerequisites
+
+To use the **GitLab Connector**, you need to have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
+or a service account on whose behalf a BPMN process will be executed.
+
+:::note
+It is highly recommended not to expose your GitLab access token credentials as plain text. Instead, use Camunda secrets.
+See an article on how to [manage secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create an GitLab Connector Task
+
+To use the **GitLab Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](../use-connectors.md) to learn more.
+
+## Fill in the endpoint and authentication
+
+In the section **HTTP Endpoint** provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
+
+## Select operation you wish to execute
+
+The **GitLab Connector** currently supports the following operations.
+
+### Issues
+
+#### Get an issue by ID
+
+**GitLab API:** [Single project issue](https://docs.gitlab.com/ee/api/issues.html#single-project-issue).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Issue ID:** The internal ID of a project’s issue.
+
+#### Create an issue
+
+**GitLab API:** [New issue](https://docs.gitlab.com/ee/api/issues.html#new-issue).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Title:** The title of an issue.
+**Description:** The description of an issue.
+
+#### Delete an issue
+
+**GitLab API:** [Delete an issue](https://docs.gitlab.com/ee/api/issues.html#delete-an-issue).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Issue ID:** The internal ID of a project’s issue.
+
+#### Comment to an issue
+
+**GitLab API:** [Create a new issue note](https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Issue ID:** The internal ID of a project’s issue.
+**Note text:** The content of a note.
+**Level of confidentiality:** Indicates whether an issue has to be marked as **internal** or not.
+
+#### Search issues
+
+**GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
+**Scope:** Return issues for the given scope: **Created by me**, **Assigned to me** or **all**.
+**State:** Return all issues or just those that are **opened** or **closed**.
+**Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
+**Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.
+**Author ID:** Return issues created by the given user ID.
+**Contains text:** Search issues against their **Title** and **Description**.
+
+### Releases
+
+#### List all releases by a project ID
+
+**GitLab API:** [List releases](https://docs.gitlab.com/ee/api/releases/#list-releases).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+
+#### Get release by a tag name
+
+**GitLab API:** [Get a release by a tag name](https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Tag name:** The Git tag the release is associated with.
+
+#### Create a release
+
+**GitLab API:** [Create a release](https://docs.gitlab.com/ee/api/releases/#create-a-release).
+**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+**Tag name:** The tag where the release is created from.
+**Ref:** A commit SHA, another tag name, or a branch name.
+**Release name:** The release name.
+**Description:** The description of the release.
+
+## Handle Connector response
+
+The **GitLab Connector** is a protocol connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+handling response is still applicable [as described](./rest.md#response).

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/gitlab.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/gitlab.md
@@ -2,30 +2,30 @@
 id: gitlab
 title: GitLab Connector
 sidebar_label: GitLab Connector
-description: Manage GitLab issues and releases from your BPMN process.
+description: Manage GitLab issues and releases from your BPMN process. Learn about creating a GitLab Connector task and get started.
 ---
 
 The **GitLab Connector** allows you to connect your BPMN service with [GitLab](https://about.gitlab.com/).
 
 ## Prerequisites
 
-To use the **GitLab Connector**, you need to have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
+To use the **GitLab Connector**, you must have a GitLab instance and an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) of a user
 or a service account on whose behalf a BPMN process will be executed.
 
 :::note
 It is highly recommended not to expose your GitLab access token credentials as plain text. Instead, use Camunda secrets.
-See an article on how to [manage secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
+See our documentation on [managing secrets](../../../components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
-## Create an GitLab Connector Task
+## Create a GitLab Connector task
 
 To use the **GitLab Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](../use-connectors.md) to learn more.
 
 ## Fill in the endpoint and authentication
 
-In the section **HTTP Endpoint** provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
+In the **HTTP Endpoint** section, provide a **GitLab base URL**, i.e. `https://gitlab.mycorp.com`, and a **GitLab access token**.
 
-## Select operation you wish to execute
+## Select operation to execute
 
 The **GitLab Connector** currently supports the following operations.
 
@@ -33,62 +33,62 @@ The **GitLab Connector** currently supports the following operations.
 
 #### Get an issue by ID
 
-**GitLab API:** [Single project issue](https://docs.gitlab.com/ee/api/issues.html#single-project-issue).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Issue ID:** The internal ID of a project’s issue.
+- **GitLab API:** [Single project issue](https://docs.gitlab.com/ee/api/issues.html#single-project-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
 
 #### Create an issue
 
-**GitLab API:** [New issue](https://docs.gitlab.com/ee/api/issues.html#new-issue).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Title:** The title of an issue.
-**Description:** The description of an issue.
+- **GitLab API:** [New issue](https://docs.gitlab.com/ee/api/issues.html#new-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Title:** The title of an issue.
+- **Description:** The description of an issue.
 
 #### Delete an issue
 
-**GitLab API:** [Delete an issue](https://docs.gitlab.com/ee/api/issues.html#delete-an-issue).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Issue ID:** The internal ID of a project’s issue.
+- **GitLab API:** [Delete an issue](https://docs.gitlab.com/ee/api/issues.html#delete-an-issue).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
 
 #### Comment to an issue
 
-**GitLab API:** [Create a new issue note](https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Issue ID:** The internal ID of a project’s issue.
-**Note text:** The content of a note.
-**Level of confidentiality:** Indicates whether an issue has to be marked as **internal** or not.
+- **GitLab API:** [Create a new issue note](https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Issue ID:** The internal ID of a project’s issue.
+- **Note text:** The content of a note.
+- **Level of confidentiality:** Indicates if an issue has to be marked as **internal** or not.
 
 #### Search issues
 
-**GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
-**Scope:** Return issues for the given scope: **Created by me**, **Assigned to me** or **all**.
-**State:** Return all issues or just those that are **opened** or **closed**.
-**Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
-**Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.
-**Author ID:** Return issues created by the given user ID.
-**Contains text:** Search issues against their **Title** and **Description**.
+- **GitLab API:** [List issues](https://docs.gitlab.com/ee/api/issues.html#list-issues).
+- **Scope:** Return issues for the given scope: **Created by me**, **Assigned to me**, or **all**.
+- **State:** Return all issues or just those that are **opened** or **closed**.
+- **Assignee ID:** Return issues assigned to the given user ID. Mutually exclusive with **Assignee username**. **None** returns unassigned issues. **Any** returns issues with an assignee.
+- **Assignee username:** Return issues assigned to the given username. Similar to **Assignee ID** and mutually exclusive with **Assignee ID**.
+- **Author ID:** Return issues created by the given user ID.
+- **Contains text:** Search issues against their **Title** and **Description**.
 
 ### Releases
 
 #### List all releases by a project ID
 
-**GitLab API:** [List releases](https://docs.gitlab.com/ee/api/releases/#list-releases).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **GitLab API:** [List releases](https://docs.gitlab.com/ee/api/releases/#list-releases).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
 
 #### Get release by a tag name
 
-**GitLab API:** [Get a release by a tag name](https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Tag name:** The Git tag the release is associated with.
+- **GitLab API:** [Get a release by a tag name](https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Tag name:** The Git tag the release is associated with.
 
 #### Create a release
 
-**GitLab API:** [Create a release](https://docs.gitlab.com/ee/api/releases/#create-a-release).
-**Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
-**Tag name:** The tag where the release is created from.
-**Ref:** A commit SHA, another tag name, or a branch name.
-**Release name:** The release name.
-**Description:** The description of the release.
+- **GitLab API:** [Create a release](https://docs.gitlab.com/ee/api/releases/#create-a-release).
+- **Project ID:** The global ID or URL-encoded path of the project owned by the authenticated user.
+- **Tag name:** The tag where the release is created from.
+- **Ref:** A commit SHA, another tag name, or a branch name.
+- **Release name:** The release name.
+- **Description:** The description of the release.
 
 ## Handle Connector response
 

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -263,6 +263,7 @@
             "components/connectors/out-of-the-box-connectors/operate",
             "components/connectors/out-of-the-box-connectors/easy-post",
             "components/connectors/out-of-the-box-connectors/github",
+            "components/connectors/out-of-the-box-connectors/gitlab",
             "components/connectors/out-of-the-box-connectors/googledrive",
             "components/connectors/out-of-the-box-connectors/google-maps-platform",
             "components/connectors/out-of-the-box-connectors/graphql",

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -304,6 +304,7 @@
             "components/connectors/out-of-the-box-connectors/easy-post",
             "components/connectors/out-of-the-box-connectors/github",
             "components/connectors/out-of-the-box-connectors/github-webhook",
+            "components/connectors/out-of-the-box-connectors/gitlab",
             "components/connectors/out-of-the-box-connectors/googledrive",
             "components/connectors/out-of-the-box-connectors/google-maps-platform",
             "components/connectors/out-of-the-box-connectors/graphql",

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -317,6 +317,7 @@
             "components/connectors/out-of-the-box-connectors/easy-post",
             "components/connectors/out-of-the-box-connectors/github",
             "components/connectors/out-of-the-box-connectors/github-webhook",
+            "components/connectors/out-of-the-box-connectors/gitlab",
             "components/connectors/out-of-the-box-connectors/googledrive",
             "components/connectors/out-of-the-box-connectors/google-maps-platform",
             "components/connectors/out-of-the-box-connectors/graphql",


### PR DESCRIPTION
## What is the purpose of the change

Introduce a new OOTB connector doc: GitLab.

## Are there related marketing activities

No

## When should this change go live?

Any time

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
