### PR TITLE
docs(apis-tools): add postman link

### DIFF
--- a/docs/apis-tools/working-with-apis-tools.md
+++ b/docs/apis-tools/working-with-apis-tools.md
@@ -68,6 +68,8 @@ Camunda Platform 8 components have APIs to enable polyglot developers to work wi
 
 ![Architecture diagram for Camunda Platform including all the components for SaaS](./img/ComponentsAndArchitecture_SaaS.png)
 
+### API Reference
+
 <DocCardList items={[{type:"link", href:"/docs/next/apis-tools/tasklist-api/tasklist-api-overview/", label: "Tasklist API (GraphQL)", docId:"apis-tools/tasklist-api/tasklist-api-overview"},
 {
 type:"link", href:"/docs/next/apis-tools/operate-api/overview/", label: "Operate API (REST)", docId:"apis-tools/operate-api/operate-api-overview"
@@ -97,5 +99,5 @@ Camunda maintains a set of collections and APIs on Postman to help learn and use
 Watch and fork your favorite collections and APIs on the [Camunda Team](https://www.postman.com/camundateam).
 
 :::note
-Collections and APIs are manually updated and not all API functionality may be available. For the most up-to-date API functionality, see the component API reference docs.
+Collections and APIs are manually updated and not all API functionality may be available. For the most up-to-date API functionality, see the [API reference docs](/apis-tools/working-with-apis-tools.md#api-reference).
 :::

--- a/docs/apis-tools/working-with-apis-tools.md
+++ b/docs/apis-tools/working-with-apis-tools.md
@@ -64,6 +64,8 @@ It is also possible to [build your own client](../apis-tools/build-your-own-clie
 
 ## Learn about Camunda Components and their APIs
 
+Camunda Platform 8 components have APIs to enable polyglot developers to work with in their programming language of choice. Below are links to available component APIs.
+
 ![Architecture diagram for Camunda Platform including all the components for SaaS](./img/ComponentsAndArchitecture_SaaS.png)
 
 <DocCardList items={[{type:"link", href:"/docs/next/apis-tools/tasklist-api/tasklist-api-overview/", label: "Tasklist API (GraphQL)", docId:"apis-tools/tasklist-api/tasklist-api-overview"},
@@ -86,4 +88,14 @@ type:"link", href:"/optimize/next/apis-tools/optimize-api/optimize-api-authoriza
 
 :::note
 Additionally, visit our documentation on [Operate](../self-managed/operate-deployment/usage-metrics.md) and [Tasklist](../self-managed/tasklist-deployment/usage-metrics.md) usage metric APIs.
+:::
+
+### Postman
+
+Camunda maintains a set of collections and APIs on Postman to help learn and use the available APIs.
+
+Watch and fork your favorite collections and APIs on the [Camunda Team](https://www.postman.com/camundateam).
+
+:::note
+Collections and APIs are manually updated and not all API functionality may be available. For the most up-to-date API functionality, see the component API reference docs.
 :::


### PR DESCRIPTION
## What is the purpose of the change

Add Postman Link to next. This makes it available for early engagers, but gives us time to build out and update APIs & collections available there.

## Are there related marketing activities

No

## When should this change go live?

Not urgent

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
