### PR TITLE
chore: update publish-stage for move to AWS hosting

### DIFF
--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -7,6 +7,9 @@ on:
     tags-ignore:
       - "*"
 
+permissions:
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -25,12 +28,31 @@ jobs:
         run: npm run build
         env:
           NODE_OPTIONS: --max_old_space_size=4096
+      - name: Get Github Actions IP
+        id: ip
+        uses: haythem/public-ip@v1.2
+      - name: Add Github Actions IP to Security group so we can publish
+        run: |
+          aws ec2 authorize-security-group-ingress --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Publish
         uses: burnett01/rsync-deployments@5.1
         with:
           switches: -avzr --delete
           path: build/
-          remote_path: ${{ secrets.PUBLISH_STAGE_PATH }}
-          remote_host: ${{ secrets.PUBLISH_STAGE_HOST }}
-          remote_user: ${{ secrets.PUBLISH_STAGE_USER }}
+          remote_path: ${{ secrets.AWS_STAGE_PUBLISH_PATH }}
+          remote_host: ${{ secrets.AWS_STAGE_PUBLISH_HOST }}
+          remote_user: ${{ secrets.AWS_STAGE_PUBLISH_USER }}
+          # vvvvv Intentionally missing the AWS_ prefix vvvvv
           remote_key: ${{ secrets.PUBLISH_STAGE_KEY }}
+      - name: Remove Github Actions IP from security group
+        run: |
+          aws ec2 revoke-security-group-ingress --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        if: always()


### PR DESCRIPTION
Partially addresses https://github.com/camunda/developer-experience/issues/61 (for the staging environment)

## What is the purpose of the change

Updates the publish-stage workflow to publish to our new AWS hosting environment. 

Note that #1994 was opened as an experiment/playground. This PR is making that experiment a reality, by updating the `publish-stage` workflow instead of a temporary `publish-stage-temp` workflow.

### Is it ready?

Yes! I confirmed with a recently merged PR that after I published to the new staging, I could see the changes.

## When should this change go live?

In the next day or so, so that we can confirm its validity before I leave for vacation on Thursday!

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
