### PR TITLE
remove version banner from 8.0

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -223,8 +223,8 @@ module.exports = {
           beforeDefaultRemarkPlugins: [versionedLinks],
           versions: {
             "8.0": {
-                banner: 'none',
-            }
+              banner: "none",
+            },
           },
         },
         blog: false,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -221,6 +221,7 @@ module.exports = {
           editUrl:
             "https://github.com/camunda/camunda-platform-docs/edit/main/",
           beforeDefaultRemarkPlugins: [versionedLinks],
+          // 👋 When cutting a new version, remove the banner for maintained versions by adding an entry. Remove the entry to versions >18 months old.
           versions: {
             "8.0": {
               banner: "none",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -221,6 +221,11 @@ module.exports = {
           editUrl:
             "https://github.com/camunda/camunda-platform-docs/edit/main/",
           beforeDefaultRemarkPlugins: [versionedLinks],
+          versions: {
+            "8.0": {
+                banner: 'none',
+            }
+          },
         },
         blog: false,
         theme: {

--- a/howtos/release-procedure.md
+++ b/howtos/release-procedure.md
@@ -65,7 +65,18 @@ To create the new versions:
 
    - Add the new mapping in the first position of the array.
 
-5. Create a PR with the changes and merge to `main`. Confirm no build issues before moving to the release steps.
+5. Ensure the "unmaintained" banner does not appear for supported versions. We currently support all versions of Camunda Platform 8 since none are older than 18 months.
+
+```javascript
+// 👋 When cutting a new version, remove the banner for maintained versions by adding an entry. Remove the entry to versions >18 months old.
+   versions: {
+      "8.0": {
+         banner: "none",
+      },
+   },
+```
+
+6. Create a PR with the changes and merge to `main`. Confirm no build issues before moving to the release steps.
 
 ### Release the new version
 


### PR DESCRIPTION
## What is the purpose of the change

OOTB Docusaurus puts up a banner stating older docs versions are "unmaintained," which is not entirely true. 

This PR removes the banner from 8.0 since OOTB, we only have 3 options - no banner, "unmaintained," or "unreleased" (as in `next`).  

Shoutout to @remcowesterhoud for starting this discussion 😄! 

## Are there related marketing activities

No.

## When should this change go live?

This should not be merged until feedback is collected internally.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
