### PR TITLE
docs(modeler/flags): document `disable-plugins` flag

### DIFF
--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -28,7 +28,7 @@ Flags passed as command line arguments take precedence over those configured via
 
 | flag                                               | default value                       |
 | -------------------------------------------------- | ----------------------------------- |
-| "disable-plugins"                                  | false                               |
+| ["disable-plugins"](#disable-plugins)              | false                               |
 | "disable-adjust-origin"                            | false                               |
 | "disable-cmmn"                                     | true                                |
 | "disable-dmn"                                      | false                               |
@@ -42,6 +42,10 @@ Flags passed as command line arguments take precedence over those configured via
 | ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
 
 ## Examples
+
+### Disable Plug-ins
+
+Start the modeler without activating installed plug-ins. This is useful to debug modeler errors.
 
 ### BPMN-only Mode
 

--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -28,7 +28,7 @@ Flags passed as command line arguments take precedence over those configured via
 
 | flag                                               | default value                       |
 | -------------------------------------------------- | ----------------------------------- |
-| ["disable-plugins"](#disable-plugins)              | false                               |
+| ["disable-plugins"](#disable-plug-ins)             | false                               |
 | "disable-adjust-origin"                            | false                               |
 | "disable-cmmn"                                     | true                                |
 | "disable-dmn"                                      | false                               |

--- a/versioned_docs/version-8.0/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.0/components/modeler/desktop-modeler/flags/flags.md
@@ -28,7 +28,7 @@ Flags passed as command line arguments take precedence over those configured via
 
 | flag                                               | default value                       |
 | -------------------------------------------------- | ----------------------------------- |
-| "disable-plugins"                                  | false                               |
+| ["disable-plugins"](#disable-plugins)              | false                               |
 | "disable-adjust-origin"                            | false                               |
 | "disable-cmmn"                                     | true                                |
 | "disable-dmn"                                      | false                               |
@@ -42,6 +42,10 @@ Flags passed as command line arguments take precedence over those configured via
 | ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
 
 ## Examples
+
+### Disable Plug-ins
+
+Start the modeler without activating installed plug-ins. This is useful to debug modeler errors.
 
 ### BPMN-only Mode
 

--- a/versioned_docs/version-8.0/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.0/components/modeler/desktop-modeler/flags/flags.md
@@ -28,7 +28,7 @@ Flags passed as command line arguments take precedence over those configured via
 
 | flag                                               | default value                       |
 | -------------------------------------------------- | ----------------------------------- |
-| ["disable-plugins"](#disable-plugins)              | false                               |
+| ["disable-plugins"](#disable-plug-ins)             | false                               |
 | "disable-adjust-origin"                            | false                               |
 | "disable-cmmn"                                     | true                                |
 | "disable-dmn"                                      | false                               |

--- a/versioned_docs/version-8.1/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.1/components/modeler/desktop-modeler/flags/flags.md
@@ -28,7 +28,7 @@ Flags passed as command line arguments take precedence over those configured via
 
 | flag                                               | default value                       |
 | -------------------------------------------------- | ----------------------------------- |
-| "disable-plugins"                                  | false                               |
+| ["disable-plugins"](#disable-plugins)              | false                               |
 | "disable-adjust-origin"                            | false                               |
 | "disable-cmmn"                                     | true                                |
 | "disable-dmn"                                      | false                               |
@@ -42,6 +42,10 @@ Flags passed as command line arguments take precedence over those configured via
 | ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
 
 ## Examples
+
+### Disable Plug-ins
+
+Start the modeler without activating installed plug-ins. This is useful to debug modeler errors.
 
 ### BPMN-only Mode
 

--- a/versioned_docs/version-8.1/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.1/components/modeler/desktop-modeler/flags/flags.md
@@ -28,7 +28,7 @@ Flags passed as command line arguments take precedence over those configured via
 
 | flag                                               | default value                       |
 | -------------------------------------------------- | ----------------------------------- |
-| ["disable-plugins"](#disable-plugins)              | false                               |
+| ["disable-plugins"](#disable-plug-ins)             | false                               |
 | "disable-adjust-origin"                            | false                               |
 | "disable-cmmn"                                     | true                                |
 | "disable-dmn"                                      | false                               |

--- a/versioned_docs/version-8.2/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.2/components/modeler/desktop-modeler/flags/flags.md
@@ -28,7 +28,7 @@ Flags passed as command line arguments take precedence over those configured via
 
 | flag                                               | default value                       |
 | -------------------------------------------------- | ----------------------------------- |
-| "disable-plugins"                                  | false                               |
+| ["disable-plugins"](#disable-plugins)              | false                               |
 | "disable-adjust-origin"                            | false                               |
 | "disable-cmmn"                                     | true                                |
 | "disable-dmn"                                      | false                               |
@@ -42,6 +42,10 @@ Flags passed as command line arguments take precedence over those configured via
 | ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
 
 ## Examples
+
+### Disable Plug-ins
+
+Start the modeler without activating installed plug-ins. This is useful to debug modeler errors.
 
 ### BPMN-only Mode
 

--- a/versioned_docs/version-8.2/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.2/components/modeler/desktop-modeler/flags/flags.md
@@ -28,7 +28,7 @@ Flags passed as command line arguments take precedence over those configured via
 
 | flag                                               | default value                       |
 | -------------------------------------------------- | ----------------------------------- |
-| ["disable-plugins"](#disable-plugins)              | false                               |
+| ["disable-plugins"](#disable-plug-ins)             | false                               |
 | "disable-adjust-origin"                            | false                               |
 | "disable-cmmn"                                     | true                                |
 | "disable-dmn"                                      | false                               |


### PR DESCRIPTION
This gives us a place to link to for disabling plug-ins.

## What is the purpose of the change

Ensure we have something to link to when hinting our users at the `--disable-plugins` flag.

## Are there related marketing activities

No.

## When should this change go live?

Immediately.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
