### PR TITLE
chore(docs): drop support for ES <7.16.2

### DIFF
--- a/optimize/self-managed/optimize-deployment/migration-update/3.9-to-3.10.md
+++ b/optimize/self-managed/optimize-deployment/migration-update/3.9-to-3.10.md
@@ -28,7 +28,7 @@ configuration options have therefore been deprecated:
 
 ## Elasticsearch
 
-Optimize now supports Elasticsearch `8.5` and `8.6`, but it requires at least Elasticsearch `7.13.0`.
+Optimize now supports Elasticsearch `8.5` and `8.6`, but it requires at least Elasticsearch `7.16.2`.
 See the [supported environments]($docs$/reference/supported-environments) section for the full range of supported versions.
 
 If you need to update your Elasticsearch cluster, refer to the general [Elasticsearch update guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html). Usually, the only thing you need to do is perform a [rolling update](https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html).


### PR DESCRIPTION
relates to OPT-6826

## What is the purpose of the change

Optimize now requires minimum 7.16.2, we should have this reflected in the docs

## Are there related marketing activities

N/A

## When should this change go live?

With the 8.2 release

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
