### PR TITLE
docs(operate): Announce changes from Spring Boot 3 update, plus elasticsearch versions

### DIFF
--- a/docs/guides/update-guide/810-to-820.md
+++ b/docs/guides/update-guide/810-to-820.md
@@ -27,4 +27,4 @@ This may change the performance characteristics. If you have tuned your system f
 
 - It is recommended to follow a sequential update path when updating to version 8.2. For example, if running on version 8.0, first update to 8.1, then update to 8.2.
 - Migration of data during the version 8.2 update could take longer than previous versions, especially for datasets containing a large amount of incidents data.
-- Operate now uses Spring Boot version 3.0, therefore URLs with a trailing slash will fail with a HTTP status 404: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes
+- Operate now uses Spring Boot version 3.0. Therefore, [URLs with a trailing slash will fail with an HTTP status 404](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes).

--- a/docs/guides/update-guide/810-to-820.md
+++ b/docs/guides/update-guide/810-to-820.md
@@ -23,7 +23,8 @@ The default [backpressure](/self-managed/zeebe-deployment/operations/backpressur
 This may change the performance characteristics. If you have tuned your system for specific latency or throughput, we recommend you reevaluate with the new version.
 :::
 
-### Operate
+## Operate
 
 - It is recommended to follow a sequential update path when updating to version 8.2. For example, if running on version 8.0, first update to 8.1, then update to 8.2.
 - Migration of data during the version 8.2 update could take longer than previous versions, especially for datasets containing a large amount of incidents data.
+- Operate now uses Spring Boot version 3.0, therefore URLs with a trailing slash will fail with a HTTP status 404: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -8,7 +8,7 @@ description: "Important announcements including deprecation & removal notices"
 
 - It is recommended to follow a sequential update path when updating to version 8.2. For example, if running on version 8.0, first update to 8.1, then update to 8.2.
 - Migration of data during the version 8.2 update could take longer than previous versions, especially for datasets containing a large amount of incidents data.
-- Operate now uses Spring Boot version 3.0, therefore URLs with a trailing slash will fail with a HTTP status 404: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes
+- Operate now uses Spring Boot version 3.0. Therefore, [URLs with a trailing slash will fail with an HTTP status 404](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes).
 
 ## Deprecated in 8.0
 

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -8,6 +8,7 @@ description: "Important announcements including deprecation & removal notices"
 
 - It is recommended to follow a sequential update path when updating to version 8.2. For example, if running on version 8.0, first update to 8.1, then update to 8.2.
 - Migration of data during the version 8.2 update could take longer than previous versions, especially for datasets containing a large amount of incidents data.
+- Operate now uses Spring Boot version 3.0, therefore URLs with a trailing slash will fail with a HTTP status 404: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes
 
 ## Deprecated in 8.0
 

--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -34,11 +34,11 @@ Requirements for the components can be seen below:
 
 | Component          | Java version | Other requirements                                                                               |
 | ------------------ | ------------ | ------------------------------------------------------------------------------------------------ |
-| Zeebe              | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x (only if Elastic exporter is used)                                  |
-| Operate            | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x                                                                     |
-| Tasklist           | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x                                                                     |
+| Zeebe              | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x (only if Elastic exporter is used), 8.5.x, 8.6.x                    |
+| Operate            | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                       |
+| Tasklist           | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                       |
 | Identity           | OpenJDK 17+  | Keycloak 16.1.1, 19.0.3                                                                          |
-| Optimize           | OpenJDK 11+  | Elasticsearch 7.13.x - 7.15.x, 7.16.2+, 7.17.x                                                   |
+| Optimize           | OpenJDK 11+  | Elasticsearch 7.13.x - 7.15.x, 7.16.2+, 7.17.x, 8.5.x, 8.6.x                                     |
 | Web Modeler (Beta) | -            | Keycloak 16.1.1, 19.0.3<br/>PostgreSQL 14.x (other database systems are currently not supported) |
 
 ### Version Matrix


### PR DESCRIPTION
## What is the purpose of the change

With Operate 8.2, it comes with Spring Boot 3.0 the following needs to documented/updated:

Operate now requires Java 17+
URLs with a trailing slash will fail with a HTTP status 404: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes

Unrelated: While updating version requirements, also added the elastic search supported versions since I will be making those doc changes as well in any case.

## Are there related marketing activities

No

## When should this change go live?

As part of 8.2 minor release

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
