### PR TITLE
chore: update publish-prod for move to AWS hosting

### DIFF
--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -19,12 +22,31 @@ jobs:
         run: npm run build
         env:
           NODE_OPTIONS: --max_old_space_size=4096
+      - name: Get Github Actions IP
+        id: ip
+        uses: haythem/public-ip@v1.2
+      - name: Add Github Actions IP to Security group
+        run: |
+          aws ec2 authorize-security-group-ingress --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Publish
         uses: burnett01/rsync-deployments@5.1
         with:
           switches: -avzr --delete
           path: build/
-          remote_path: ${{ secrets.PUBLISH_PROD_PATH }}
-          remote_host: ${{ secrets.PUBLISH_PROD_HOST }}
-          remote_user: ${{ secrets.PUBLISH_PROD_USER }}
+          remote_path: ${{ secrets.AWS_PROD_PUBLISH_PATH }}
+          remote_host: ${{ secrets.AWS_PROD_PUBLISH_HOST }}
+          remote_user: ${{ secrets.AWS_PROD_PUBLISH_USER }}
+          # vvvvv Intentionally missing the AWS_ prefix vvvvv
           remote_key: ${{ secrets.PUBLISH_PROD_KEY }}
+      - name: Remove Github Actions IP from security group
+        run: |
+          aws ec2 revoke-security-group-ingress --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        if: always()


### PR DESCRIPTION
Partially addresses https://github.com/camunda/developer-experience/issues/61 (for the production environment)

No longer blocked by:
- [x] #2016
- [x] The fact that [the new production environment had an SSL certificate for `docs.camunda.org`](https://camunda.slack.com/archives/C0543GY5C4U/p1682365023952709) instead of `docs.camunda.io`: 

   <img width="1491" alt="image" src="https://user-images.githubusercontent.com/1627089/234107872-7232d065-2c60-44a9-abe2-b2981c8185a1.png">
   
## What is the purpose of the change

Updates the publish-stage workflow to publish to our new AWS hosting environment. 

Note that #2018 was opened as an experiment/playground. This PR is making that experiment a reality, by updating the `publish-prod` workflow instead of a temporary `publish-prod-temp` workflow.

### Is it ready?

~Not yet!~
Yes!!!!!

## When should this change go live?

Hopefully by early Wednesday! If we don't make it by then, we're going to wait until after I return from vacation.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
