### PR TITLE
docs(regions): update available GCP regions

### DIFF
--- a/docs/reference/regions.md
+++ b/docs/reference/regions.md
@@ -16,11 +16,11 @@ Below, find a list of regions currently supported in Camunda Platform 8 SaaS.
 
 ## Available Google Cloud Platform (GCP) regions
 
-- Europe West: europe-west1
-- US East: us-east1
-- US Central: us-central1
-- Australia Southeast: australia-southeast1
-- North America Northeast: northamerica-northeast2
+- Belgium, Europe (europe-west1)
+- Iowa, North America (us-central1)
+- South Carolina, North America (us-east1)
+- Sydney, Australia (australia-southeast1)
+- Toronto, North America (northamerica-northeast2)
 
 You can find the locations behind the region codes [on the Google page](https://cloud.google.com/about/locations).
 

--- a/versioned_docs/version-8.2/reference/regions.md
+++ b/versioned_docs/version-8.2/reference/regions.md
@@ -16,11 +16,11 @@ Below, find a list of regions currently supported in Camunda Platform 8 SaaS.
 
 ## Available Google Cloud Platform (GCP) regions
 
-- Europe West: europe-west1
-- US East: us-east1
-- US Central: us-central1
-- Australia Southeast: australia-southeast1
-- North America Northeast: northamerica-northeast2
+- Belgium, Europe (europe-west1)
+- Iowa, North America (us-central1)
+- South Carolina, North America (us-east1)
+- Sydney, Australia (australia-southeast1)
+- Toronto, North America (northamerica-northeast2)
 
 You can find the locations behind the region codes [on the Google page](https://cloud.google.com/about/locations).
 


### PR DESCRIPTION

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/108522410/232763335-bad9862c-bf3f-4682-b4ce-79f3f4f9bf1e.png">

## What is the purpose of the change

Updating the naming of the GCP available regions of Camunda Platform 

## Are there related marketing activities



## When should this change go live?

_Does this change need to be released before a certain date or milestone? If so, when?_

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
