### PR TITLE
docs(identity): fix sidebar labels for group related pages

### DIFF
--- a/docs/self-managed/identity/user-guide/groups/assigning-roles-to-a-group.md
+++ b/docs/self-managed/identity/user-guide/groups/assigning-roles-to-a-group.md
@@ -1,7 +1,7 @@
 ---
 id: assigning-roles-to-a-group
 title: "Assigning roles to a group"
-sidebar_label: "Groups are a way to apply a set of roles and authorizations to users. Use Identity to assign roles to a group."
+description: "Groups are a way to apply a set of roles and authorizations to users. Use Identity to assign roles to a group."
 ---
 
 In this guide we will show you how to use Identity to assign roles to a group.

--- a/docs/self-managed/identity/user-guide/groups/assigning-users-to-a-group.md
+++ b/docs/self-managed/identity/user-guide/groups/assigning-users-to-a-group.md
@@ -1,7 +1,7 @@
 ---
 id: assigning-users-to-a-group
 title: "Assigning users to a group"
-sidebar_label: "Groups are a way to apply a set of roles and authorizations to users. Use Identity to assign users to a group."
+description: "Groups are a way to apply a set of roles and authorizations to users. Use Identity to assign users to a group."
 ---
 
 In this guide we will show you how to use Identity to assign users to a group.

--- a/docs/self-managed/identity/user-guide/groups/creating-a-group.md
+++ b/docs/self-managed/identity/user-guide/groups/creating-a-group.md
@@ -1,7 +1,7 @@
 ---
 id: creating-a-group
 title: "Creating a group"
-sidebar_label: "Groups are a way to apply a set of roles and authorizations to users. Use Identity to create a group."
+description: "Groups are a way to apply a set of roles and authorizations to users. Use Identity to create a group."
 ---
 
 In this guide we will show you how to use Identity to create a group.

--- a/docs/self-managed/identity/user-guide/groups/creating-authorizations-for-a-group.md
+++ b/docs/self-managed/identity/user-guide/groups/creating-authorizations-for-a-group.md
@@ -1,7 +1,7 @@
 ---
 id: creating-authorizations-for-a-group
 title: "Creating autorizations for a group"
-sidebar_label: "Groups are a way to apply a set of roles and authorizations to users. Use Identity to create authorizations for a group."
+description: "Groups are a way to apply a set of roles and authorizations to users. Use Identity to create authorizations for a group."
 ---
 
 In this guide we will show you how to use Identity to create authorizations for a group.


### PR DESCRIPTION
## What is the purpose of the change

I spotted that as part of a recent change I made, the sidebar labels for several pages were altered, this is because they were `sidebar_labels` and not `description`. This PR updates the fields to now be `description`

## Are there related marketing activities

Nope :)

## When should this change go live?

Before the next docs release

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
