### PR TITLE
Inline FEEL expressions in script tasks

### DIFF
--- a/docs/components/modeler/bpmn/script-tasks/script-tasks.md
+++ b/docs/components/modeler/bpmn/script-tasks/script-tasks.md
@@ -10,26 +10,29 @@ JavaScript, or Python.
 
 ![task](assets/script-task.png)
 
-Script tasks behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). Both task
-types are based on jobs and [job workers](/components/concepts/job-workers.md). The
+### Job worker implementation
+
+When the job worker implementation is used, script tasks behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md).
+Both task types are based on jobs and [job workers](/components/concepts/job-workers.md). The
 differences between these task types are the visual representation (i.e. the task marker) and the
 semantics for the model.
 
-When a process instance enters a script task, it creates a corresponding job and waits for its
-completion. A job worker should request jobs of this job type and process them. When the job is
-complete, the process instance continues.
+When a process instance enters a script task using a job worker implementation, it creates a corresponding job and waits
+for its completion. A job worker should request jobs of this job type and process them. When the job is complete, the
+process instance continues.
 
 :::note
 Jobs for script tasks are not processed by Zeebe itself. To process them, provide a job worker.
 :::
 
-## Defining a task
+### Defining a job worker script task
 
-A script task must define a [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a service task does. It specifies
-the type of job workers should subscribe to (e.g. `script`).
+A script task must define a [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the
+same way as a service task does. It specifies the type of job workers should subscribe to (e.g. `script`).
 
-Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to the job
-worker (e.g. the script to evaluate). The community extension [Zeebe Script Worker](https://github.com/camunda-community-hub/zeebe-script-worker) requires certain attributes to be set in the task headers.
+Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to
+the job worker (e.g. the script to evaluate). The community extension [Zeebe Script Worker](https://github.com/camunda-community-hub/zeebe-script-worker)
+requires certain attributes to be set in the task headers.
 
 Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
 the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)

--- a/docs/components/modeler/bpmn/script-tasks/script-tasks.md
+++ b/docs/components/modeler/bpmn/script-tasks/script-tasks.md
@@ -33,7 +33,7 @@ To define a script task with an inline FEEL expression, you need to use the `zee
 1. Define the name of process variable in the `resultVariable` attribute. This variable will store the result of the
    FEEL expression evaluation.
 
-### Job worker implementation
+## Job worker implementation
 
 When the job worker implementation is used, script tasks behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md).
 Both task types are based on jobs and [job workers](/components/concepts/job-workers.md). The
@@ -83,6 +83,16 @@ A script task with a custom header:
       <zeebe:header key="language" value="javascript" />
       <zeebe:header key="script" value="a + b" />
     </zeebe:taskHeaders>
+  </bpmn:extensionElements>
+</bpmn:scriptTask>
+```
+
+A script task with an inline FEEL expression:
+
+```xml
+<bpmn:scriptTask id="calculate-sum" name="Calculate sum">
+  <bpmn:extensionElements>
+    <zeebe:script expression="=a + b" resultVariable="sum" />
   </bpmn:extensionElements>
 </bpmn:scriptTask>
 ```

--- a/docs/components/modeler/bpmn/script-tasks/script-tasks.md
+++ b/docs/components/modeler/bpmn/script-tasks/script-tasks.md
@@ -11,7 +11,7 @@ JavaScript, or Python.
 ![task](assets/script-task.png)
 
 :::info
-Camunda Platform 8 supports alternative task implementations for the script task. If you want to use your own
+Camunda Platform 8 supports alternative task implementations for the script task. To use your own
 implementation for a script task, see the [job worker implementation](#job-worker-implementation) section below. The
 sections before this job worker implementation apply to the [FEEL expression](/components/modeler/feel/language-guide/feel-expressions-introduction.md)
 implementation only.
@@ -26,12 +26,11 @@ raised at the script task. When the incident is resolved, the script task is eva
 
 ## Defining a script task
 
-To define a script task with an inline FEEL expression, you need to use the `zeebe:script` extension element. In the
-`zeebe:script` extension element, you need to perform the following steps:
+To define a script task with an inline FEEL expression, use the `zeebe:script` extension element. In the
+`zeebe:script` extension element, perform the following steps:
 
 1. Define the **FEEL expression** inside the `expression` attribute.
-1. Define the name of process variable in the `resultVariable` attribute. This variable will store the result of the
-   FEEL expression evaluation.
+2. Define the name of process variable in the `resultVariable` attribute. This variable will store the result of the FEEL expression evaluation.
 
 ### Variable mappings
 
@@ -42,18 +41,16 @@ All variables in scope of the script task are available to the FEEL engine when 
 is evaluated. Input mappings can be used to transform the variables into a format accepted by the FEEL expression.
 
 :::info
-Input mappings are applied on activating the script task (or when an incident at the script task is resolved), before
+Input mappings are applied on activating the script task (or when an incident at the script task is resolved) before
 the FEEL expression evaluation. When an incident is resolved at the script task, the input mappings are applied again
 before evaluating the FEEL expression. This can affect the result of the FEEL expression evaluation.
 :::
 
-For more information about this topic, visit the documentation about [input/output variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings).
+For more information about this topic, visit the documentation about [input and output variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings).
 
 ## Job worker implementation
 
-When the job worker implementation is used, script tasks behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md).
-Both task types are based on jobs and [job workers](/components/concepts/job-workers.md). The
-differences between these task types are the visual representation (i.e. the task marker) and the
+When the job worker implementation is used, script tasks behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). Both task types are based on jobs and [job workers](/components/concepts/job-workers.md). The differences between these task types are the visual representation (i.e. the task marker) and the
 semantics for the model.
 
 When a process instance enters a script task using a job worker implementation, it creates a corresponding job and waits
@@ -67,14 +64,14 @@ Jobs for script tasks are not processed by Zeebe itself. To process them, provid
 ### Defining a job worker script task
 
 A script task must define a [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the
-same way as a service task does. It specifies the type of job workers should subscribe to (e.g. `script`).
+same way a service task does. It specifies the type of job workers should subscribe to (e.g. `script`).
 
 Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to
 the job worker (e.g. the script to evaluate). The community extension [Zeebe Script Worker](https://github.com/camunda-community-hub/zeebe-script-worker)
 requires certain attributes to be set in the task headers.
 
 Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
-the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
+the [same way a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
 to transform the variables passed to the job worker, or to customize how the variables of the job merge.
 
 ## Additional resources

--- a/docs/components/modeler/bpmn/script-tasks/script-tasks.md
+++ b/docs/components/modeler/bpmn/script-tasks/script-tasks.md
@@ -33,6 +33,22 @@ To define a script task with an inline FEEL expression, you need to use the `zee
 1. Define the name of process variable in the `resultVariable` attribute. This variable will store the result of the
    FEEL expression evaluation.
 
+### Variable mappings
+
+By default, the variable defined by `resultVariable` is merged into the process instance. This behavior can be
+customized by defining an output mapping at the script task.
+
+All variables in scope of the script task are available to the FEEL engine when the FEEL expression in the script task
+is evaluated. Input mappings can be used to transform the variables into a format accepted by the FEEL expression.
+
+:::info
+Input mappings are applied on activating the script task (or when an incident at the script task is resolved), before
+the FEEL expression evaluation. When an incident is resolved at the script task, the input mappings are applied again
+before evaluating the FEEL expression. This can affect the result of the FEEL expression evaluation.
+:::
+
+For more information about this topic, visit the documentation about [input/output variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings).
+
 ## Job worker implementation
 
 When the job worker implementation is used, script tasks behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md).

--- a/docs/components/modeler/bpmn/script-tasks/script-tasks.md
+++ b/docs/components/modeler/bpmn/script-tasks/script-tasks.md
@@ -10,6 +10,29 @@ JavaScript, or Python.
 
 ![task](assets/script-task.png)
 
+:::info
+Camunda Platform 8 supports alternative task implementations for the script task. If you want to use your own
+implementation for a script task, see the [job worker implementation](#job-worker-implementation) section below. The
+sections before this job worker implementation apply to the [FEEL expression](/components/modeler/feel/language-guide/feel-expressions-introduction.md)
+implementation only.
+:::
+
+When the process instance arrives at a script task, the integrated [FEEL Scala](https://github.com/camunda/feel-scala)
+engine evaluates the script task FEEL expression. Once the FEEL expression is evaluated successfully, the process
+instance continues.
+
+If the FEEL expression evaluation is unsuccessful, an [incident](/components/concepts/incidents.md) is
+raised at the script task. When the incident is resolved, the script task is evaluated again.
+
+## Defining a script task
+
+To define a script task with an inline FEEL expression, you need to use the `zeebe:script` extension element. In the
+`zeebe:script` extension element, you need to perform the following steps:
+
+1. Define the **FEEL expression** inside the `expression` attribute.
+1. Define the name of process variable in the `resultVariable` attribute. This variable will store the result of the
+   FEEL expression evaluation.
+
 ### Job worker implementation
 
 When the job worker implementation is used, script tasks behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md).


### PR DESCRIPTION
## What is the purpose of the change

* Add a new documentation section for script tasks covering the usage of FEEL expressions.
* Point out that there are two different implementations for script tasks in Camunda Platform 8 (FEEL expressions and job workers).
* Add an example for script tasks using inline FEEL expressions.

## Are there related marketing activities

/

## When should this change go live?

Before the Camunda Platform 8.2 release.

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.

## Additional context
- Only added for version `8.2`, it shouldn't be ported to older versions.

closes #1548 