### PR TITLE
docs(connectors): update changes to reflect 8.2 release

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/http-webhook.md
+++ b/docs/components/connectors/out-of-the-box-connectors/http-webhook.md
@@ -27,7 +27,7 @@ Please refer to the [update guide](../../../../guides/update-guide/connectors/06
 ![HTTP Webhook prefilled](../img/use-inbound-connector-template-filled.png)
 
 1. In the **Webhook Configuration** section, configure the **Webhook ID**. By default, **Webhook ID** is pre-filled with a random value. This value will be part of the Webhook URL. You will find more details about HTTP Webhook URLs [below](#activate-the-http-webhook-connector-by-deploying-your-diagram).
-2. (Optional) Configure [HMAC authentication](https://en.wikipedia.org/wiki/HMAC) if required. **Not recommended:** leave it `disabled` to ignore HMAC verification if your use case doesn't require verification or your use case is not yet supported.
+2. Configure [HMAC authentication](https://en.wikipedia.org/wiki/HMAC) if required.
 
 - Set the HMAC shared secret key which is used to calculate the message hash. The value is defined by a webhook administrator.
 - Set the HMAC header whose value contains an encrypted hash message. The exact value is provided by the external caller.
@@ -39,6 +39,11 @@ Please refer to the [update guide](../../../../guides/update-guide/connectors/06
 ## Activate the HTTP Webhook Connector by deploying your diagram
 
 Once you click the **Deploy** button, your HTTP Webhook will be activated and publicly available.
+You can trigger it by making a POST request to the generated URL.
+
+:::note
+HTTP Webhook Connector currently supports only POST requests.
+:::
 
 URLs of the exposed HTTP Webhooks adhere to the following pattern:
 

--- a/docs/self-managed/connectors-deployment/connectors-configuration.md
+++ b/docs/self-managed/connectors-deployment/connectors-configuration.md
@@ -66,6 +66,7 @@ However, if you still wish to do so, you need to start your Connectors runtime w
 CAMUNDA_CONNECTOR_POLLING_ENABLED=false
 CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false
 SPRING_MAIN_WEB-APPLICATION-TYPE=none
+OPERATE_CLIENT_ENABLED=false
 ```
 
 ## Manual discovery of Connectors
@@ -104,7 +105,7 @@ docker run --rm --name=connectors -d \
   --network=your-zeebe-network \                                      # Optional: attach to network if Zeebe is isolated with Docker network
   -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \  # Specify Zeebe address
   -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                           # Optional: provide security configs to connect to Zeebe
-  camunda/connectors:0.5.0
+  camunda/connectors:latest
 ```
 
 The secret `MY_SECRET` value is specified directly in the `docker run` call,
@@ -141,7 +142,7 @@ docker run --rm --name=connectors -d \
   -v $PWD/my-secret-provider-with-dependencies.jar:/opt/app/my-secret-provider-with-dependencies.jar \  # Specify secret provider
   -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \                                    # Specify Zeebe address
   -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                                                             # Optional: provide security configs to connect to Zeebe
-  camunda/connectors:0.5.0
+  camunda/connectors:latest
 ```
 
 In manual installations, add the JAR to the `-cp` argument of the Java call:

--- a/docs/self-managed/connectors-deployment/install-and-start.md
+++ b/docs/self-managed/connectors-deployment/install-and-start.md
@@ -25,18 +25,34 @@ For the [out-of-the-box Connectors](/components/connectors/out-of-the-box-connec
 the Connectors Bundle project provides a set of all Connector templates related to one [release version](https://github.com/camunda/connectors-bundle/releases).
 If you use the [Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose) installation, you can thus fetch all Connector templates that match the versions of the Connectors used in the backend.
 
-Alternatively, you can fetch the JSON templates from the respective Connector's releases:
+Alternatively, you can fetch the JSON templates from the respective Connector's releases at respective connectors folder in the [bundle repository](https://github.com/camunda/connectors-bundle)
+at `connectors/{connector name}/element-templates`:
 
-- [Amazon SNS Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/sns/element-templates)
-- [Amazon SQS Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/sqs/element-templates)
-- [AWS Lambda Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/aws-lambda/element-templates)
-- [Google Drive Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/google-drive/element-templates)
-- [Kafka Producer Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/kafka/element-templates)
-- [Microsoft Teams Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/microsoft-teams/element-templates)
-- [RabbitMQ Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/rabbitmq/element-templates)
-- [REST Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/http-json/element-templates)
-- [SendGrid Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/sendgrid/element-templates)
-- [Slack Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/slack/element-templates)
+| Connector                      | License                                      |
+| ------------------------------ | -------------------------------------------- |
+| Asana Connector                | [Camunda Platform Self-Managed Free Edition] |
+| Automation Anywhere Connector  | [Camunda Platform Self-Managed Free Edition] |
+| Amazon SNS Connector           | [Camunda Platform Self-Managed Free Edition] |
+| Amazon SQS Connector           | [Camunda Platform Self-Managed Free Edition] |
+| AWS Lambda Connector           | [Camunda Platform Self-Managed Free Edition] |
+| Camunda Operate Connector      | [Camunda Platform Self-Managed Free Edition] |
+| Easy Post Connector            | [Camunda Platform Self-Managed Free Edition] |
+| GitHub Connector               | [Camunda Platform Self-Managed Free Edition] |
+| GitHub Webhook Connector       | [Camunda Platform Self-Managed Free Edition] |
+| GitLab Connector               | [Camunda Platform Self-Managed Free Edition] |
+| Google Drive Connector         | [Camunda Platform Self-Managed Free Edition] |
+| Google Maps Platform Connector | [Camunda Platform Self-Managed Free Edition] |
+| GraphQL Connector              | [Camunda Platform Self-Managed Free Edition] |
+| HTTP Webhook Connector         | [Camunda Platform Self-Managed Free Edition] |
+| Kafka Producer Connector       | [Camunda Platform Self-Managed Free Edition] |
+| Microsoft Teams Connector      | [Camunda Platform Self-Managed Free Edition] |
+| OpenAI Connector               | [Camunda Platform Self-Managed Free Edition] |
+| Power Automate Connector       | [Camunda Platform Self-Managed Free Edition] |
+| RabbitMQ Connector             | [Camunda Platform Self-Managed Free Edition] |
+| REST Connector                 | [Apache 2.0]                                 |
+| SendGrid Connector             | [Camunda Platform Self-Managed Free Edition] |
+| Slack Connector                | [Camunda Platform Self-Managed Free Edition] |
+| UiPath Connector               | [Camunda Platform Self-Managed Free Edition] |
 
 You can use the Connector templates as provided or modify them to your needs as described in our [Connector templates guide](/components/connectors/custom-built-connectors/connector-templates.md).
 

--- a/docs/self-managed/connectors-deployment/install-and-start.md
+++ b/docs/self-managed/connectors-deployment/install-and-start.md
@@ -17,6 +17,11 @@ The Connector runtime environment can be installed using the supported [deployme
 Currently, we support an installation of Connectors with [Docker](/self-managed/platform-deployment/docker.md#connectors),
 [Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose), and the [manual setup](/self-managed/platform-deployment/manual.md#run-connectors).
 
+:::note
+Inbound Connectors require Operate to be deployed as part of your Camunda Platform Self-Managed installation.
+If you don't use Operate with your cluster, you can still use Outbound Connectors.
+:::
+
 ## Connector templates
 
 For the modeling interface, you need to [provide Connector templates](/components/connectors/custom-built-connectors/connector-templates.md#providing-and-using-connector-templates).

--- a/docs/self-managed/platform-deployment/docker.md
+++ b/docs/self-managed/platform-deployment/docker.md
@@ -187,6 +187,20 @@ Find an overview in the [Connectors Bundle project](https://github.com/camunda/c
 
 Refer to the [Connector installation guide](../../connectors-deployment/install-and-start) for details on how to provide the Connector templates for modeling.
 
+#### Running single Connectors container
+
+```shell
+docker run --rm --name=MyConnectorsInstance \
+  --network=camunda-platform_camunda-platform \
+  -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500 \
+  -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \
+  -e CAMUNDA_CONNECTOR_POLLING_ENABLED=false \
+  -e CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false \
+  -e OPERATE_CLIENT_ENABLED=false \
+  -e SPRING_MAIN_WEB-APPLICATION-TYPE=none \
+    camunda/connectors-bundle:latest
+```
+
 #### Custom set of Connectors
 
 To add custom Connectors, you can build on top of our [Connectors base image](https://hub.docker.com/r/camunda/connectors/) that includes the pre-packaged runtime environment without any Connector.
@@ -202,13 +216,13 @@ To prevent this, common dependencies like `jackson` can be shaded and relocated 
 You can add a Connector JAR by extending the base image with a JAR from a public URL:
 
 ```yml
-FROM camunda/connectors:0.3.0
+FROM camunda/connectors:x.y.z
 
-ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/0.11.0/connector-http-json-0.11.0-with-dependencies.jar /opt/app/
+ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/x.y.z/connector-http-json-0..0-with-dependencies.jar /opt/app/
 ```
 
 You can also add a Connector JAR using volumes:
 
 ```bash
-docker run --rm --name=connectors -d -v $PWD/connector.jar:/opt/app/ camunda/connectors:0.3.0
+docker run --rm --name=connectors -d -v $PWD/connector.jar:/opt/app/ camunda/connectors:x.y.z
 ```

--- a/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
@@ -23,13 +23,10 @@ The following charts will be installed as part of Camunda Platform 8 Self-Manage
 - **Tasklist**: Deploys the Tasklist component to work with user tasks.
 - **Optimize**: Deploys the Optimize component to analyze the historic process executions.
 - **Identity**: Deploys the Identity component responsible for authentication and authorization.
+- **Connectors**: Deploys the Connectors component responsible for both inbound and outbound integration with external systems.
 - **Elasticsearch**: Deploys an Elasticsearch cluster with two nodes.
 - **Web Modeler**: Deploys the Web Modeler component that allows you to model BPMN processes in a collaborative way.
   - _Note_: The chart is disabled by default and needs to be [enabled explicitly](#installing-web-modeler) as Web Modeler is only available to enterprise customers.
-
-:::note Connectors
-We do not provide a Helm chart for Connectors in Self-Managed yet.
-:::
 
 ![Camunda Platform 8 Self-Managed Architecture Diagram](../../platform-architecture/assets/camunda-platform-8-self-managed-architecture-diagram-combined-ingress.png)
 
@@ -90,6 +87,7 @@ NAME                                           READY   STATUS              RESTA
 <RELEASE_NAME>-identity-6bb5d864cc-kk6dv        0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-operate-cb597fd76-6vr2x          0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-optimize-676955b547-vxts7        0/1     ContainerCreating   0          4s
+<RELEASE_NAME>-connectors-1bba590ff-a63dc       0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-postgresql-0                     0/1     Pending             0          4s
 <RELEASE_NAME>-tasklist-5bf5c56f7b-sdwg7        0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-zeebe-0                          0/1     Pending             0          4s
@@ -113,6 +111,7 @@ This will return something similar to the following:
 NAME                                                   READY   STATUS    RESTARTS   AGE
 elasticsearch-master-0                                 1/1     Running   0          4m6s
 <RELEASE_NAME>-operate-XXX                             1/1     Running   0          4m6s
+<RELEASE_NAME>-connectors-XXX                          1/1     Running   0          4m6s
 <RELEASE_NAME>-zeebe-0                                 1/1     Running   0          4m6s
 <RELEASE_NAME>-tasklist-XXX                            1/1     Running   0          4m6s
 <RELEASE_NAME>-zeebe-gateway                           1/1     Running   0          4m6s

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress.md
@@ -41,6 +41,8 @@ kubectl port-forward svc/<RELEASE_NAME>-operate  8081:80
 kubectl port-forward svc/<RELEASE_NAME>-tasklist 8082:80
 
 kubectl port-forward svc/<RELEASE_NAME>-optimize 8083:80
+
+kubectl port-forward svc/<RELEASE_NAME>-connectors 8088:8080
 ```
 
 To be able to use Web Modeler, create additional port-forwardings for Web Modeler itself and Keycloak (assuming that Keycloak is installed as part of the Helm release):
@@ -82,3 +84,6 @@ Log in to these services using the `demo`/`demo` credentials.
 If you deploy process definitions, they will appear in the dashboard. Then, you can drill down to see your active instances.
 
 You can deploy and create new instances using the Zeebe clients or `zbctl`.
+
+You can also trigger **Connectors** inbound webhook, given you deployed one.
+You can do so with the following example: `curl -X POST -H "Content-Type: application/json" -d '{"myId": 123456, "myMessage": "Hello, world!"}' http://localhost:8088/inbound/<YOUR_WEBHOOK_ID>`.

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -15,6 +15,7 @@ The following images must be available in your air-gapped environment:
 - [camunda/operate](https://hub.docker.com/r/camunda/operate)
 - [camunda/tasklist](https://hub.docker.com/r/camunda/tasklist)
 - [camunda/optimize](https://hub.docker.com/r/camunda/optimize)
+- [camunda/connectors-bundle](https://hub.docker.com/r/camunda/connectors-bundle)
 - [camunda/identity](https://hub.docker.com/r/camunda/identity)
 - [postgres](https://hub.docker.com/_/postgres)
 - [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak)
@@ -48,6 +49,7 @@ camunda-platform
     |_ optimize
     |_ operate
     |_ tasklist
+    |_ connectors
     |_ postgresql
 ```
 
@@ -55,6 +57,7 @@ camunda-platform
 - PostgreSQL is a dependency for Web Modeler.
   - This dependency is optional as you can either install PostgreSQL with Helm or use an existing [external database](../deploy.md#optional-configure-external-database).
 - Elasticsearch is a dependency for Zeebe, Operate, Tasklist, and Optimize.
+- Connectors can be stand-alone; however if there's an intention to use inbound capabilities, Operate becomes a dependency.
 
 The values for the dependencies Keycloak and PostgreSQL can be set in the same hierarchy:
 
@@ -141,6 +144,10 @@ tasklist:
 optimize:
   image:
     repository: example.jfrog.io/camunda/optimize
+    ...
+connectors:
+  image:
+    repository: example.jfrog.io/camunda/connectors-bundle
     ...
 webModeler:
   image:

--- a/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -62,6 +62,7 @@ To extract the secrets, use the following code snippet. Make sure to replace `<R
 export TASKLIST_SECRET=$(kubectl get secret "<RELEASE_NAME>-tasklist-identity-secret" -o jsonpath="{.data.tasklist-secret}" | base64 --decode)
 export OPTIMIZE_SECRET=$(kubectl get secret "<RELEASE_NAME>-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
 export OPERATE_SECRET=$(kubectl get secret "<RELEASE_NAME>-operate-identity-secret" -o jsonpath="{.data.operate-secret}" | base64 --decode)
+export CONNECTORS_SECRET=$(kubectl get secret "<RELEASE_NAME>-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
 export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
 export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
 export POSTGRESQL_SECRET=$(kubectl get secret "<RELEASE_NAME>-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
@@ -74,6 +75,7 @@ helm upgrade <RELEASE_NAME> charts/camunda-platform/ \
   --set global.identity.auth.tasklist.existingSecret=$TASKLIST_SECRET \
   --set global.identity.auth.optimize.existingSecret=$OPTIMIZE_SECRET \
   --set global.identity.auth.operate.existingSecret=$OPERATE_SECRET \
+  --set global.identity.auth.connectors.existingSecret=$CONNECTORS_SECRET \
   --set identity.keycloak.auth.adminPassword=$KEYCLOAK_ADMIN_SECRET \
   --set identity.keycloak.auth.managementPassword=$KEYCLOAK_MANAGEMENT_SECRET \
   --set identity.keycloak.postgresql.auth.password=$POSTGRESQL_SECRET

--- a/docs/self-managed/platform-deployment/overview.md
+++ b/docs/self-managed/platform-deployment/overview.md
@@ -14,7 +14,7 @@ Camunda Platform 8 includes the following components:
 - Zeebe Broker and Gateway
 - Operate (requiring Elasticsearch)
 - Tasklist (requiring Elasticsearch)
-- Connectors
+- Connectors (requiring Operate)
 - Optimize (requiring Elasticsearch)
 - Identity (requiring Keycloak)
 - Web Modeler (requiring Identity, Keycloak, and PostgreSQL) [<span class="badge badge--enterprise-only">Enterprise only</span>](../../../reference/licenses/#web-modeler)

--- a/versioned_docs/version-8.0/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.0/self-managed/connectors-deployment/connectors-configuration.md
@@ -116,7 +116,7 @@ to inject multiple secrets at once.
 
 ### Secrets in manual installations
 
-In the [manual setup](../platform-deployment/manual.md#run-connectors), inject secrets during Connector execution by providing
+In the [manual setup](../platform-deployment/local.md#run-connectors), inject secrets during Connector execution by providing
 them as environment variables before starting the runtime environment. You can, for example, export them beforehand as follows:
 
 ```bash

--- a/versioned_docs/version-8.0/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.0/self-managed/connectors-deployment/connectors-configuration.md
@@ -40,6 +40,8 @@ ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=127.0.0.1:26500
 ZEEBE_CLIENT_SECURITY_PLAINTEXT=true
 ```
 
+If the Zeebe Gateway is set up with Camunda Identity-based authorization, [Zeebe client OAuth environment variables](../zeebe-deployment/security/client-authorization.md#environment-variables) must be provided.
+
 Connect to Operate locally using username and password:
 
 ```bash
@@ -64,6 +66,7 @@ However, if you still wish to do so, you need to start your Connectors runtime w
 CAMUNDA_CONNECTOR_POLLING_ENABLED=false
 CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false
 SPRING_MAIN_WEB-APPLICATION-TYPE=none
+OPERATE_CLIENT_ENABLED=false
 ```
 
 ## Manual discovery of Connectors
@@ -102,7 +105,7 @@ docker run --rm --name=connectors -d \
   --network=your-zeebe-network \                                      # Optional: attach to network if Zeebe is isolated with Docker network
   -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \  # Specify Zeebe address
   -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                           # Optional: provide security configs to connect to Zeebe
-  camunda/connectors:0.5.0
+  camunda/connectors:latest
 ```
 
 The secret `MY_SECRET` value is specified directly in the `docker run` call,
@@ -113,7 +116,7 @@ to inject multiple secrets at once.
 
 ### Secrets in manual installations
 
-In the [manual setup](../platform-deployment/local.md#run-connectors), inject secrets during Connector execution by providing
+In the [manual setup](../platform-deployment/manual.md#run-connectors), inject secrets during Connector execution by providing
 them as environment variables before starting the runtime environment. You can, for example, export them beforehand as follows:
 
 ```bash
@@ -139,7 +142,7 @@ docker run --rm --name=connectors -d \
   -v $PWD/my-secret-provider-with-dependencies.jar:/opt/app/my-secret-provider-with-dependencies.jar \  # Specify secret provider
   -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \                                    # Specify Zeebe address
   -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                                                             # Optional: provide security configs to connect to Zeebe
-  camunda/connectors:0.5.0
+  camunda/connectors:latest
 ```
 
 In manual installations, add the JAR to the `-cp` argument of the Java call:

--- a/versioned_docs/version-8.0/self-managed/connectors-deployment/install-and-start.md
+++ b/versioned_docs/version-8.0/self-managed/connectors-deployment/install-and-start.md
@@ -15,7 +15,7 @@ The concept of a [Connector](/components/connectors/introduction.md) consists of
 The Connector runtime environment can be installed using the supported [deployment options](/self-managed/platform-deployment/platform-8-deployment.md#deployment-options).
 
 Currently, we support an installation of Connectors with [Docker](/self-managed/platform-deployment/docker.md#connectors),
-[Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose), and the [manual setup](/self-managed/platform-deployment/manual.md#run-connectors).
+[Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose), and the [manual setup](/self-managed/platform-deployment/local.md#run-connectors).
 
 ## Connector templates
 

--- a/versioned_docs/version-8.0/self-managed/connectors-deployment/install-and-start.md
+++ b/versioned_docs/version-8.0/self-managed/connectors-deployment/install-and-start.md
@@ -12,7 +12,7 @@ The concept of a [Connector](/components/connectors/introduction.md) consists of
 
 ## Connector runtime and function
 
-The Connector runtime environment can be installed using the supported [deployment options](/self-managed/platform-deployment/overview.md#deployment-options).
+The Connector runtime environment can be installed using the supported [deployment options](/self-managed/platform-deployment/platform-8-deployment.md#deployment-options).
 
 Currently, we support an installation of Connectors with [Docker](/self-managed/platform-deployment/docker.md#connectors),
 [Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose), and the [manual setup](/self-managed/platform-deployment/manual.md#run-connectors).

--- a/versioned_docs/version-8.0/self-managed/connectors-deployment/install-and-start.md
+++ b/versioned_docs/version-8.0/self-managed/connectors-deployment/install-and-start.md
@@ -12,10 +12,10 @@ The concept of a [Connector](/components/connectors/introduction.md) consists of
 
 ## Connector runtime and function
 
-The Connector runtime environment can be installed using the supported [deployment options](/self-managed/platform-deployment/platform-8-deployment.md#deployment-options).
+The Connector runtime environment can be installed using the supported [deployment options](/self-managed/platform-deployment/overview.md#deployment-options).
 
 Currently, we support an installation of Connectors with [Docker](/self-managed/platform-deployment/docker.md#connectors),
-[Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose), and the [manual setup](/self-managed/platform-deployment/local.md#run-connectors).
+[Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose), and the [manual setup](/self-managed/platform-deployment/manual.md#run-connectors).
 
 ## Connector templates
 
@@ -25,18 +25,34 @@ For the [out-of-the-box Connectors](/components/connectors/out-of-the-box-connec
 the Connectors Bundle project provides a set of all Connector templates related to one [release version](https://github.com/camunda/connectors-bundle/releases).
 If you use the [Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose) installation, you can thus fetch all Connector templates that match the versions of the Connectors used in the backend.
 
-Alternatively, you can fetch the JSON templates from the respective Connector's releases:
+Alternatively, you can fetch the JSON templates from the respective Connector's releases at respective connectors folder in the [bundle repository](https://github.com/camunda/connectors-bundle)
+at `connectors/{connector name}/element-templates`:
 
-- [Amazon SNS Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/sns/element-templates)
-- [Amazon SQS Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/sqs/element-templates)
-- [AWS Lambda Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/aws-lambda/element-templates)
-- [Google Drive Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/google-drive/element-templates)
-- [Kafka Producer Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/kafka/element-templates)
-- [Microsoft Teams Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/microsoft-teams/element-templates)
-- [RabbitMQ Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/rabbitmq/element-templates)
-- [REST Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/http-json/element-templates)
-- [SendGrid Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/sendgrid/element-templates)
-- [Slack Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/slack/element-templates)
+| Connector                      | License                                      |
+| ------------------------------ | -------------------------------------------- |
+| Asana Connector                | [Camunda Platform Self-Managed Free Edition] |
+| Automation Anywhere Connector  | [Camunda Platform Self-Managed Free Edition] |
+| Amazon SNS Connector           | [Camunda Platform Self-Managed Free Edition] |
+| Amazon SQS Connector           | [Camunda Platform Self-Managed Free Edition] |
+| AWS Lambda Connector           | [Camunda Platform Self-Managed Free Edition] |
+| Camunda Operate Connector      | [Camunda Platform Self-Managed Free Edition] |
+| Easy Post Connector            | [Camunda Platform Self-Managed Free Edition] |
+| GitHub Connector               | [Camunda Platform Self-Managed Free Edition] |
+| GitHub Webhook Connector       | [Camunda Platform Self-Managed Free Edition] |
+| GitLab Connector               | [Camunda Platform Self-Managed Free Edition] |
+| Google Drive Connector         | [Camunda Platform Self-Managed Free Edition] |
+| Google Maps Platform Connector | [Camunda Platform Self-Managed Free Edition] |
+| GraphQL Connector              | [Camunda Platform Self-Managed Free Edition] |
+| HTTP Webhook Connector         | [Camunda Platform Self-Managed Free Edition] |
+| Kafka Producer Connector       | [Camunda Platform Self-Managed Free Edition] |
+| Microsoft Teams Connector      | [Camunda Platform Self-Managed Free Edition] |
+| OpenAI Connector               | [Camunda Platform Self-Managed Free Edition] |
+| Power Automate Connector       | [Camunda Platform Self-Managed Free Edition] |
+| RabbitMQ Connector             | [Camunda Platform Self-Managed Free Edition] |
+| REST Connector                 | [Apache 2.0]                                 |
+| SendGrid Connector             | [Camunda Platform Self-Managed Free Edition] |
+| Slack Connector                | [Camunda Platform Self-Managed Free Edition] |
+| UiPath Connector               | [Camunda Platform Self-Managed Free Edition] |
 
 You can use the Connector templates as provided or modify them to your needs as described in our [Connector templates guide](/components/connectors/custom-built-connectors/connector-templates.md).
 

--- a/versioned_docs/version-8.0/self-managed/platform-deployment/docker.md
+++ b/versioned_docs/version-8.0/self-managed/platform-deployment/docker.md
@@ -147,6 +147,20 @@ Find an overview in the [Connectors Bundle project](https://github.com/camunda/c
 
 Refer to the [Connector installation guide](../../connectors-deployment/install-and-start) for details on how to provide the Connector templates for modeling.
 
+#### Running single Connectors container
+
+```shell
+docker run --rm --name=MyConnectorsInstance \
+  --network=camunda-platform_camunda-platform \
+  -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500 \
+  -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \
+  -e CAMUNDA_CONNECTOR_POLLING_ENABLED=false \
+  -e CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false \
+  -e OPERATE_CLIENT_ENABLED=false \
+  -e SPRING_MAIN_WEB-APPLICATION-TYPE=none \
+    camunda/connectors-bundle:latest
+```
+
 #### Custom set of Connectors
 
 To add custom Connectors, you can build on top of our [Connectors base image](https://hub.docker.com/r/camunda/connectors/) that includes the pre-packaged runtime environment without any Connector.
@@ -162,13 +176,13 @@ To prevent this, common dependencies like `jackson` can be shaded and relocated 
 You can add a Connector JAR by extending the base image with a JAR from a public URL:
 
 ```yml
-FROM camunda/connectors:0.3.0
+FROM camunda/connectors:x.y.z
 
-ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/0.11.0/connector-http-json-0.11.0-with-dependencies.jar /opt/app/
+ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/x.y.z/connector-http-json-0..0-with-dependencies.jar /opt/app/
 ```
 
 You can also add a Connector JAR using volumes:
 
 ```bash
-docker run --rm --name=connectors -d -v $PWD/connector.jar:/opt/app/ camunda/connectors:0.3.0
+docker run --rm --name=connectors -d -v $PWD/connector.jar:/opt/app/ camunda/connectors:x.y.z
 ```

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/http-webhook.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/http-webhook.md
@@ -27,7 +27,7 @@ Please refer to the [update guide](../../../../guides/update-guide/connectors/06
 ![HTTP Webhook prefilled](../img/use-inbound-connector-template-filled.png)
 
 1. In the **Webhook Configuration** section, configure the **Webhook ID**. By default, **Webhook ID** is pre-filled with a random value. This value will be part of the Webhook URL. You will find more details about HTTP Webhook URLs [below](#activate-the-http-webhook-connector-by-deploying-your-diagram).
-2. (Optional) Configure [HMAC authentication](https://en.wikipedia.org/wiki/HMAC) if required. **Not recommended:** leave it `disabled` to ignore HMAC verification if your use case doesn't require verification or your use case is not yet supported.
+2. Configure [HMAC authentication](https://en.wikipedia.org/wiki/HMAC) if required.
 
 - Set the HMAC shared secret key which is used to calculate the message hash. The value is defined by a webhook administrator.
 - Set the HMAC header whose value contains an encrypted hash message. The exact value is provided by the external caller.
@@ -39,6 +39,11 @@ Please refer to the [update guide](../../../../guides/update-guide/connectors/06
 ## Activate the HTTP Webhook Connector by deploying your diagram
 
 Once you click the **Deploy** button, your HTTP Webhook will be activated and publicly available.
+You can trigger it by making a POST request to the generated URL.
+
+:::note
+HTTP Webhook Connector currently supports only POST requests.
+:::
 
 URLs of the exposed HTTP Webhooks adhere to the following pattern:
 

--- a/versioned_docs/version-8.1/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.1/self-managed/connectors-deployment/connectors-configuration.md
@@ -40,6 +40,8 @@ ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=127.0.0.1:26500
 ZEEBE_CLIENT_SECURITY_PLAINTEXT=true
 ```
 
+If the Zeebe Gateway is set up with Camunda Identity-based authorization, [Zeebe client OAuth environment variables](../zeebe-deployment/security/client-authorization.md#environment-variables) must be provided.
+
 Connect to Operate locally using username and password:
 
 ```bash
@@ -64,6 +66,7 @@ However, if you still wish to do so, you need to start your Connectors runtime w
 CAMUNDA_CONNECTOR_POLLING_ENABLED=false
 CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false
 SPRING_MAIN_WEB-APPLICATION-TYPE=none
+OPERATE_CLIENT_ENABLED=false
 ```
 
 ## Manual discovery of Connectors
@@ -102,7 +105,7 @@ docker run --rm --name=connectors -d \
   --network=your-zeebe-network \                                      # Optional: attach to network if Zeebe is isolated with Docker network
   -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \  # Specify Zeebe address
   -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                           # Optional: provide security configs to connect to Zeebe
-  camunda/connectors:0.5.0
+  camunda/connectors:latest
 ```
 
 The secret `MY_SECRET` value is specified directly in the `docker run` call,
@@ -139,7 +142,7 @@ docker run --rm --name=connectors -d \
   -v $PWD/my-secret-provider-with-dependencies.jar:/opt/app/my-secret-provider-with-dependencies.jar \  # Specify secret provider
   -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \                                    # Specify Zeebe address
   -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                                                             # Optional: provide security configs to connect to Zeebe
-  camunda/connectors:0.5.0
+  camunda/connectors:latest
 ```
 
 In manual installations, add the JAR to the `-cp` argument of the Java call:

--- a/versioned_docs/version-8.1/self-managed/connectors-deployment/install-and-start.md
+++ b/versioned_docs/version-8.1/self-managed/connectors-deployment/install-and-start.md
@@ -25,18 +25,34 @@ For the [out-of-the-box Connectors](/components/connectors/out-of-the-box-connec
 the Connectors Bundle project provides a set of all Connector templates related to one [release version](https://github.com/camunda/connectors-bundle/releases).
 If you use the [Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose) installation, you can thus fetch all Connector templates that match the versions of the Connectors used in the backend.
 
-Alternatively, you can fetch the JSON templates from the respective Connector's releases:
+Alternatively, you can fetch the JSON templates from the respective Connector's releases at respective connectors folder in the [bundle repository](https://github.com/camunda/connectors-bundle)
+at `connectors/{connector name}/element-templates`:
 
-- [Amazon SNS Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/sns/element-templates)
-- [Amazon SQS Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/sqs/element-templates)
-- [AWS Lambda Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/aws-lambda/element-templates)
-- [Google Drive Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/google-drive/element-templates)
-- [Kafka Producer Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/kafka/element-templates)
-- [Microsoft Teams Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/microsoft-teams/element-templates)
-- [RabbitMQ Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/rabbitmq/element-templates)
-- [REST Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/http-json/element-templates)
-- [SendGrid Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/sendgrid/element-templates)
-- [Slack Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/slack/element-templates)
+| Connector                      | License                                      |
+| ------------------------------ | -------------------------------------------- |
+| Asana Connector                | [Camunda Platform Self-Managed Free Edition] |
+| Automation Anywhere Connector  | [Camunda Platform Self-Managed Free Edition] |
+| Amazon SNS Connector           | [Camunda Platform Self-Managed Free Edition] |
+| Amazon SQS Connector           | [Camunda Platform Self-Managed Free Edition] |
+| AWS Lambda Connector           | [Camunda Platform Self-Managed Free Edition] |
+| Camunda Operate Connector      | [Camunda Platform Self-Managed Free Edition] |
+| Easy Post Connector            | [Camunda Platform Self-Managed Free Edition] |
+| GitHub Connector               | [Camunda Platform Self-Managed Free Edition] |
+| GitHub Webhook Connector       | [Camunda Platform Self-Managed Free Edition] |
+| GitLab Connector               | [Camunda Platform Self-Managed Free Edition] |
+| Google Drive Connector         | [Camunda Platform Self-Managed Free Edition] |
+| Google Maps Platform Connector | [Camunda Platform Self-Managed Free Edition] |
+| GraphQL Connector              | [Camunda Platform Self-Managed Free Edition] |
+| HTTP Webhook Connector         | [Camunda Platform Self-Managed Free Edition] |
+| Kafka Producer Connector       | [Camunda Platform Self-Managed Free Edition] |
+| Microsoft Teams Connector      | [Camunda Platform Self-Managed Free Edition] |
+| OpenAI Connector               | [Camunda Platform Self-Managed Free Edition] |
+| Power Automate Connector       | [Camunda Platform Self-Managed Free Edition] |
+| RabbitMQ Connector             | [Camunda Platform Self-Managed Free Edition] |
+| REST Connector                 | [Apache 2.0]                                 |
+| SendGrid Connector             | [Camunda Platform Self-Managed Free Edition] |
+| Slack Connector                | [Camunda Platform Self-Managed Free Edition] |
+| UiPath Connector               | [Camunda Platform Self-Managed Free Edition] |
 
 You can use the Connector templates as provided or modify them to your needs as described in our [Connector templates guide](/components/connectors/custom-built-connectors/connector-templates.md).
 

--- a/versioned_docs/version-8.1/self-managed/connectors-deployment/install-and-start.md
+++ b/versioned_docs/version-8.1/self-managed/connectors-deployment/install-and-start.md
@@ -17,6 +17,11 @@ The Connector runtime environment can be installed using the supported [deployme
 Currently, we support an installation of Connectors with [Docker](/self-managed/platform-deployment/docker.md#connectors),
 [Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose), and the [manual setup](/self-managed/platform-deployment/manual.md#run-connectors).
 
+:::note
+Inbound Connectors require Operate to be deployed as part of your Camunda Platform Self-Managed installation.
+If you don't use Operate with your cluster, you can still use Outbound Connectors.
+:::
+
 ## Connector templates
 
 For the modeling interface, you need to [provide Connector templates](/components/connectors/custom-built-connectors/connector-templates.md#providing-and-using-connector-templates).

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/docker.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/docker.md
@@ -183,6 +183,20 @@ Find an overview in the [Connectors Bundle project](https://github.com/camunda/c
 
 Refer to the [Connector installation guide](../../connectors-deployment/install-and-start) for details on how to provide the Connector templates for modeling.
 
+#### Running single Connectors container
+
+```shell
+docker run --rm --name=MyConnectorsInstance \
+  --network=camunda-platform_camunda-platform \
+  -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500 \
+  -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \
+  -e CAMUNDA_CONNECTOR_POLLING_ENABLED=false \
+  -e CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false \
+  -e OPERATE_CLIENT_ENABLED=false \
+  -e SPRING_MAIN_WEB-APPLICATION-TYPE=none \
+    camunda/connectors-bundle:latest
+```
+
 #### Custom set of Connectors
 
 To add custom Connectors, you can build on top of our [Connectors base image](https://hub.docker.com/r/camunda/connectors/) that includes the pre-packaged runtime environment without any Connector.
@@ -198,13 +212,13 @@ To prevent this, common dependencies like `jackson` can be shaded and relocated 
 You can add a Connector JAR by extending the base image with a JAR from a public URL:
 
 ```yml
-FROM camunda/connectors:0.3.0
+FROM camunda/connectors:x.y.z
 
-ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/0.11.0/connector-http-json-0.11.0-with-dependencies.jar /opt/app/
+ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/x.y.z/connector-http-json-0..0-with-dependencies.jar /opt/app/
 ```
 
 You can also add a Connector JAR using volumes:
 
 ```bash
-docker run --rm --name=connectors -d -v $PWD/connector.jar:/opt/app/ camunda/connectors:0.3.0
+docker run --rm --name=connectors -d -v $PWD/connector.jar:/opt/app/ camunda/connectors:x.y.z
 ```

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/deploy.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/deploy.md
@@ -21,6 +21,7 @@ The following charts will be installed as part of Camunda Platform 8 Self-Manage
 - **Zeebe Gateway**: Deploys the standalone Zeebe Gateway with two replicas.
 - **Operate**: Deploys Operate, which connects to an existing Elasticsearch.
 - **Tasklist**: Deploys the Tasklist component to work with user tasks.
+- **Connectors**: Deploys the Connectors component responsible for both inbound and outbound integration with external systems.
 - **Optimize**: Deploys the Optimize component to analyze the historic process executions.
 - **Identity**: Deploys the Identity component responsible for authentication and authorization.
 - **Elasticsearch**: Deploys an Elasticsearch cluster with two nodes.
@@ -90,6 +91,7 @@ NAME                                           READY   STATUS              RESTA
 <RELEASE_NAME>-identity-6bb5d864cc-kk6dv        0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-operate-cb597fd76-6vr2x          0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-optimize-676955b547-vxts7        0/1     ContainerCreating   0          4s
+<RELEASE_NAME>-connectors-1bba590ff-a63dc       0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-postgresql-0                     0/1     Pending             0          4s
 <RELEASE_NAME>-tasklist-5bf5c56f7b-sdwg7        0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-zeebe-0                          0/1     Pending             0          4s
@@ -113,6 +115,7 @@ This will return something similar to the following:
 NAME                                                   READY   STATUS    RESTARTS   AGE
 elasticsearch-master-0                                 1/1     Running   0          4m6s
 <RELEASE_NAME>-operate-XXX                             1/1     Running   0          4m6s
+<RELEASE_NAME>-connectors-XXX                          1/1     Running   0          4m6s
 <RELEASE_NAME>-zeebe-0                                 1/1     Running   0          4m6s
 <RELEASE_NAME>-tasklist-XXX                            1/1     Running   0          4m6s
 <RELEASE_NAME>-zeebe-gateway                           1/1     Running   0          4m6s

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress.md
@@ -41,6 +41,8 @@ kubectl port-forward svc/<RELEASE_NAME>-operate  8081:80
 kubectl port-forward svc/<RELEASE_NAME>-tasklist 8082:80
 
 kubectl port-forward svc/<RELEASE_NAME>-optimize 8083:80
+
+kubectl port-forward svc/<RELEASE_NAME>-connectors 8088:8080
 ```
 
 To be able to use Web Modeler, create additional port-forwardings for Web Modeler itself and Keycloak (assuming that Keycloak is installed as part of the Helm release):
@@ -82,3 +84,6 @@ Log in to these services using the `demo`/`demo` credentials.
 If you deploy process definitions, they will appear in the dashboard. Then, you can drill down to see your active instances.
 
 You can deploy and create new instances using the Zeebe clients or `zbctl`.
+
+You can also trigger **Connectors** inbound webhook, given you deployed one.
+You can do so with the following example: `curl -X POST -H "Content-Type: application/json" -d '{"myId": 123456, "myMessage": "Hello, world!"}' http://localhost:8088/inbound/<YOUR_WEBHOOK_ID>`.

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -15,6 +15,7 @@ The following images must be available in your air-gapped environment:
 - [camunda/operate](https://hub.docker.com/r/camunda/operate)
 - [camunda/tasklist](https://hub.docker.com/r/camunda/tasklist)
 - [camunda/optimize](https://hub.docker.com/r/camunda/optimize)
+- [camunda/connectors-bundle](https://hub.docker.com/r/camunda/connectors-bundle)
 - [camunda/identity](https://hub.docker.com/r/camunda/identity)
 - [postgres](https://hub.docker.com/_/postgres)
 - [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak)
@@ -48,6 +49,7 @@ camunda-platform
     |_ optimize
     |_ operate
     |_ tasklist
+    |_ connectors
     |_ web-modeler
         |_ postgresql
 ```
@@ -56,6 +58,7 @@ camunda-platform
 - PostgreSQL is a dependency for Web Modeler.
   - This dependency is optional as you can either install PostgreSQL with Helm or use an existing [external database](../deploy.md#optional-configure-external-database).
 - Elasticsearch is a dependency for Zeebe, Operate, Tasklist, and Optimize.
+- Connectors can be stand-alone; however if there's an intention to use inbound capabilities, Operate becomes a dependency.
 
 The values for the dependencies Keycloak and PostgreSQL can be set in the same hierarchy:
 
@@ -144,6 +147,10 @@ tasklist:
 optimize:
   image:
     repository: example.jfrog.io/camunda/optimize
+    ...
+connectors:
+  image:
+    repository: example.jfrog.io/camunda/connectors-bundle
     ...
 web-modeler:
   image:

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -62,6 +62,7 @@ To extract the secrets, use the following code snippet. Make sure to replace `<R
 export TASKLIST_SECRET=$(kubectl get secret "<RELEASE_NAME>-tasklist-identity-secret" -o jsonpath="{.data.tasklist-secret}" | base64 --decode)
 export OPTIMIZE_SECRET=$(kubectl get secret "<RELEASE_NAME>-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
 export OPERATE_SECRET=$(kubectl get secret "<RELEASE_NAME>-operate-identity-secret" -o jsonpath="{.data.operate-secret}" | base64 --decode)
+export CONNECTORS_SECRET=$(kubectl get secret "<RELEASE_NAME>-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
 export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
 export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
 export POSTGRESQL_SECRET=$(kubectl get secret "<RELEASE_NAME>-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
@@ -74,6 +75,7 @@ helm upgrade <RELEASE_NAME> charts/camunda-platform/ \
   --set global.identity.auth.tasklist.existingSecret=$TASKLIST_SECRET \
   --set global.identity.auth.optimize.existingSecret=$OPTIMIZE_SECRET \
   --set global.identity.auth.operate.existingSecret=$OPERATE_SECRET \
+  --set global.identity.auth.connectors.existingSecret=$CONNECTORS_SECRET \
   --set identity.keycloak.auth.adminPassword=$KEYCLOAK_ADMIN_SECRET \
   --set identity.keycloak.auth.managementPassword=$KEYCLOAK_MANAGEMENT_SECRET \
   --set identity.keycloak.postgresql.auth.password=$POSTGRESQL_SECRET

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/overview.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/overview.md
@@ -14,7 +14,7 @@ Camunda Platform 8 includes the following components:
 - Zeebe Broker and Gateway
 - Operate (requiring Elasticsearch)
 - Tasklist (requiring Elasticsearch)
-- Connectors
+- Connectors (requiring Operate)
 - Optimize (requiring Elasticsearch)
 - Identity (requiring Keycloak)
 - Web Modeler (requiring Identity, Keycloak, and PostgreSQL) [<span class="badge badge--beta">Beta</span>](../../../reference/early-access#beta)

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/http-webhook.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/http-webhook.md
@@ -27,7 +27,7 @@ Please refer to the [update guide](../../../../guides/update-guide/connectors/06
 ![HTTP Webhook prefilled](../img/use-inbound-connector-template-filled.png)
 
 1. In the **Webhook Configuration** section, configure the **Webhook ID**. By default, **Webhook ID** is pre-filled with a random value. This value will be part of the Webhook URL. You will find more details about HTTP Webhook URLs [below](#activate-the-http-webhook-connector-by-deploying-your-diagram).
-2. (Optional) Configure [HMAC authentication](https://en.wikipedia.org/wiki/HMAC) if required. **Not recommended:** leave it `disabled` to ignore HMAC verification if your use case doesn't require verification or your use case is not yet supported.
+2. Configure [HMAC authentication](https://en.wikipedia.org/wiki/HMAC) if required.
 
 - Set the HMAC shared secret key which is used to calculate the message hash. The value is defined by a webhook administrator.
 - Set the HMAC header whose value contains an encrypted hash message. The exact value is provided by the external caller.
@@ -39,6 +39,11 @@ Please refer to the [update guide](../../../../guides/update-guide/connectors/06
 ## Activate the HTTP Webhook Connector by deploying your diagram
 
 Once you click the **Deploy** button, your HTTP Webhook will be activated and publicly available.
+You can trigger it by making a POST request to the generated URL.
+
+:::note
+HTTP Webhook Connector currently supports only POST requests.
+:::
 
 URLs of the exposed HTTP Webhooks adhere to the following pattern:
 

--- a/versioned_docs/version-8.2/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.2/self-managed/connectors-deployment/connectors-configuration.md
@@ -66,6 +66,7 @@ However, if you still wish to do so, you need to start your Connectors runtime w
 CAMUNDA_CONNECTOR_POLLING_ENABLED=false
 CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false
 SPRING_MAIN_WEB-APPLICATION-TYPE=none
+OPERATE_CLIENT_ENABLED=false
 ```
 
 ## Manual discovery of Connectors
@@ -104,7 +105,7 @@ docker run --rm --name=connectors -d \
   --network=your-zeebe-network \                                      # Optional: attach to network if Zeebe is isolated with Docker network
   -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \  # Specify Zeebe address
   -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                           # Optional: provide security configs to connect to Zeebe
-  camunda/connectors:0.5.0
+  camunda/connectors:latest
 ```
 
 The secret `MY_SECRET` value is specified directly in the `docker run` call,
@@ -141,7 +142,7 @@ docker run --rm --name=connectors -d \
   -v $PWD/my-secret-provider-with-dependencies.jar:/opt/app/my-secret-provider-with-dependencies.jar \  # Specify secret provider
   -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \                                    # Specify Zeebe address
   -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                                                             # Optional: provide security configs to connect to Zeebe
-  camunda/connectors:0.5.0
+  camunda/connectors:latest
 ```
 
 In manual installations, add the JAR to the `-cp` argument of the Java call:

--- a/versioned_docs/version-8.2/self-managed/connectors-deployment/install-and-start.md
+++ b/versioned_docs/version-8.2/self-managed/connectors-deployment/install-and-start.md
@@ -25,18 +25,34 @@ For the [out-of-the-box Connectors](/components/connectors/out-of-the-box-connec
 the Connectors Bundle project provides a set of all Connector templates related to one [release version](https://github.com/camunda/connectors-bundle/releases).
 If you use the [Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose) installation, you can thus fetch all Connector templates that match the versions of the Connectors used in the backend.
 
-Alternatively, you can fetch the JSON templates from the respective Connector's releases:
+Alternatively, you can fetch the JSON templates from the respective Connector's releases at respective connectors folder in the [bundle repository](https://github.com/camunda/connectors-bundle)
+at `connectors/{connector name}/element-templates`:
 
-- [Amazon SNS Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/sns/element-templates)
-- [Amazon SQS Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/sqs/element-templates)
-- [AWS Lambda Connector](https://github.com/camunda/connectors-bundle/blob/main/connectors/aws-lambda/element-templates)
-- [Google Drive Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/google-drive/element-templates)
-- [Kafka Producer Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/kafka/element-templates)
-- [Microsoft Teams Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/microsoft-teams/element-templates)
-- [RabbitMQ Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/rabbitmq/element-templates)
-- [REST Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/http-json/element-templates)
-- [SendGrid Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/sendgrid/element-templates)
-- [Slack Connector](https://github.com/camunda/connectors-bundle/tree/main/connectors/slack/element-templates)
+| Connector                      | License                                      |
+| ------------------------------ | -------------------------------------------- |
+| Asana Connector                | [Camunda Platform Self-Managed Free Edition] |
+| Automation Anywhere Connector  | [Camunda Platform Self-Managed Free Edition] |
+| Amazon SNS Connector           | [Camunda Platform Self-Managed Free Edition] |
+| Amazon SQS Connector           | [Camunda Platform Self-Managed Free Edition] |
+| AWS Lambda Connector           | [Camunda Platform Self-Managed Free Edition] |
+| Camunda Operate Connector      | [Camunda Platform Self-Managed Free Edition] |
+| Easy Post Connector            | [Camunda Platform Self-Managed Free Edition] |
+| GitHub Connector               | [Camunda Platform Self-Managed Free Edition] |
+| GitHub Webhook Connector       | [Camunda Platform Self-Managed Free Edition] |
+| GitLab Connector               | [Camunda Platform Self-Managed Free Edition] |
+| Google Drive Connector         | [Camunda Platform Self-Managed Free Edition] |
+| Google Maps Platform Connector | [Camunda Platform Self-Managed Free Edition] |
+| GraphQL Connector              | [Camunda Platform Self-Managed Free Edition] |
+| HTTP Webhook Connector         | [Camunda Platform Self-Managed Free Edition] |
+| Kafka Producer Connector       | [Camunda Platform Self-Managed Free Edition] |
+| Microsoft Teams Connector      | [Camunda Platform Self-Managed Free Edition] |
+| OpenAI Connector               | [Camunda Platform Self-Managed Free Edition] |
+| Power Automate Connector       | [Camunda Platform Self-Managed Free Edition] |
+| RabbitMQ Connector             | [Camunda Platform Self-Managed Free Edition] |
+| REST Connector                 | [Apache 2.0]                                 |
+| SendGrid Connector             | [Camunda Platform Self-Managed Free Edition] |
+| Slack Connector                | [Camunda Platform Self-Managed Free Edition] |
+| UiPath Connector               | [Camunda Platform Self-Managed Free Edition] |
 
 You can use the Connector templates as provided or modify them to your needs as described in our [Connector templates guide](/components/connectors/custom-built-connectors/connector-templates.md).
 

--- a/versioned_docs/version-8.2/self-managed/connectors-deployment/install-and-start.md
+++ b/versioned_docs/version-8.2/self-managed/connectors-deployment/install-and-start.md
@@ -17,6 +17,11 @@ The Connector runtime environment can be installed using the supported [deployme
 Currently, we support an installation of Connectors with [Docker](/self-managed/platform-deployment/docker.md#connectors),
 [Docker Compose](/self-managed/platform-deployment/docker.md#docker-compose), and the [manual setup](/self-managed/platform-deployment/manual.md#run-connectors).
 
+:::note
+Inbound Connectors require Operate to be deployed as part of your Camunda Platform Self-Managed installation.
+If you don't use Operate with your cluster, you can still use Outbound Connectors.
+:::
+
 ## Connector templates
 
 For the modeling interface, you need to [provide Connector templates](/components/connectors/custom-built-connectors/connector-templates.md#providing-and-using-connector-templates).

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/docker.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/docker.md
@@ -187,6 +187,20 @@ Find an overview in the [Connectors Bundle project](https://github.com/camunda/c
 
 Refer to the [Connector installation guide](../../connectors-deployment/install-and-start) for details on how to provide the Connector templates for modeling.
 
+#### Running single Connectors container
+
+```shell
+docker run --rm --name=MyConnectorsInstance \
+  --network=camunda-platform_camunda-platform \
+  -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500 \
+  -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \
+  -e CAMUNDA_CONNECTOR_POLLING_ENABLED=false \
+  -e CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false \
+  -e OPERATE_CLIENT_ENABLED=false \
+  -e SPRING_MAIN_WEB-APPLICATION-TYPE=none \
+    camunda/connectors-bundle:latest
+```
+
 #### Custom set of Connectors
 
 To add custom Connectors, you can build on top of our [Connectors base image](https://hub.docker.com/r/camunda/connectors/) that includes the pre-packaged runtime environment without any Connector.
@@ -202,13 +216,13 @@ To prevent this, common dependencies like `jackson` can be shaded and relocated 
 You can add a Connector JAR by extending the base image with a JAR from a public URL:
 
 ```yml
-FROM camunda/connectors:0.3.0
+FROM camunda/connectors:x.y.z
 
-ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/0.11.0/connector-http-json-0.11.0-with-dependencies.jar /opt/app/
+ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/x.y.z/connector-http-json-0..0-with-dependencies.jar /opt/app/
 ```
 
 You can also add a Connector JAR using volumes:
 
 ```bash
-docker run --rm --name=connectors -d -v $PWD/connector.jar:/opt/app/ camunda/connectors:0.3.0
+docker run --rm --name=connectors -d -v $PWD/connector.jar:/opt/app/ camunda/connectors:x.y.z
 ```

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/deploy.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/deploy.md
@@ -23,13 +23,10 @@ The following charts will be installed as part of Camunda Platform 8 Self-Manage
 - **Tasklist**: Deploys the Tasklist component to work with user tasks.
 - **Optimize**: Deploys the Optimize component to analyze the historic process executions.
 - **Identity**: Deploys the Identity component responsible for authentication and authorization.
+- **Connectors**: Deploys the Connectors component responsible for both inbound and outbound integration with external systems.
 - **Elasticsearch**: Deploys an Elasticsearch cluster with two nodes.
 - **Web Modeler**: Deploys the Web Modeler component that allows you to model BPMN processes in a collaborative way.
   - _Note_: The chart is disabled by default and needs to be [enabled explicitly](#installing-web-modeler) as Web Modeler is only available to enterprise customers.
-
-:::note Connectors
-We do not provide a Helm chart for Connectors in Self-Managed yet.
-:::
 
 ![Camunda Platform 8 Self-Managed Architecture Diagram](../../platform-architecture/assets/camunda-platform-8-self-managed-architecture-diagram-combined-ingress.png)
 
@@ -90,6 +87,7 @@ NAME                                           READY   STATUS              RESTA
 <RELEASE_NAME>-identity-6bb5d864cc-kk6dv        0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-operate-cb597fd76-6vr2x          0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-optimize-676955b547-vxts7        0/1     ContainerCreating   0          4s
+<RELEASE_NAME>-connectors-1bba590ff-a63dc       0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-postgresql-0                     0/1     Pending             0          4s
 <RELEASE_NAME>-tasklist-5bf5c56f7b-sdwg7        0/1     ContainerCreating   0          4s
 <RELEASE_NAME>-zeebe-0                          0/1     Pending             0          4s
@@ -113,6 +111,7 @@ This will return something similar to the following:
 NAME                                                   READY   STATUS    RESTARTS   AGE
 elasticsearch-master-0                                 1/1     Running   0          4m6s
 <RELEASE_NAME>-operate-XXX                             1/1     Running   0          4m6s
+<RELEASE_NAME>-connectors-XXX                          1/1     Running   0          4m6s
 <RELEASE_NAME>-zeebe-0                                 1/1     Running   0          4m6s
 <RELEASE_NAME>-tasklist-XXX                            1/1     Running   0          4m6s
 <RELEASE_NAME>-zeebe-gateway                           1/1     Running   0          4m6s

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress.md
@@ -41,6 +41,8 @@ kubectl port-forward svc/<RELEASE_NAME>-operate  8081:80
 kubectl port-forward svc/<RELEASE_NAME>-tasklist 8082:80
 
 kubectl port-forward svc/<RELEASE_NAME>-optimize 8083:80
+
+kubectl port-forward svc/<RELEASE_NAME>-connectors 8088:8080
 ```
 
 To be able to use Web Modeler, create additional port-forwardings for Web Modeler itself and Keycloak (assuming that Keycloak is installed as part of the Helm release):
@@ -82,3 +84,6 @@ Log in to these services using the `demo`/`demo` credentials.
 If you deploy process definitions, they will appear in the dashboard. Then, you can drill down to see your active instances.
 
 You can deploy and create new instances using the Zeebe clients or `zbctl`.
+
+You can also trigger **Connectors** inbound webhook, given you deployed one.
+You can do so with the following example: `curl -X POST -H "Content-Type: application/json" -d '{"myId": 123456, "myMessage": "Hello, world!"}' http://localhost:8088/inbound/<YOUR_WEBHOOK_ID>`.

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -15,6 +15,7 @@ The following images must be available in your air-gapped environment:
 - [camunda/operate](https://hub.docker.com/r/camunda/operate)
 - [camunda/tasklist](https://hub.docker.com/r/camunda/tasklist)
 - [camunda/optimize](https://hub.docker.com/r/camunda/optimize)
+- [camunda/connectors-bundle](https://hub.docker.com/r/camunda/connectors-bundle)
 - [camunda/identity](https://hub.docker.com/r/camunda/identity)
 - [postgres](https://hub.docker.com/_/postgres)
 - [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak)
@@ -48,6 +49,7 @@ camunda-platform
     |_ optimize
     |_ operate
     |_ tasklist
+    |_ connectors
     |_ postgresql
 ```
 
@@ -55,6 +57,7 @@ camunda-platform
 - PostgreSQL is a dependency for Web Modeler.
   - This dependency is optional as you can either install PostgreSQL with Helm or use an existing [external database](../deploy.md#optional-configure-external-database).
 - Elasticsearch is a dependency for Zeebe, Operate, Tasklist, and Optimize.
+- Connectors can be stand-alone; however if there's an intention to use inbound capabilities, Operate becomes a dependency.
 
 The values for the dependencies Keycloak and PostgreSQL can be set in the same hierarchy:
 
@@ -141,6 +144,10 @@ tasklist:
 optimize:
   image:
     repository: example.jfrog.io/camunda/optimize
+    ...
+connectors:
+  image:
+    repository: example.jfrog.io/camunda/connectors-bundle
     ...
 webModeler:
   image:

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -62,6 +62,7 @@ To extract the secrets, use the following code snippet. Make sure to replace `<R
 export TASKLIST_SECRET=$(kubectl get secret "<RELEASE_NAME>-tasklist-identity-secret" -o jsonpath="{.data.tasklist-secret}" | base64 --decode)
 export OPTIMIZE_SECRET=$(kubectl get secret "<RELEASE_NAME>-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
 export OPERATE_SECRET=$(kubectl get secret "<RELEASE_NAME>-operate-identity-secret" -o jsonpath="{.data.operate-secret}" | base64 --decode)
+export CONNECTORS_SECRET=$(kubectl get secret "<RELEASE_NAME>-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
 export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
 export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
 export POSTGRESQL_SECRET=$(kubectl get secret "<RELEASE_NAME>-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
@@ -74,6 +75,7 @@ helm upgrade <RELEASE_NAME> charts/camunda-platform/ \
   --set global.identity.auth.tasklist.existingSecret=$TASKLIST_SECRET \
   --set global.identity.auth.optimize.existingSecret=$OPTIMIZE_SECRET \
   --set global.identity.auth.operate.existingSecret=$OPERATE_SECRET \
+  --set global.identity.auth.connectors.existingSecret=$CONNECTORS_SECRET \
   --set identity.keycloak.auth.adminPassword=$KEYCLOAK_ADMIN_SECRET \
   --set identity.keycloak.auth.managementPassword=$KEYCLOAK_MANAGEMENT_SECRET \
   --set identity.keycloak.postgresql.auth.password=$POSTGRESQL_SECRET

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/overview.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/overview.md
@@ -14,7 +14,7 @@ Camunda Platform 8 includes the following components:
 - Zeebe Broker and Gateway
 - Operate (requiring Elasticsearch)
 - Tasklist (requiring Elasticsearch)
-- Connectors
+- Connectors (requiring Operate)
 - Optimize (requiring Elasticsearch)
 - Identity (requiring Keycloak)
 - Web Modeler (requiring Identity, Keycloak, and PostgreSQL) [<span class="badge badge--enterprise-only">Enterprise only</span>](../../../reference/licenses/#web-modeler)


### PR DESCRIPTION
## What is the purpose of the change

With `8.2.0` Camunda and `0.18.0` Connectors releases, there's numerous changes, that have to be reflected in the doc. Those changes are reflected here.

## Are there related marketing activities

None

## When should this change go live?

Anytime

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
