### PR TITLE
fix(sidebar): show data handling in Modeler section

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -233,6 +233,7 @@ module.exports = {
         require("./docs/components/modeler/dmn/sidebar-schema"),
         require("./docs/components/modeler/feel/sidebar-schema"),
         require("./docs/components/modeler/forms/sidebar-schema"),
+        "components/modeler/data-handling",
       ],
       Connectors: [
         "components/connectors/introduction-to-connectors",
@@ -269,7 +270,6 @@ module.exports = {
             "components/connectors/custom-built-connectors/connector-sdk",
           ],
         },
-        "components/modeler/data-handling",
       ],
       Zeebe: [
         "components/zeebe/zeebe-overview",

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -300,7 +300,8 @@
               ]
             }
           ]
-        }
+        },
+        "components/modeler/data-handling"
       ],
       "Connectors": [
         "components/connectors/introduction-to-connectors",
@@ -336,8 +337,7 @@
             "components/connectors/custom-built-connectors/connector-templates",
             "components/connectors/custom-built-connectors/connector-sdk"
           ]
-        },
-        "components/modeler/data-handling"
+        }
       ],
       "Zeebe": [
         "components/zeebe/zeebe-overview",


### PR DESCRIPTION
## What is the purpose of the change

The "Data Handling" Page is currently displayed under "Connectors", when it should be a Modeler Page. This PR moves it to the correct subsection.

![image](https://user-images.githubusercontent.com/21984219/233992716-1e4ecae0-0077-495f-8ddc-9fc6d845b151.png)

Cf. current live page: https://docs.camunda.io/docs/next/components/modeler/data-handling/

## Are there related marketing activities

n/a

## When should this change go live?

ASAP

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
