### PR TITLE
docs(aws-lambda): fix link to manage-secrets

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/aws-lambda.md
+++ b/docs/components/connectors/out-of-the-box-connectors/aws-lambda.md
@@ -11,7 +11,7 @@ The **AWS Lambda Connector** allows you to connect your BPMN service with Amazon
 To use an **AWS Lambda Connector**, you need to have an [AWS Lambda Function](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html), IAM key, and secret pair with permissions for execute function. See the [AWS Lambda developer guide](https://docs.aws.amazon.com/lambda/latest/dg/lambda-permissions.html) to learn more.
 
 :::note
-It is highly recommended to not expose your AWS IAM credentials as plain text and instead use Camunda secrets. See [manage secrets](../img/connectors-aws-lambda-filled.png) to learn more.
+It is highly recommended to not expose your AWS IAM credentials as plain text and instead use Camunda secrets. See [manage secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
 ## Create an AWS Lambda Connector task

--- a/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/aws-lambda.md
+++ b/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/aws-lambda.md
@@ -11,7 +11,7 @@ The **AWS Lambda Connector** allows you to connect your BPMN service with Amazon
 To use an **AWS Lambda Connector**, you need to have an [AWS Lambda Function](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html), IAM key, and secret pair with permissions for execute function. See the [AWS Lambda developer guide](https://docs.aws.amazon.com/lambda/latest/dg/lambda-permissions.html) to learn more.
 
 It is highly recommended not to expose your AWS IAM credentials as plain text but rather use Camunda secrets.
-See [Manage secrets](../img/connectors-aws-lambda-filled.png) to learn more.
+See [Manage secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 
 ## Create an AWS Lambda Connector task
 

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/aws-lambda.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/aws-lambda.md
@@ -11,7 +11,7 @@ The **AWS Lambda Connector** allows you to connect your BPMN service with Amazon
 To use an **AWS Lambda Connector**, you need to have an [AWS Lambda Function](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html), IAM key, and secret pair with permissions for execute function. See the [AWS Lambda developer guide](https://docs.aws.amazon.com/lambda/latest/dg/lambda-permissions.html) to learn more.
 
 :::note
-It is highly recommended to not expose your AWS IAM credentials as plain text and instead use Camunda secrets. See [manage secrets](../img/connectors-aws-lambda-filled.png) to learn more.
+It is highly recommended to not expose your AWS IAM credentials as plain text and instead use Camunda secrets. See [manage secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
 ## Create an AWS Lambda Connector task

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/aws-lambda.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/aws-lambda.md
@@ -11,7 +11,7 @@ The **AWS Lambda Connector** allows you to connect your BPMN service with Amazon
 To use an **AWS Lambda Connector**, you need to have an [AWS Lambda Function](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html), IAM key, and secret pair with permissions for execute function. See the [AWS Lambda developer guide](https://docs.aws.amazon.com/lambda/latest/dg/lambda-permissions.html) to learn more.
 
 :::note
-It is highly recommended to not expose your AWS IAM credentials as plain text and instead use Camunda secrets. See [manage secrets](../img/connectors-aws-lambda-filled.png) to learn more.
+It is highly recommended to not expose your AWS IAM credentials as plain text and instead use Camunda secrets. See [manage secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
 ## Create an AWS Lambda Connector task


### PR DESCRIPTION
## What is the purpose of the change

Link to manage-secrets.md is incorrect in all versions of aws-lambda docs. 

## Are there related marketing activities

No

## When should this change go live?

This is a bug, we should merge and trigger a release to get this updated.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
