### PR TITLE
chore(config): reduce default zeebe import batch size to 200

### DIFF
--- a/optimize/self-managed/optimize-deployment/configuration/system-configuration-platform-8.md
+++ b/optimize/self-managed/optimize-deployment/configuration/system-configuration-platform-8.md
@@ -9,4 +9,4 @@ description: "Connection to Camunda Platform 8."
 | zeebe.enabled           | false         | Toggles whether Optimize should attempt to import data from the connected Zeebe instance.                                    |
 | zeebe.name              | zeebe-record  | The name suffix of the exported Zeebe records. This must match the record-prefix configured in the exporter of the instance. |
 | zeebe.partitionCount    | 1             | The number of partitions configured for the Zeebe record source.                                                             |
-| zeebe.maxImportPageSize | 10000         | The max page size for importing Zeebe data.                                                                                  |
+| zeebe.maxImportPageSize | 200           | The max page size for importing Zeebe data.                                                                                  |


### PR DESCRIPTION
## What is the purpose of the change

The default value we use for the import batch size will be changed in the next release

## Are there related marketing activities

N/A

## When should this change go live?

With the upcoming 8.2 release

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
