### PR TITLE
chore(sidebars): synchronize sidebars for 8.1/3.9.0 apis-tools 

### DIFF
--- a/optimize_versioned_sidebars/version-3.9.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.9.0-sidebars.json
@@ -1317,7 +1317,7 @@
   "APIs & Tools": [
     {
       "type": "link",
-      "label": "Working with APIs & Tools",
+      "label": "Working with APIs & tools",
       "href": "/docs/apis-tools/working-with-apis-tools/"
     },
     {
@@ -1341,6 +1341,11 @@
           "Tasklist API (GraphQL)": [
             {
               "type": "link",
+              "label": "Schema Documentation",
+              "href": "/docs/apis-tools/tasklist-api/"
+            },
+            {
+              "type": "link",
               "label": "Overview",
               "href": "/docs/apis-tools/tasklist-api/tasklist-api-overview/"
             },
@@ -1348,11 +1353,6 @@
               "type": "link",
               "label": "Tutorial",
               "href": "/docs/apis-tools/tasklist-api/tasklist-api-tutorial/"
-            },
-            {
-              "type": "link",
-              "label": "Schema Documentation",
-              "href": "/docs/apis-tools/tasklist-api/"
             },
             {
               "Directives": [
@@ -1686,6 +1686,11 @@
               "type": "link",
               "label": "Spring",
               "href": "/docs/apis-tools/community-clients/spring/"
+            },
+            {
+              "type": "link",
+              "label": "Quarkus",
+              "href": "/docs/apis-tools/community-clients/quarkus/"
             }
           ]
         },


### PR DESCRIPTION
## What is the purpose of the change

Synchronizes the sidebars for the APIs & Tools documentation, versions 8.1/3.9.0. 

Yet to come, in a different PR: APIs & Tools sidebars for versions `next`.

## When should this change go live?

Merged today, hopefully!

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
