### PR TITLE
docs(status): add status page to sidebars 8.0+

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -694,6 +694,7 @@ module.exports = {
     "reference/release-notes",
     "reference/licenses",
     "reference/notices",
+    "reference/status",
     "reference/release-policy",
     "reference/early-access",
     "reference/supported-environments",

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -748,6 +748,7 @@
     "reference/announcements",
     "reference/licenses",
     "reference/notices",
+    "reference/status",
     "reference/release-policy",
     "reference/supported-environments",
     "reference/dependencies"

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -796,6 +796,7 @@
     "reference/release-notes",
     "reference/licenses",
     "reference/notices",
+    "reference/status",
     "reference/release-policy",
     "reference/early-access",
     "reference/supported-environments",

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -846,6 +846,7 @@
     "reference/release-notes",
     "reference/licenses",
     "reference/notices",
+    "reference/status",
     "reference/release-policy",
     "reference/early-access",
     "reference/supported-environments",


### PR DESCRIPTION
## What is the purpose of the change

Caught the missing status page that wasn't in the sidebar.

## Are there related marketing activities

No

## When should this change go live?

Technically its a bug, but it's gone unnoticed for a while and the link is on the Reference overview.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
