### PR TITLE
docs(web-modeler): remove beta status

### DIFF
--- a/docs/apis-clients/web-modeler-api/index.md
+++ b/docs/apis-clients/web-modeler-api/index.md
@@ -5,11 +5,11 @@ description: "Web Modeler API (beta) is a REST API and provides access to Web Mo
 ---
 
 :::caution Beta Offering
-Web Modeler API is currently offered as a [beta release](../../reference/early-access#beta). It is not recommended for production use and there is no maintenance service guaranteed.
+The Web Modeler API is currently offered as a [beta feature](../../reference/early-access#beta). It is not recommended for production use and there is no maintenance service guaranteed.
 
 While in beta, the API may introduce breaking changes without prior notice.
 
-However, we encourage you to provide feedback via your designated support channel or the [Camunda Forum](https://forum.camunda.io/).
+We encourage you to provide feedback via your designated support channel or the [Camunda Forum](https://forum.camunda.io/).
 :::
 
 Web Modeler provides a REST API at `/api/*`. Clients can access this API by passing a JWT access token in an authorization header `Authorization: Bearer <JWT>`.

--- a/docs/reference/licenses.md
+++ b/docs/reference/licenses.md
@@ -22,7 +22,7 @@ The Connector SDK, REST Connector, Connector Runtime Docker image, and Connector
 
 ### Web Modeler
 
-Web Modeler (including Beta) is licensed under a [proprietary license](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/).
+Web Modeler is licensed under the proprietary Camunda Platform Self-Managed Enterprise Edition license (a copy you obtain when you contact Camunda).
 
 ### Desktop Modeler
 

--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -32,14 +32,14 @@ We highly recommend running Camunda Platform 8 Self-Managed in a Kubernetes envi
 
 Requirements for the components can be seen below:
 
-| Component          | Java version | Other requirements                                                                               |
-| ------------------ | ------------ | ------------------------------------------------------------------------------------------------ |
-| Zeebe              | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x (only if Elastic exporter is used), 8.5.x, 8.6.x                    |
-| Operate            | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                       |
-| Tasklist           | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                       |
-| Identity           | OpenJDK 17+  | Keycloak 16.1.1, 19.0.3                                                                          |
-| Optimize           | OpenJDK 11+  | Elasticsearch 7.13.x - 7.15.x, 7.16.2+, 7.17.x, 8.5.x, 8.6.x                                     |
-| Web Modeler (Beta) | -            | Keycloak 16.1.1, 19.0.3<br/>PostgreSQL 14.x (other database systems are currently not supported) |
+| Component   | Java version | Other requirements                                                                               |
+| ----------- | ------------ | ------------------------------------------------------------------------------------------------ |
+| Zeebe       | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x (only if Elastic exporter is used), 8.5.x, 8.6.x                    |
+| Operate     | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                       |
+| Tasklist    | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                       |
+| Identity    | OpenJDK 17+  | Keycloak 16.1.1, 19.0.3                                                                          |
+| Optimize    | OpenJDK 11+  | Elasticsearch 7.13.x - 7.15.x, 7.16.2+, 7.17.x, 8.5.x, 8.6.x                                     |
+| Web Modeler | -            | Keycloak 16.1.1, 19.0.3<br/>PostgreSQL 14.x (other database systems are currently not supported) |
 
 ### Version Matrix
 
@@ -53,7 +53,7 @@ This overview shows which Zeebe version works with which Modeler, Operate, Taskl
 | Desktop Modeler 4.12+ | Zeebe 1.3.x | Operate 1.3.x Tasklist 1.3.x IAM 1.3.x      | Optimize 3.7.x |
 | Desktop Modeler 5.0+  | Zeebe 8.0.x | Operate 8.0.x Tasklist 8.0.x Identity 8.0.x | Optimize 3.8.x |
 | Desktop Modeler 5.4+  | Zeebe 8.1.x | Operate 8.1.x Tasklist 8.1.x Identity 8.1.x | Optimize 3.9.x |
-| Web Modeler (Beta)    | Zeebe 8.1.x | Operate 8.1.x Tasklist 8.1.x Identity 8.1.x | Optimize 3.9.x |
+| Web Modeler           | Zeebe 8.1.x | Operate 8.1.x Tasklist 8.1.x Identity 8.1.x | Optimize 3.9.x |
 
 :::note
 You can also use newer versions of Desktop and Web Modeler with older Zeebe versions.

--- a/docs/self-managed/about-self-managed.md
+++ b/docs/self-managed/about-self-managed.md
@@ -26,12 +26,7 @@ The following components are available for Camunda Platform 8 Self-Managed:
 - Connectors
 - Optimize
 - Identity (not available in Camunda Platform 8 SaaS)
-- Web Modeler [<span class="badge badge--beta" style={{marginLeft: 4, verticalAlign: "text-top"}}>Beta</span>](../../reference/early-access#beta)
-  :::caution Beta offering
-  Web Modeler Self-Managed is currently offered as a [beta release](../../reference/early-access#beta)
-  with limited availability for enterprise customers only. It is not recommended for production use.
-  Special [terms & conditions](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/) apply.
-  :::
+- Web Modeler [<span class="badge badge--enterprise-only">Enterprise only</span>](../../reference/licenses/#web-modeler)
 
 Camunda Platform 8 Self-Managed users may also use [Desktop Modeler](../../components/modeler/desktop-modeler/install-the-modeler) as an addition to these components. Desktop Modeler can be used by process developers to build BPMN diagrams, DMN diagrams, or [Camunda Forms](../guides/utilizing-forms.md) for automation.
 

--- a/docs/self-managed/modeler/web-modeler/api.md
+++ b/docs/self-managed/modeler/web-modeler/api.md
@@ -4,15 +4,17 @@ title: API access
 description: "Details on accessing the API (beta) of Web Modeler Self-Managed. Learn more about OpenAPI documentation, authentication, and JWT tokens."
 ---
 
-:::caution Beta Offering
-Web Modeler Self-Managed API is currently offered as a [beta release](../../../../reference/early-access#beta)
-with limited availability for enterprise customers only. It is not recommended for production use and there is no maintenance service guaranteed.
+:::note
+Web Modeler Self-Managed is available to [enterprise customers](../../../reference/licenses.md#web-modeler) only.
+:::
 
-Special [terms and conditions](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/) apply.
+:::caution Beta Offering
+The Web Modeler API is currently offered as a [beta feature](../../../../reference/early-access#beta).
+It is not recommended for production use and there is no maintenance service guaranteed. Special [terms and conditions](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/) apply.
 
 While in beta, the API may introduce breaking changes without prior notice.
 
-However, we encourage you to provide feedback via your designated support channel or the [Camunda Forum](https://forum.camunda.io/).
+We encourage you to provide feedback via your designated support channel or the [Camunda Forum](https://forum.camunda.io/).
 :::
 
 Web Modeler provides a [REST API](../../../../apis-clients/web-modeler-api/) at `/api/*`. Clients can access this API by passing a JWT access token in an authorization header `Authorization: Bearer <JWT>`.

--- a/docs/self-managed/modeler/web-modeler/configuration.md
+++ b/docs/self-managed/modeler/web-modeler/configuration.md
@@ -4,17 +4,14 @@ title: Configuration
 description: "Read details on the configuration variables of Web Modeler Self-Managed, including components such as REST API, Identity, Keycloak, webapp, and WebSocket."
 ---
 
-:::caution Beta Offering
-Web Modeler Self-Managed is currently offered as a [beta release](../../../../reference/early-access#beta)
-with limited availability for enterprise customers only. It is not recommended for production use and there is no maintenance service guaranteed.
-Special [terms & conditions](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/) apply.
-However, we encourage you to provide feedback via your designated support channel or the [Camunda Forum](https://forum.camunda.io/).
+:::note
+Web Modeler Self-Managed is available to [enterprise customers](../../../reference/licenses.md#web-modeler) only.
 :::
 
 The different components of Web Modeler Self-Managed can be configured using environment variables. Each component's variables are described below.
 
 - For a working example configuration showing how the components are correctly wired together, see the [Docker Compose file for Web Modeler](../../../platform-deployment/docker#web-modeler-1).
-- If you are using the Camunda Platform 8 [Helm chart](../../platform-deployment/helm-kubernetes/deploy.md) to set up Web Modeler, read more about the different configuration options in the chart's [README file](https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform/README.md#web-modeler-beta).
+- If you are using the Camunda Platform 8 [Helm chart](../../platform-deployment/helm-kubernetes/deploy.md) to set up Web Modeler, read more about the different configuration options in the chart's [README file](https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform/README.md#web-modeler).
 
 ## Configuration of the `restapi` component
 

--- a/docs/self-managed/modeler/web-modeler/installation.md
+++ b/docs/self-managed/modeler/web-modeler/installation.md
@@ -4,11 +4,8 @@ title: Installation
 description: "Details on installation of Web Modeler Self-Managed."
 ---
 
-:::caution Beta Offering
-Web Modeler Self-Managed is currently offered as a [beta release](../../../../reference/early-access#beta)
-with limited availability for enterprise customers only. It is not recommended for production use and there is no maintenance service guaranteed.
-Special [terms & conditions](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/) apply.
-However, we encourage you to provide feedback via your designated support channel or the [Camunda Forum](https://forum.camunda.io/).
+:::note
+Web Modeler Self-Managed is available to [enterprise customers](../../../reference/licenses.md#web-modeler) only.
 :::
 
 Refer to the [Installation Guide](../../platform-deployment/overview.md) for details on how to install Web Modeler.

--- a/docs/self-managed/platform-deployment/docker.md
+++ b/docs/self-managed/platform-deployment/docker.md
@@ -7,7 +7,7 @@ This page guides you through Camunda Platform 8 Docker images and how to run the
 
 ## Docker images
 
-We provide Docker images [via Dockerhub](https://hub.docker.com/u/camunda). All these images are publicly accessible (except for [Web Modeler Beta](#web-modeler)).
+We provide Docker images [via Dockerhub](https://hub.docker.com/u/camunda). All these images are publicly accessible (except for [Web Modeler](#web-modeler)).
 
 :::info
 The provided Docker images are supported for production usage only on Linux systems. Windows or macOS are only supported for development environments.
@@ -47,20 +47,18 @@ We currently only recommend the `linux/amd64` for production usage, as the `linu
 
 ### Web Modeler
 
-:::caution Beta offering
-Web Modeler Self-Managed is currently offered as a [beta release](../../../reference/early-access#beta)
-with limited availability for enterprise customers only. It is not recommended for production use.
-Special [terms & conditions](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/) apply.
+:::note
+Web Modeler Self-Managed is available to [enterprise customers](../../reference/licenses.md#web-modeler) only.
 :::
 
 The Docker images for Web Modeler are not publicly accessible, but available to enterprise customers only from
 Camunda's private Docker registry.
 
-| Web Modeler Component | Docker image                                                          |
-| --------------------- | :-------------------------------------------------------------------- |
-| Backend (`restapi`)   | `registry.camunda.cloud/web-modeler-ee/modeler-restapi:0.8.0-beta`    |
-| Frontend (`webapp`)   | `registry.camunda.cloud/web-modeler-ee/modeler-webapp:0.8.0-beta`     |
-| WebSocket server      | `registry.camunda.cloud/web-modeler-ee/modeler-websockets:0.8.0-beta` |
+| Web Modeler Component | Docker image                                                      |
+| --------------------- | :---------------------------------------------------------------- |
+| Backend (`restapi`)   | `registry.camunda.cloud/web-modeler-ee/modeler-restapi:latest`    |
+| Frontend (`webapp`)   | `registry.camunda.cloud/web-modeler-ee/modeler-webapp:latest`     |
+| WebSocket server      | `registry.camunda.cloud/web-modeler-ee/modeler-websockets:latest` |
 
 To pull the images you first need to log in using the credentials you received from Camunda:
 
@@ -94,14 +92,8 @@ We recommend to use [Helm + KIND](./helm-kubernetes/guides/local-kubernetes-clus
 
 ### Web Modeler
 
-:::caution Beta offering
-Web Modeler Self-Managed is currently offered as a [beta release](../../../reference/early-access#beta)
-with limited availability for enterprise customers only. It is not recommended for production use.
-Special [terms & conditions](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/) apply.
-:::
-
 An additional Docker Compose configuration to run Web Modeler is also available in the
-[camunda-platform](https://github.com/camunda/camunda-platform/blob/main/docker-compose-web-modeler-beta.yaml) repository. Follow the instructions in the [README](https://github.com/camunda/camunda-platform#web-modeler-self-managed-beta-release) to utilize this configuration.
+[camunda-platform](https://github.com/camunda/camunda-platform/blob/main/docker-compose-web-modeler.yaml) repository. Follow the instructions in the [README](https://github.com/camunda/camunda-platform#web-modeler-self-managed) to utilize this configuration.
 
 ## Configuration hints
 

--- a/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
@@ -24,8 +24,8 @@ The following charts will be installed as part of Camunda Platform 8 Self-Manage
 - **Optimize**: Deploys the Optimize component to analyze the historic process executions.
 - **Identity**: Deploys the Identity component responsible for authentication and authorization.
 - **Elasticsearch**: Deploys an Elasticsearch cluster with two nodes.
-- **Web Modeler** [<span class="badge badge--beta">Beta</span>](../../../../reference/early-access#beta): Deploys the Web Modeler component that allows you to model BPMN processes in a collaborative way.
-  - _Note_: The chart is disabled by default and needs to be [enabled explicitly](#installing-web-modeler-beta) as Web Modeler is only available to enterprise customers.
+- **Web Modeler**: Deploys the Web Modeler component that allows you to model BPMN processes in a collaborative way.
+  - _Note_: The chart is disabled by default and needs to be [enabled explicitly](#installing-web-modeler) as Web Modeler is only available to enterprise customers.
 
 :::note Connectors
 We do not provide a Helm chart for Connectors in Self-Managed yet.
@@ -69,7 +69,7 @@ Replace &lt;RELEASE_NAME&gt; with a name of your choice.
 
 You can also add the `-n` flag to specify in which Kubernetes namespace the components should be installed.
 
-The command does not install Web Modeler by default. To enable Web Modeler, refer to the [installation instructions](#installing-web-modeler-beta) below.
+The command does not install Web Modeler by default. To enable Web Modeler, refer to the [installation instructions](#installing-web-modeler) below.
 :::
 
 Notice that this Kubernetes cluster can have services which are already running; Camunda components are simply installed as another set of services.
@@ -118,13 +118,10 @@ elasticsearch-master-0                                 1/1     Running   0      
 <RELEASE_NAME>-zeebe-gateway                           1/1     Running   0          4m6s
 ```
 
-### Installing Web Modeler (Beta)
+### Installing Web Modeler
 
-:::caution Beta offering
-Web Modeler Self-Managed is currently offered as a [beta release](../../../../reference/early-access#beta)
-with limited availability for enterprise customers only. It is not recommended for production use and there is no maintenance service guaranteed.
-Special [terms & conditions](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/) apply.
-However, we encourage you to provide feedback via your designated support channel or the [Camunda Forum](https://forum.camunda.io/).
+:::note
+Web Modeler Self-Managed is available to [enterprise customers](../../../reference/licenses.md#web-modeler) only.
 :::
 
 To install the Camunda Helm chart with Web Modeler enabled, follow the steps below.
@@ -152,7 +149,7 @@ Alternatively, create an image pull secret [from your Docker configuration file]
 
 #### Configure Web Modeler
 
-To set up Web Modeler, you need to provide the following required configuration values (all available configuration options are described in more detail in the Helm chart's [README](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform#web-modeler-beta) file):
+To set up Web Modeler, you need to provide the following required configuration values (all available configuration options are described in more detail in the Helm chart's [README](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform#web-modeler) file):
 
 - Enable Web Modeler with `webModeler.enabled: true` (it is disabled by default).
 - Configure the previously created [image pull secret](#create-image-pull-secret) in `webModeler.image.pullSecrets`.

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -4,7 +4,7 @@ title: "Installing in an air-gapped environment"
 description: "Camunda Platform 8 Self-Managed installation in an air-gapped environment"
 ---
 
-The [Camunda Platform Helm chart](../../helm-kubernetes/deploy.md) may assist in an air-gapped environment. By default, the Docker images are fetched via Docker Hub (except for [Web Modeler Beta](../../docker.md#web-modeler)).
+The [Camunda Platform Helm chart](../../helm-kubernetes/deploy.md) may assist in an air-gapped environment. By default, the Docker images are fetched via Docker Hub (except for [Web Modeler](../../docker.md#web-modeler)).
 With the dependencies in third-party Docker images and Helm charts, additional steps are required to make all charts available as outlined in this resource.
 
 ## Required Docker images

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -78,7 +78,7 @@ zeebe-gateway:
 ```
 
 :::note Web Modeler
-The configuration above only contains the Ingress-related values under `webModeler`. Note the additional [installation instructions and configuration hints](../../helm-kubernetes/deploy.md#installing-web-modeler-beta).
+The configuration above only contains the Ingress-related values under `webModeler`. Note the additional [installation instructions and configuration hints](../../helm-kubernetes/deploy.md#installing-web-modeler).
 :::
 
 Using the custom values file, [deploy Camunda Platform 8 as usual](../../helm-kubernetes/deploy.md):
@@ -170,7 +170,7 @@ webModeler:
 ```
 
 :::note Web Modeler
-The configuration above only contains the Ingress-related values under `webModeler`. Note the additional [installation instructions and configuration hints](../../helm-kubernetes/deploy.md#installing-web-modeler-beta).
+The configuration above only contains the Ingress-related values under `webModeler`. Note the additional [installation instructions and configuration hints](../../helm-kubernetes/deploy.md#installing-web-modeler).
 :::
 
 Using the custom values file, [deploy Camunda Platform 8 as usual](../../helm-kubernetes/deploy.md):

--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/platforms.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/platforms.md
@@ -14,5 +14,5 @@ In addition to Stock Kubernetes (which could be deployed on cloud or on-premise)
 <DocCardList items={useCurrentSidebarCategory().items}/>
 
 :::caution Web Modeler
-While it is likely Web Modeler Beta will work on your cloud platform, we do not guarantee functionality and currently offer no dedicated support for these cloud platforms.
+While it is likely Web Modeler will work on your cloud platform, we do not guarantee functionality and currently offer no dedicated support for these cloud platforms.
 :::

--- a/docs/self-managed/platform-deployment/overview.md
+++ b/docs/self-managed/platform-deployment/overview.md
@@ -17,12 +17,7 @@ Camunda Platform 8 includes the following components:
 - Connectors
 - Optimize (requiring Elasticsearch)
 - Identity (requiring Keycloak)
-- Web Modeler (requiring Identity, Keycloak, and PostgreSQL) [<span class="badge badge--beta">Beta</span>](../../../reference/early-access#beta)
-  :::caution Beta offering
-  Web Modeler Self-Managed is currently offered as a [beta release](../../../reference/early-access#beta)
-  with limited availability for enterprise customers only. It is not recommended for production use.
-  Special [terms & conditions](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/) apply.
-  :::
+- Web Modeler (requiring Identity, Keycloak, and PostgreSQL) [<span class="badge badge--enterprise-only">Enterprise only</span>](../../../reference/licenses/#web-modeler)
 
 All components except Web Modeler are single Java applications.
 

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -1712,11 +1712,16 @@ module.exports = {
     },
 
     {
-      "Web Modeler (Beta)": [
+      "Web Modeler": [
         docsLink(
           "Installation",
           "self-managed/modeler/web-modeler/installation/"
         ),
+        docsLink(
+          "Configuration",
+          "self-managed/modeler/web-modeler/configuration/"
+        ),
+        docsLink("API access", "self-managed/modeler/web-modeler/api/"),
       ],
     },
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -1093,7 +1093,7 @@ module.exports = {
     {
       Modeler: [
         {
-          "Web Modeler (Beta)": [
+          "Web Modeler": [
             "self-managed/modeler/web-modeler/installation",
             "self-managed/modeler/web-modeler/configuration",
             "self-managed/modeler/web-modeler/api",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -202,6 +202,13 @@ svg.implemented:hover [stroke="#333"] {
   color: #000000;
 }
 
+.badge--enterprise-only {
+  background-color: #26d07c;
+  color: #000000;
+  margin-left: 4px;
+  vertical-align: text-top;
+}
+
 navbar .navbar .navbar__link[href*="self-managed"] {
   font-size: 0;
   padding: 4px;


### PR DESCRIPTION
## What is the purpose of the change
Update the docs for the General Availability (GA) release of Web Modeler Self-Manged (= remove beta status).

Closes https://github.com/camunda/web-modeler/issues/3764.

## Are there related marketing activities
There will probably be a blog post on the Camunda Platform 8.2 release that mentions Web Modeler GA.

## When should this change go live?
With the 8.2 release next week (April 11).

## PR Checklist
- [x] ~My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory,~ or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, ~or they are not for future versions.~
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, ~or my changes do not require an Engineering review.~
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, ~or my changes do not require a technical writer review.~