### PR TITLE
docs(release-procedure): manually trigger Algolia crawler

### DIFF
--- a/howtos/release-procedure.md
+++ b/howtos/release-procedure.md
@@ -21,7 +21,7 @@ The build process for [publish-prod](https://github.com/camunda/camunda-platform
 
 ## Perform a minor release
 
-Minor releases to Camunda Platform 8 happen twice a year in April and October, and the documentation is versioned on the same cadence.
+Minor releases to Camunda Platform 8 happen twice a year in April and October, on the second Tuesday of the month, and the documentation is versioned on the same cadence.
 
 To prepare for a minor product release, you'll need to create a new docs version.
 
@@ -88,3 +88,15 @@ Use the GitHub UI and follow the instructions below:
 4. Click **Publish release**.
 
 The build process for [publish-prod](https://github.com/camunda/camunda-platform-docs/actions/workflows/publish-prod.yaml) will kick off which could take around 30 min to finish. If publish-prod is successful, the updates will appear on [docs.camunda.io](https://docs.camunda.io).
+
+## Manually Trigger the Algolia crawler (DocSearch)
+
+Search not working for a new minor version? A specific document, published recently, not showing up in the internal search results? 
+
+Our twice yearly minor releases usually line up nicely with the scheduled Algolia crawl - Tuesday early US morning. 
+
+If the minor version docs are deployed after Tuesday early US morning, the Algolia crawler should be manually triggered, or the internal search (DocSearch) will not work for the new minor version. 
+
+Patch releases with significant or urgent updates may also require a manually triggered crawler.
+
+This requires [admin access](https://crawler.algolia.com/admin/users/login). Contact @pepopowitz or @akeller for assistance.


### PR DESCRIPTION
## What is the purpose of the change

Add hints and link to manually trigger Algolia crawler is search is degraded, particularly for new content.

## Are there related marketing activities

No

## When should this change go live?

Not urgent, but doesn't require a release just a merge.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
