### PR TITLE
docs(self-managed): update Helm chart docs after Web Modeler subchart was merged to parent

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
@@ -154,15 +154,19 @@ Alternatively, create an image pull secret [from your Docker configuration file]
 
 To set up Web Modeler, you need to provide the following required configuration values (all available configuration options are described in more detail in the Helm chart's [README](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform#web-modeler-beta) file):
 
-- Enable Web Modeler with `web-modeler.enabled: true` (it is disabled by default).
-- Configure the previously created [image pull secret](#create-image-pull-secret) in `web-modeler.image.pullSecrets`.
-- Configure your SMTP server by providing the values under `web-modeler.restapi.mail`.
+- Enable Web Modeler with `webModeler.enabled: true` (it is disabled by default).
+- Configure the previously created [image pull secret](#create-image-pull-secret) in `webModeler.image.pullSecrets`.
+- Configure your SMTP server by providing the values under `webModeler.restapi.mail`.
   - Web Modeler requires an SMTP server to send notification emails to users.
+- Configure the database connection
+  - Web Modeler requires a PostgreSQL database as persistent data storage (other database systems are currently not supported).
+  - _Option 1_: Set `postgresql.enabled: true`. This will install a new PostgreSQL instance as part of the Helm release (using the [PostgreSQL Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) by Bitnami as a dependency).
+  - _Option 2_: Set `postgresql.enabled: false` and configure a [connection to an external database](#optional-configure-external-database).
 
 We recommend specifying these values in a YAML file that you pass to the `helm install` command. A minimum configuration file would look as follows:
 
 ```yaml
-web-modeler:
+webModeler:
   enabled: true
   image:
     pullSecrets:
@@ -176,19 +180,16 @@ web-modeler:
       smtpPassword: secret
       # email address to be displayed as sender of emails from Web Modeler
       fromAddress: no-reply@example.com
+postgresql:
+  enabled: true
 ```
 
 #### Optional: Configure external database
 
-Web Modeler requires a PostgreSQL database as persistent data storage (other database systems are currently not supported).
-By default, a new PostgreSQL instance is installed as part of the Helm release (using the [PostgreSQL Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) by Bitnami as a dependency).
-Alternatively, you can configure a connection to an existing external database:
+If you don't like to install a new PostgreSQL instance with Helm, you can configure Web Modeler to use an existing external database. Set `postgresql.enabled: false` and provide the values under `webModeler.restapi.externalDatabase`:
 
 ```yaml
-web-modeler:
-  postgresql:
-    # disables the PostgreSQL chart dependency
-    enabled: false
+webModeler:
   restapi:
     externalDatabase:
       host: postgres.example.com
@@ -196,6 +197,9 @@ web-modeler:
       database: modeler-db
       user: modeler-user
       password: secret
+postgresql:
+  # disables the PostgreSQL chart dependency
+  enabled: false
 ```
 
 #### Install the Helm chart

--- a/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
@@ -186,7 +186,7 @@ postgresql:
 
 #### Optional: Configure external database
 
-If you don't like to install a new PostgreSQL instance with Helm, you can configure Web Modeler to use an existing external database. Set `postgresql.enabled: false` and provide the values under `webModeler.restapi.externalDatabase`:
+If you don't want to install a new PostgreSQL instance with Helm, but connect Web Modeler to an existing external database, set `postgresql.enabled: false` and provide the values under `webModeler.restapi.externalDatabase`:
 
 ```yaml
 webModeler:

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -48,8 +48,7 @@ camunda-platform
     |_ optimize
     |_ operate
     |_ tasklist
-    |_ web-modeler
-        |_ postgresql
+    |_ postgresql
 ```
 
 - Keycloak is a dependency for Camunda Identity and PostgreSQL is a dependency for Keycloak.
@@ -66,10 +65,8 @@ identity:
     [keycloak values]
     postgresql:
       [postgresql values]
-web-modeler:
-  [web-modeler values]
-  postgresql:
-    [postgresql values]
+postgresql:
+  [postgresql values]
 ```
 
 ## Push Docker images to your repository
@@ -145,7 +142,7 @@ optimize:
   image:
     repository: example.jfrog.io/camunda/optimize
     ...
-web-modeler:
+webModeler:
   image:
     # registry and tag will be used for all three Web Modeler images
     registry: example.jfrog.io
@@ -159,11 +156,11 @@ web-modeler:
   websockets:
     image:
       repository: camunda/modeler-websockets
-  # only necessary if the PostgreSQL chart dependency is used for Web Modeler
-  postgresql:
-    image:
-      repository: example.jfrog.io/bitnami/postgres
   ...
+# only necessary if the PostgreSQL chart dependency is used for Web Modeler
+postgresql:
+  image:
+    repository: example.jfrog.io/bitnami/postgres
 ```
 
 Afterwards, you can deploy Camunda Platform using Helm and the custom values file.

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -151,7 +151,7 @@ zeebe-gateway:
     className: nginx
     host: "zeebe.camunda.example.com"
 
-web-modeler:
+webModeler:
   ingress:
     enabled: true
     className: nginx
@@ -162,7 +162,7 @@ web-modeler:
 ```
 
 :::note Web Modeler
-The configuration above only contains the Ingress-related values under `web-modeler`. Note the additional [installation instructions and configuration hints](../../helm-kubernetes/deploy.md#installing-web-modeler-beta).
+The configuration above only contains the Ingress-related values under `webModeler`. Note the additional [installation instructions and configuration hints](../../helm-kubernetes/deploy.md#installing-web-modeler-beta).
 :::
 
 Using the custom values file, [deploy Camunda Platform 8 as usual](../../helm-kubernetes/deploy.md):


### PR DESCRIPTION
## What is the purpose of the change
The structure of the Camunda 8 Helm chart has recently been refactored (the Web Modeler subchart has been merged to the parent chart; see https://github.com/camunda/camunda-platform-helm/pull/584). This change requires a few updates to the documentation.

Closes https://github.com/camunda/web-modeler/issues/4170.

## Are there related marketing activities
no

## When should this change go live?
It can go live any time.

## PR Checklist

- [x] ~My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory,~ or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, ~or they are not for future versions.~
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, ~or my changes do not require an Engineering review.~
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, ~or my changes do not require a technical writer review.~