### PR TITLE
chore: correct apis-tools cards URLs

### DIFF
--- a/docs/apis-tools/working-with-apis-tools.md
+++ b/docs/apis-tools/working-with-apis-tools.md
@@ -34,12 +34,12 @@ Camunda Platform 8 provides several official clients based on this API. Official
 
 Official clients have been developed and tested by Camunda. They also add convenience functions (e.g. thread handling for job workers) on top of the core API.
 
-<DocCardList items={[{type:"link", href:"/docs/apis-tools/java-client/", label: "Java client", docId:"apis-tools/java-client/index"},
+<DocCardList items={[{type:"link", href:"/docs/next/apis-tools/java-client/", label: "Java client", docId:"apis-tools/java-client/index"},
 {
-type:"link", href:"/docs/apis-tools/go-client/go-get-started/", label: "Go client", docId:"apis-tools/go-client/index"
+type:"link", href:"/docs/next/apis-tools/go-client/go-get-started/", label: "Go client", docId:"apis-tools/go-client/index"
 },
 {
-type:"link", href:"/docs/apis-tools/cli-client/index", label: "CLI client", docId:"apis-tools/cli-client/index"
+type:"link", href:"/docs/next/apis-tools/cli-client/", label: "CLI client", docId:"apis-tools/cli-client/index"
 }
 ]}/>
 
@@ -66,21 +66,21 @@ It is also possible to [build your own client](../apis-tools/build-your-own-clie
 
 ![Architecture diagram for Camunda Platform including all the components for SaaS](./img/ComponentsAndArchitecture_SaaS.png)
 
-<DocCardList items={[{type:"link", href:"/docs/apis-tools/tasklist-api/tasklist-api-overview/", label: "Tasklist API (GraphQL)", docId:"apis-tools/tasklist-api/tasklist-api-overview"},
+<DocCardList items={[{type:"link", href:"/docs/next/apis-tools/tasklist-api/tasklist-api-overview/", label: "Tasklist API (GraphQL)", docId:"apis-tools/tasklist-api/tasklist-api-overview"},
 {
-type:"link", href:"/docs/apis-tools/operate-api/", label: "Operate API (REST)", docId:"apis-tools/operate-api/operate-api-overview"
+type:"link", href:"/docs/next/apis-tools/operate-api/overview/", label: "Operate API (REST)", docId:"apis-tools/operate-api/operate-api-overview"
 },
 {
-type:"link", href:"/docs/apis-tools/console-api-reference/", label: "Console API (REST)", docId:"apis-tools/console-api-reference"
+type:"link", href:"/docs/next/apis-tools/console-api-reference/", label: "Console API (REST)", docId:"apis-tools/console-api-reference"
 },
 {
 type:"link", href:"/docs/next/apis-tools/web-modeler-api/", label: "Web Modeler API (Beta, REST)", docId:"apis-tools/web-modeler-api/index", border: "highlight"
 },
 {
-type:"link", href:"/docs/apis-tools/grpc/", label: "Zeebe API (gRPC)", docId:"apis-tools/grpc"
+type:"link", href:"/docs/next/apis-tools/grpc/", label: "Zeebe API (gRPC)", docId:"apis-tools/grpc"
 },
 {
-type:"link", href:"/optimize/apis-tools/optimize-api/optimize-api-authorization/", label: "Optimize API (REST)"
+type:"link", href:"/optimize/next/apis-tools/optimize-api/optimize-api-authorization/", label: "Optimize API (REST)"
 }
 ]}/>
 

--- a/versioned_docs/version-8.2/apis-tools/working-with-apis-tools.md
+++ b/versioned_docs/version-8.2/apis-tools/working-with-apis-tools.md
@@ -34,12 +34,12 @@ Camunda Platform 8 provides several official clients based on this API. Official
 
 Official clients have been developed and tested by Camunda. They also add convenience functions (e.g. thread handling for job workers) on top of the core API.
 
-<DocCardList items={[{type:"link", href:"/docs/apis-clients/java-client/", label: "Java client", docId:"apis-tools/java-client/index"},
+<DocCardList items={[{type:"link", href:"/docs/apis-tools/java-client/", label: "Java client", docId:"apis-tools/java-client/index"},
 {
-type:"link", href:"/docs/apis-clients/go-client/go-get-started/", label: "Go client", docId:"apis-tools/go-client/index"
+type:"link", href:"/docs/apis-tools/go-client/go-get-started/", label: "Go client", docId:"apis-tools/go-client/index"
 },
 {
-type:"link", href:"/docs/apis-clients/cli-client/index", label: "CLI client", docId:"apis-tools/cli-client/index"
+type:"link", href:"/docs/apis-tools/cli-client/", label: "CLI client", docId:"apis-tools/cli-client/index"
 }
 ]}/>
 
@@ -66,21 +66,21 @@ It is also possible to [build your own client](../apis-tools/build-your-own-clie
 
 ![Architecture diagram for Camunda Platform including all the components for SaaS](./img/ComponentsAndArchitecture_SaaS.png)
 
-<DocCardList items={[{type:"link", href:"/docs/apis-clients/tasklist-api/tasklist-api-overview/", label: "Tasklist API (GraphQL)", docId:"apis-tools/tasklist-api/tasklist-api-overview"},
+<DocCardList items={[{type:"link", href:"/docs/apis-tools/tasklist-api/tasklist-api-overview/", label: "Tasklist API (GraphQL)", docId:"apis-tools/tasklist-api/tasklist-api-overview"},
 {
-type:"link", href:"/docs/apis-clients/operate-api/", label: "Operate API (REST)", docId:"apis-tools/operate-api/operate-api-overview"
+type:"link", href:"/docs/apis-tools/operate-api/overview", label: "Operate API (REST)", docId:"apis-tools/operate-api/operate-api-overview"
 },
 {
-type:"link", href:"/docs/apis-clients/console-api-reference/", label: "Console API (REST)", docId:"apis-tools/console-api-reference"
+type:"link", href:"/docs/apis-tools/console-api-reference/", label: "Console API (REST)", docId:"apis-tools/console-api-reference"
 },
 {
 type:"link", href:"/docs/next/apis-tools/web-modeler-api/", label: "Web Modeler API (Beta, REST)", docId:"apis-tools/web-modeler-api/index", border: "highlight"
 },
 {
-type:"link", href:"/docs/apis-clients/grpc/", label: "Zeebe API (gRPC)", docId:"apis-tools/grpc"
+type:"link", href:"/docs/apis-tools/grpc/", label: "Zeebe API (gRPC)", docId:"apis-tools/grpc"
 },
 {
-type:"link", href:"/optimize/apis-clients/optimize-api/optimize-api-authorization/", label: "Optimize API (REST)"
+type:"link", href:"/optimize/apis-tools/optimize-api/optimize-api-authorization/", label: "Optimize API (REST)"
 }
 ]}/>
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes `main`!!!

Corrects the apis-tools cards URLs. I'd created the release PR prior to @christinaausley's fixes in #1938, and for some reason I was able to merge without conflicts? 

## When should this change go live?

Immediately! `main` is broken.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
