### PR TITLE
chore: rephrase element templates configuration

### DIFF
--- a/docs/components/modeler/desktop-modeler/element-templates/configuring-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/configuring-templates.md
@@ -3,22 +3,37 @@ id: configuring-templates
 title: Configuring templates
 ---
 
-Element templates are defined as [JSON files](../defining-templates). There are two ways to integrate them into Camunda Modeler:
+Templates will be loaded by the modeler at application startup. Reloading it using `CtrlOrCmd+R` will also reload all templates. Templates will be treated as global or local depending on their location in your file system.
 
-1. **Local filesystem (Camunda Platform 7, and Camunda Platform 8):** You can fetch the JSON templates from [here](/self-managed/connectors-deployment/install-and-start.md#connector-templates). Store element templates as `.json` file in the `resources/element-templates` folder, relative to the modelers executable _or_ relative to the modeler's data directory ([see below](#example-setup)). Alternatively, they can be stored in a `.camunda/element-templates` directory that resides, relative to the currently opened diagram, anywhere in the diagram's path hierarchy.
-2. **Retrieve from Cawemo (Camunda Platform 7 only):** use the [Camunda Cloud Connect Plugin for Camunda Platform 7](https://docs.camunda.org/cawemo/latest/technical-guide/integrations/modeler/) to integrate Camunda Modeler with [Cawemo](https://cawemo.com/). Camunda Modeler can then retrieve templates from catalog projects setup in Cawemo. Note that the [Cloud Connect plugin](https://docs.camunda.org/cawemo/latest/technical-guide/integrations/modeler/) will keep Cawemo and your local Camunda Modeler installation in sync (e.g., deleting a template in Cawemo will delete it locally as well). Locally the synced templates will be stored in the `config.json` file in your [`{USER_DATA_DIRECTORY}`](../../search-paths#user-data-directory). You should not manually change the `config.json` unless you know what you're doing.
+### Global templates
 
-New templates will be recognized when reconnecting to Cawemo or on Camunda Modeler reload/restart.
+For templates to be available for all diagrams store them in the `resources/element-templates` directory containing the Camunda Modeler executable. Alternatively, for element templates to be available across Camunda Modeler installations, you can store them in the `resources/element-templates` directory in the modeler's [data directory](../../search-paths#user-data-directory).
 
-#### Example Setup
+#### Example (Windows)
 
-Add a `.json` file to the `resources/element-templates` sub-folder of your local [`{APP_DATA_DIRECTORY}`](../../search-paths#app-data-directory) or [`{USER_DATA_DIRECTORY}`](../../search-paths#user-data-directory) directory. You may have to create the `resources` and `element-templates` folders yourself.
+```
+└── camunda-modeler-5.10.0-win-x64
+    ├── Camunda Modeler.exe
+    └── resources
+        └── element-templates
+            └── my-element-templates.json
+```
 
-For local template discovery, create a `.camunda/element-templates` folder relative in the directory
-or any parent directory of the diagrams you are editing.
+:::note
+Camunda 7 templates can be syncronized with [Cawemo](https://cawemo.com/) using the [Camunda Cloud Connect Plugin for Camunda Platform 7](https://docs.camunda.org/cawemo/latest/technical-guide/integrations/modeler/). These templates will be treated as global.
+:::
 
-#### Development Workflow
+### Local templates
 
-When creating custom element templates, the modeler will give you detailed validation error messages.
+For element templates to only be available for specific diagrams, you can store them in a `.camunda/element-templates` directory in the diagrams parent directory or any of their parent directories.
 
-Templates will be loaded on application load and reload. To reload the application with updated templates, open the developer tools `F12` and press `CtrlOrCmd+R`. This will clear all unsaved diagrams **!**
+#### Example
+
+```
+├── diagram.bpmn
+└── .camunda
+    └── element-templates
+        └── my-element-templates.json
+```
+
+Learn more about search paths [here](../../search-paths).

--- a/docs/components/modeler/desktop-modeler/search-paths/search-paths.md
+++ b/docs/components/modeler/desktop-modeler/search-paths/search-paths.md
@@ -6,16 +6,16 @@ description: "Features like element templates and plugins allow you to add your 
 
 Features like element templates and plugins allow you to add your own resources to Desktop Modeler. For these resources to be found, they have to be in one of two directories depending on how local or global you want them to be.
 
-## App Data Directory
+## App data directory
 
 The `resources` directory relative to the directory containing the Camunda Modeler executable file. In our documentation we refer to it as `{APP_DATA_DIRECTORY}`.
 
 Resources in the app data directory will be found by any local Camunda Modeler instance.
 
-### Example (Windows):
+### Example (Windows)
 
 ```
-└── camunda-modeler-3.5.0-win-x64
+└── camunda-modeler-5.10.0-win-x64
     ├── Camunda Modeler.exe
     └── resources
         ├── element-templates
@@ -25,7 +25,7 @@ Resources in the app data directory will be found by any local Camunda Modeler i
                 └── index.js
 ```
 
-## User Data Directory
+## User data directory
 
 The `camunda-modeler/resources` directory relative to the per-user application data directory, which by default points to:
 
@@ -37,7 +37,7 @@ In our documentation we refer to it as `{USER_DATA_DIRECTORY}`.
 
 Resources in the user data directory will be found by all Camunda Modeler instances.
 
-### Example (Windows):
+### Example (Windows)
 
 ```
 └── AppData

--- a/versioned_docs/version-8.0/components/modeler/desktop-modeler/search-paths/search-paths.md
+++ b/versioned_docs/version-8.0/components/modeler/desktop-modeler/search-paths/search-paths.md
@@ -6,16 +6,16 @@ description: "Features like element templates and plugins allow you to add your 
 
 Features like element templates and plugins allow you to add your own resources to Desktop Modeler. For these resources to be found, they have to be in one of two directories depending on how local or global you want them to be.
 
-## App Data Directory
+## App data directory
 
 The `resources` directory relative to the directory containing the Camunda Modeler executable file. In our documentation we refer to it as `{APP_DATA_DIRECTORY}`.
 
 Resources in the app data directory will be found by any local Camunda Modeler instance.
 
-### Example (Windows):
+### Example (Windows)
 
 ```
-└── camunda-modeler-3.5.0-win-x64
+└── camunda-modeler-5.10.0-win-x64
     ├── Camunda Modeler.exe
     └── resources
         ├── element-templates
@@ -25,7 +25,7 @@ Resources in the app data directory will be found by any local Camunda Modeler i
                 └── index.js
 ```
 
-## User Data Directory
+## User data directory
 
 The `camunda-modeler/resources` directory relative to the per-user application data directory, which by default points to:
 
@@ -37,7 +37,7 @@ In our documentation we refer to it as `{USER_DATA_DIRECTORY}`.
 
 Resources in the user data directory will be found by all Camunda Modeler instances.
 
-### Example (Windows):
+### Example (Windows)
 
 ```
 └── AppData

--- a/versioned_docs/version-8.1/components/modeler/desktop-modeler/search-paths/search-paths.md
+++ b/versioned_docs/version-8.1/components/modeler/desktop-modeler/search-paths/search-paths.md
@@ -1,21 +1,21 @@
 ---
 id: search-paths
 title: Search paths
-description: "Features like element templates and plugins allow you to add your own resources to Desktop Modeler."
+description: "Features like element templates and plugins allow you to add your own resources to Desktop Modeler. For these resources to be found, they have to be in one of two directories depending on how local or global you want them to be."
 ---
 
 Features like element templates and plugins allow you to add your own resources to Desktop Modeler. For these resources to be found, they have to be in one of two directories depending on how local or global you want them to be.
 
-## App Data Directory
+## App data directory
 
 The `resources` directory relative to the directory containing the Camunda Modeler executable file. In our documentation we refer to it as `{APP_DATA_DIRECTORY}`.
 
 Resources in the app data directory will be found by any local Camunda Modeler instance.
 
-### Example (Windows):
+### Example (Windows)
 
 ```
-└── camunda-modeler-3.5.0-win-x64
+└── camunda-modeler-5.10.0-win-x64
     ├── Camunda Modeler.exe
     └── resources
         ├── element-templates
@@ -25,7 +25,7 @@ Resources in the app data directory will be found by any local Camunda Modeler i
                 └── index.js
 ```
 
-## User Data Directory
+## User data directory
 
 The `camunda-modeler/resources` directory relative to the per-user application data directory, which by default points to:
 
@@ -37,7 +37,7 @@ In our documentation we refer to it as `{USER_DATA_DIRECTORY}`.
 
 Resources in the user data directory will be found by all Camunda Modeler instances.
 
-### Example (Windows):
+### Example (Windows)
 
 ```
 └── AppData

--- a/versioned_docs/version-8.2/components/modeler/desktop-modeler/element-templates/configuring-templates.md
+++ b/versioned_docs/version-8.2/components/modeler/desktop-modeler/element-templates/configuring-templates.md
@@ -3,22 +3,37 @@ id: configuring-templates
 title: Configuring templates
 ---
 
-Element templates are defined as [JSON files](../defining-templates). There are two ways to integrate them into Camunda Modeler:
+Templates will be loaded by the modeler at application startup. Reloading it using `CtrlOrCmd+R` will also reload all templates. Templates will be treated as global or local depending on their location in your file system.
 
-1. **Local filesystem (Camunda Platform 7, and Camunda Platform 8):** You can fetch the JSON templates from [here](/self-managed/connectors-deployment/install-and-start.md#connector-templates). Store element templates as `.json` file in the `resources/element-templates` folder, relative to the modelers executable _or_ relative to the modeler's data directory ([see below](#example-setup)). Alternatively, they can be stored in a `.camunda/element-templates` directory that resides, relative to the currently opened diagram, anywhere in the diagram's path hierarchy.
-2. **Retrieve from Cawemo (Camunda Platform 7 only):** use the [Camunda Cloud Connect Plugin for Camunda Platform 7](https://docs.camunda.org/cawemo/latest/technical-guide/integrations/modeler/) to integrate Camunda Modeler with [Cawemo](https://cawemo.com/). Camunda Modeler can then retrieve templates from catalog projects setup in Cawemo. Note that the [Cloud Connect plugin](https://docs.camunda.org/cawemo/latest/technical-guide/integrations/modeler/) will keep Cawemo and your local Camunda Modeler installation in sync (e.g., deleting a template in Cawemo will delete it locally as well). Locally the synced templates will be stored in the `config.json` file in your [`{USER_DATA_DIRECTORY}`](../../search-paths#user-data-directory). You should not manually change the `config.json` unless you know what you're doing.
+### Global templates
 
-New templates will be recognized when reconnecting to Cawemo or on Camunda Modeler reload/restart.
+For templates to be available for all diagrams store them in the `resources/element-templates` directory containing the Camunda Modeler executable. Alternatively, for element templates to be available across Camunda Modeler installations, you can store them in the `resources/element-templates` directory in the modeler's [data directory](../../search-paths#user-data-directory).
 
-#### Example Setup
+#### Example (Windows)
 
-Add a `.json` file to the `resources/element-templates` sub-folder of your local [`{APP_DATA_DIRECTORY}`](../../search-paths#app-data-directory) or [`{USER_DATA_DIRECTORY}`](../../search-paths#user-data-directory) directory. You may have to create the `resources` and `element-templates` folders yourself.
+```
+└── camunda-modeler-5.10.0-win-x64
+    ├── Camunda Modeler.exe
+    └── resources
+        └── element-templates
+            └── my-element-templates.json
+```
 
-For local template discovery, create a `.camunda/element-templates` folder relative in the directory
-or any parent directory of the diagrams you are editing.
+:::note
+Camunda 7 templates can be syncronized with [Cawemo](https://cawemo.com/) using the [Camunda Cloud Connect Plugin for Camunda Platform 7](https://docs.camunda.org/cawemo/latest/technical-guide/integrations/modeler/). These templates will be treated as global.
+:::
 
-#### Development Workflow
+### Local templates
 
-When creating custom element templates, the modeler will give you detailed validation error messages.
+For element templates to only be available for specific diagrams, you can store them in a `.camunda/element-templates` directory in the diagrams parent directory or any of their parent directories.
 
-Templates will be loaded on application load and reload. To reload the application with updated templates, open the developer tools `F12` and press `CtrlOrCmd+R`. This will clear all unsaved diagrams **!**
+#### Example
+
+```
+├── diagram.bpmn
+└── .camunda
+    └── element-templates
+        └── my-element-templates.json
+```
+
+Learn more about search paths [here](../../search-paths).

--- a/versioned_docs/version-8.2/components/modeler/desktop-modeler/search-paths/search-paths.md
+++ b/versioned_docs/version-8.2/components/modeler/desktop-modeler/search-paths/search-paths.md
@@ -6,16 +6,16 @@ description: "Features like element templates and plugins allow you to add your 
 
 Features like element templates and plugins allow you to add your own resources to Desktop Modeler. For these resources to be found, they have to be in one of two directories depending on how local or global you want them to be.
 
-## App Data Directory
+## App data directory
 
 The `resources` directory relative to the directory containing the Camunda Modeler executable file. In our documentation we refer to it as `{APP_DATA_DIRECTORY}`.
 
 Resources in the app data directory will be found by any local Camunda Modeler instance.
 
-### Example (Windows):
+### Example (Windows)
 
 ```
-└── camunda-modeler-3.5.0-win-x64
+└── camunda-modeler-5.10.0-win-x64
     ├── Camunda Modeler.exe
     └── resources
         ├── element-templates
@@ -25,7 +25,7 @@ Resources in the app data directory will be found by any local Camunda Modeler i
                 └── index.js
 ```
 
-## User Data Directory
+## User data directory
 
 The `camunda-modeler/resources` directory relative to the per-user application data directory, which by default points to:
 
@@ -37,7 +37,7 @@ In our documentation we refer to it as `{USER_DATA_DIRECTORY}`.
 
 Resources in the user data directory will be found by all Camunda Modeler instances.
 
-### Example (Windows):
+### Example (Windows)
 
 ```
 └── AppData


### PR DESCRIPTION
## What is the purpose of the change

_Briefly describe the change you are making, this helps the reviewer by providing an overview._

Rephrased documentation of configuring element templates to distinct between element templates available for all diagrams (`resouces/element-templates`) and element templates available for specific diagrams only (`.camunda/element-templates)`. This is based on feedback from our QA engineers and a follow-up to https://github.com/camunda/camunda-modeler/pull/3561.

## Are there related marketing activities

No.

## When should this change go live?

Immediately.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
