### PR TITLE
docs(identity): revert Keycloak 20 support

### DIFF
--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -37,7 +37,7 @@ Requirements for the components can be seen below:
 | Zeebe              | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x (only if Elastic exporter is used)                                  |
 | Operate            | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x                                                                     |
 | Tasklist           | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x                                                                     |
-| Identity           | OpenJDK 17+  | Keycloak 16.1.1, 19.x, 20.x                                                                      |
+| Identity           | OpenJDK 17+  | Keycloak 16.1.1, 19.0.3                                                                          |
 | Optimize           | OpenJDK 11+  | Elasticsearch 7.13.x - 7.15.x, 7.16.2+, 7.17.x                                                   |
 | Web Modeler (Beta) | -            | Keycloak 16.1.1, 19.0.3<br/>PostgreSQL 14.x (other database systems are currently not supported) |
 


### PR DESCRIPTION
## What is the purpose of the change

Reverts the changes added in https://github.com/camunda/camunda-platform-docs/pull/1819 due to a [bug that was found](https://github.com/camunda-cloud/identity/issues/1515).

## Are there related marketing activities

no

## When should this change go live?

no

## PR Checklist

- [ ] ~My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.~
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] ~My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.~
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
