### PR TITLE
Pepopowitz/dockerfile improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,8 @@ RUN sed -i \
 
 # Enable rewrites
 RUN sed -i '/<Directory "\/usr\/local\/apache2\/htdocs">/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /usr/local/apache2/conf/httpd.conf
+
+# Restart Apache server
+#  I'm not totally convinced we need to do this, but I don't think there's a down-side,
+#  and I had one situation where I needed to go do it manually after startup so 🤷🏼
+RUN apachectl -k restart

--- a/howtos/documentation-guidelines.md
+++ b/howtos/documentation-guidelines.md
@@ -152,7 +152,9 @@ If you wish to test `.htaccess` rules, you have a couple options:
 2. Use `docker compose` to spin up a locally-running Apache webserver.
    This repo includes Docker configuration ([Dockerfile](../Dockerfile) and [docker-compose.yml](../docker-compose.yml)) to spin up a local environment that better simulates a published environment. Redirect rules can then be tested directly in a browser.
 
-   The local server is based on the contents of your `./build` folder. To start this local server:
+   The local server is based on the contents of your `./build` folder.
+
+   **To start the local server**:
 
    1. Build the docs with `npm run build`.
    2. Start the server with `docker compose up`.
@@ -160,6 +162,13 @@ If you wish to test `.htaccess` rules, you have a couple options:
 
       It is probably best to do this in an incognito browser session, as browsers clutch tightly to 301 redirects.
 
+   4. Clean up the server with `docker compose down`.
+
+   **If you make changes and want to re-start the server**:
+
+   1. Apply the changes to your `build` folder, either manually or by re-running `npm run build`.
+   2. Rebuild the environment with `docker compose build`.
+   3. Re-start the server with `docker compose up`.
    4. Clean up the server with `docker compose down`.
 
 ## Screenshot automation


### PR DESCRIPTION
## What is the purpose of the change

Improves the experience when testing htaccess rules locally. 

1. Adds a step to the Dockerfile that restarts the Apache server, to make sure it picks up changes to the server configuration.
2. Better clarifies how to re-start the server after making changes to the htaccess file.

I'm not totally convinced item 1 needs to happen, because I haven't needed it in the past.....but for some reason, when testing with @christinaausley, I had to go into the running instance and manually restart Apache. I don't think there's any harm in adding it, even if it isn't necessary.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
