### PR TITLE
Fix link to community provided exporters

### DIFF
--- a/versioned_docs/version-8.1/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-8.1/components/zeebe/technical-concepts/architecture.md
@@ -67,4 +67,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/master/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://awesome.zeebe.io) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/master/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.


### PR DESCRIPTION
The original link https://awesome.zeebe.io is not working

## What is the purpose of the change

the original link is not working 

## Are there related marketing activities

No

## When should this change go live?

No rush ;)

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or **they are not for an already released version**.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or **they are not for future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or **my changes do not require an Engineering review**.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or **my changes do not require a technical writer review**.
