### PR TITLE
fix: replace URLs with paths-to-markdown-files

### DIFF
--- a/docs/reference/notices.md
+++ b/docs/reference/notices.md
@@ -28,7 +28,7 @@ The REST API functionality of Tasklist 8.2.0 and 8.2.1 allows unauthenticated ac
 - POST /v1/forms/{formId}
 - POST /v1/variables/{variableId}
 
-You can find more information about the methods in our [docs](https://docs.camunda.io/docs/next/apis-tools/tasklist-api-rest/tasklist-api-rest-overview/).
+You can find more information about the methods in our [docs](/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md).
 
 This means if you use Tasklist 8.2.0 or 8.2.1 and if you have sensible data that is stored in process variables, which are accessed by User Tasks, then this data could have been accessed by users knowing the endpoint of the Tasklist instance without authentication.
 

--- a/versioned_docs/version-8.2/reference/notices.md
+++ b/versioned_docs/version-8.2/reference/notices.md
@@ -28,7 +28,7 @@ The REST API functionality of Tasklist 8.2.0 and 8.2.1 allows unauthenticated ac
 - POST /v1/forms/{formId}
 - POST /v1/variables/{variableId}
 
-You can find more information about the methods in our [docs](https://docs.camunda.io/docs/next/apis-tools/tasklist-api-rest/tasklist-api-rest-overview/).
+You can find more information about the methods in our [docs](/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md).
 
 This means if you use Tasklist 8.2.0 or 8.2.1 and if you have sensible data that is stored in process variables, which are accessed by User Tasks, then this data could have been accessed by users knowing the endpoint of the Tasklist instance without authentication.
 


### PR DESCRIPTION
Addresses #1974 

## What is the purpose of the change

Replaces two brittle absolute URLs with relative paths-to-markdown-files. These are preferred, because: 

* Docusaurus can validate them for us
* They don't need to change when docs are versioned


## When should this change go live?

Sounds like it's pretty urgent.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
