### PR TITLE
docs(identity): update supported environments

### DIFF
--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -37,7 +37,7 @@ Requirements for the components can be seen below:
 | Zeebe Broker and Gateway | OpenJDK 17+  | Elasticsearch 7.16.x (only if Elastic exporter is used)                                          |
 | Operate                  | OpenJDK 11+  | Elasticsearch 7.16.x                                                                             |
 | Tasklist                 | OpenJDK 11+  | Elasticsearch 7.16.x                                                                             |
-| Identity                 | OpenJDK 17+  | Keycloak 16.1.1, 19.0.3                                                                          |
+| Identity                 | OpenJDK 17+  | Keycloak 16.1.1, 19.x, 20.x                                                                      |
 | Optimize                 | OpenJDK 11+  | Elasticsearch 7.13.x - 7.15.x, 7.16.2+, 7.17.x                                                   |
 | Web Modeler (Beta)       | -            | Keycloak 16.1.1, 19.0.3<br/>PostgreSQL 14.x (other database systems are currently not supported) |
 


### PR DESCRIPTION
## What is the purpose of the change

Related to https://github.com/camunda-cloud/identity/issues/1515

We have added support for Keycloak 20 in Identity, which will be effective in the next 8.2.0 release. Although we only test with the latest patch of each major version, backwards compatibility for other patch/minor releases should be seen as given by semver design. Therefore I made the supported versions we have tested more generic (19.x instead of 19.0.3). This should ensure the users who run different patch versions of Keycloak, that running c8 with their environment will not break anything.

## Are there related marketing activities

None are known

## When should this change go live?

With the 8.2 release

## PR Checklist

- [ ] ~My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.~
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] ~My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.~
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
