### PR TITLE
dx: use hyperlink to crawl site looking for broken links

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           args: "product-links.prod.txt"
           fail: true
-      - name: crawl site
+      - name: Check internal links
         uses: untitaker/hyperlink@0.1.27
         with:
           args: build/

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -55,3 +55,7 @@ jobs:
         with:
           args: "product-links.prod.txt"
           fail: true
+      - name: crawl site
+        uses: untitaker/hyperlink@0.1.27
+        with:
+          args: build/


### PR DESCRIPTION
## What is the purpose of the change

During last week's release debacle, we [replaced our very-slow link-checking with fast link-checking](https://github.com/camunda/camunda-platform-docs/pull/1941/)....but in doing so, we lost the checking of links within the site. The replacement tool does not crawl the site, it only looks directly at the URLs you give it. 

This PR re-introduces crawling of the site to find broken links, using the [`hyperlink`](https://github.com/untitaker/hyperlink) tool. 

This is much faster than our previous crawling link-checker. One of the reasons is that it does not use HTTP to identify broken links -- it looks at the .html source files directly. This is slightly less accurate, because it does not account for server redirects....but assuming it doesn't uncover a ton of internal links that were depending on redirects, I think the slight loss in accuracy is worth it for the immense speed gains.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
