### PR TITLE
docs(operate): Elasticsearch 8 ILM support

### DIFF
--- a/docs/self-managed/operate-deployment/data-retention.md
+++ b/docs/self-managed/operate-deployment/data-retention.md
@@ -33,7 +33,7 @@ In case of intensive Zeebe usage, the amount of data can grow significantly over
 
 Dated indices may be safely removed from Elasticsearch. "Safely" means only finished process instances are deleted together with all related data, and the rest of the data stays consistent. You can use Elasticsearch Curator or other tools/scripts to delete old data.
 
-Users updating from Elasticsearch 7 to Elasticsearch 8, will encounter issues with the Elasticsearch Curator. To resolve this, Operate allows configuring an Index Lifecycle Management (ILM) Policy using the `archiver` configuration options:
+Users updating from Elasticsearch 7 to Elasticsearch 8 will encounter issues with the Elasticsearch Curator. To resolve this, Operate allows configuring an Index Lifecycle Management (ILM) Policy using the `archiver` configuration options:
 
 ### A snippet from application.yml
 
@@ -44,7 +44,7 @@ camunda.operate:
     ilmMinAgeForDeleteArchivedIndices: 30d
 ```
 
-`ilmMinAgeForDeleteArchivedIndices` defines the duration for which archived data will be stored before deletion. The values use Elasticsearch TimeUnit format: https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units.
+`ilmMinAgeForDeleteArchivedIndices` defines the duration for which archived data will be stored before deletion. The values use [Elasticsearch TimeUnit format](https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units).
 
 This ILM Policy works on Elasticsearch 7 as well, and can function as a replacement of the Elasticsearch Curator.
 

--- a/docs/self-managed/operate-deployment/data-retention.md
+++ b/docs/self-managed/operate-deployment/data-retention.md
@@ -33,6 +33,21 @@ In case of intensive Zeebe usage, the amount of data can grow significantly over
 
 Dated indices may be safely removed from Elasticsearch. "Safely" means only finished process instances are deleted together with all related data, and the rest of the data stays consistent. You can use Elasticsearch Curator or other tools/scripts to delete old data.
 
+Users updating from Elasticsearch 7 to Elasticsearch 8, will encounter issues with the Elasticsearch Curator. To resolve this, Operate allows configuring an Index Lifecycle Management (ILM) Policy using the `archiver` configuration options:
+
+### A snippet from application.yml
+
+```yaml
+camunda.operate:
+  archiver:
+    ilmEnabled: true
+    ilmMinAgeForDeleteArchivedIndices: 30d
+```
+
+`ilmMinAgeForDeleteArchivedIndices` defines the duration for which archived data will be stored before deletion. The values use Elasticsearch TimeUnit format: https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units.
+
+This ILM Policy works on Elasticsearch 7 as well, and can function as a replacement of the Elasticsearch Curator.
+
 :::note
 Only indices containing dates in their suffix may be deleted.
 :::

--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -18,9 +18,7 @@ By default, the configuration for Operate is stored in a YAML file (`application
 - [Monitoring possibilities](#monitoring-operate)
 - [Logging configuration](#logging)
 
-## Configurations
-
-### Webserver
+## Webserver
 
 Operate supports customizing the **context-path** using default Spring configuration.
 
@@ -32,7 +30,7 @@ Example for environment variable:
 
 The default context-path is `/`.
 
-#### Security
+### Security
 
 To change the values for http header for security reasons, you can use the configuration parameters:
 
@@ -42,7 +40,7 @@ To change the values for http header for security reasons, you can use the confi
 | camunda.operate.websecurity.httpStrictTransportSecurityMaxAgeInSeconds   | See [Spring description](https://docs.spring.io/spring-security/site/docs/5.2.0.RELEASE/reference/html/default-security-headers-2.html#webflux-headers-hsts) | 63,072,000 (two years)                                                                                                                                                                                                                                                                                           |
 | camunda.operate.websecurity.httpStrictTransportSecurityIncludeSubDomains | See [Spring description](https://docs.spring.io/spring-security/site/docs/5.2.0.RELEASE/reference/html/default-security-headers-2.html#webflux-headers-hsts) | true                                                                                                                                                                                                                                                                                                             |
 
-### Elasticsearch
+## Elasticsearch
 
 Operate stores and reads data in/from Elasticsearch.
 


### PR DESCRIPTION
## What is the purpose of the change

With the update to Elasticsearch 8, the Elasticsearch Curator will no longer function. It is replaced with Index Lifecycle Management. This change documents the configuration needed to enable ILM.

## Are there related marketing activities

No

## When should this change go live?

As part of the 8.2 minor release

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
