### PR TITLE
docs(web-modeler): link Play mode docs from configuration page

### DIFF
--- a/docs/self-managed/modeler/web-modeler/configuration.md
+++ b/docs/self-managed/modeler/web-modeler/configuration.md
@@ -118,14 +118,14 @@ Web Modeler integrates with Identity and Keycloak for authentication and authori
 
 ### General
 
-| Environment variable      | Description                                                                                                                            | Example value                                                    | Default value |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------- |
-| `SERVER_URL`              | URL at which users access Web Modeler in the browser.<br/>_Note_: To use a sub path for Web Modeler, just include the path in the URL. | `https://modeler.example.com`,<br/>`https://example.com/modeler` | -             |
-| `SERVER_HTTPS_ONLY`       | Enforce the usage of HTTPS when users access Web Modeler (by redirecting from `http://` to `https://`).                                | `true`                                                           | `false`       |
-| `RESTAPI_HOST`            | [Internal](#notes-on-host-names-and-port-numbers) host name of the `restapi` application.                                              | `modeler-restapi`                                                | -             |
-| `RESTAPI_PORT`            | [Internal](#notes-on-host-names-and-port-numbers) port number on which the `restapi` serves the regular API endpoints.                 | `8081`                                                           | `8081`        |
-| `RESTAPI_MANAGEMENT_PORT` | [Internal](#notes-on-host-names-and-port-numbers) port number on which the `restapi` serves the management API endpoints.              | `8091`                                                           | `8091`        |
-| `PLAY_ENABLED`            | [optional]<br/>Enables the **Play** mode in the BPMN editor, allowing users to test processes in a playground environment.             | `true`                                                           | `false`       |
+| Environment variable      | Description                                                                                                                                                                                | Example value                                                    | Default value |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | ------------- |
+| `SERVER_URL`              | URL at which users access Web Modeler in the browser.<br/>_Note_: To use a sub path for Web Modeler, just include the path in the URL.                                                     | `https://modeler.example.com`,<br/>`https://example.com/modeler` | -             |
+| `SERVER_HTTPS_ONLY`       | Enforce the usage of HTTPS when users access Web Modeler (by redirecting from `http://` to `https://`).                                                                                    | `true`                                                           | `false`       |
+| `RESTAPI_HOST`            | [Internal](#notes-on-host-names-and-port-numbers) host name of the `restapi` application.                                                                                                  | `modeler-restapi`                                                | -             |
+| `RESTAPI_PORT`            | [Internal](#notes-on-host-names-and-port-numbers) port number on which the `restapi` serves the regular API endpoints.                                                                     | `8081`                                                           | `8081`        |
+| `RESTAPI_MANAGEMENT_PORT` | [Internal](#notes-on-host-names-and-port-numbers) port number on which the `restapi` serves the management API endpoints.                                                                  | `8091`                                                           | `8091`        |
+| `PLAY_ENABLED`            | [optional]<br/>Enables the [**Play** mode](../../../components/modeler/web-modeler/play-your-process.md) in the BPMN editor, allowing users to test processes in a playground environment. | `true`                                                           | `false`       |
 
 ### Identity / Keycloak
 

--- a/versioned_docs/version-8.2/self-managed/modeler/web-modeler/configuration.md
+++ b/versioned_docs/version-8.2/self-managed/modeler/web-modeler/configuration.md
@@ -118,14 +118,14 @@ Web Modeler integrates with Identity and Keycloak for authentication and authori
 
 ### General
 
-| Environment variable      | Description                                                                                                                            | Example value                                                    | Default value |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------- |
-| `SERVER_URL`              | URL at which users access Web Modeler in the browser.<br/>_Note_: To use a sub path for Web Modeler, just include the path in the URL. | `https://modeler.example.com`,<br/>`https://example.com/modeler` | -             |
-| `SERVER_HTTPS_ONLY`       | Enforce the usage of HTTPS when users access Web Modeler (by redirecting from `http://` to `https://`).                                | `true`                                                           | `false`       |
-| `RESTAPI_HOST`            | [Internal](#notes-on-host-names-and-port-numbers) host name of the `restapi` application.                                              | `modeler-restapi`                                                | -             |
-| `RESTAPI_PORT`            | [Internal](#notes-on-host-names-and-port-numbers) port number on which the `restapi` serves the regular API endpoints.                 | `8081`                                                           | `8081`        |
-| `RESTAPI_MANAGEMENT_PORT` | [Internal](#notes-on-host-names-and-port-numbers) port number on which the `restapi` serves the management API endpoints.              | `8091`                                                           | `8091`        |
-| `PLAY_ENABLED`            | [optional]<br/>Enables the **Play** mode in the BPMN editor, allowing users to test processes in a playground environment.             | `true`                                                           | `false`       |
+| Environment variable      | Description                                                                                                                                                                                | Example value                                                    | Default value |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | ------------- |
+| `SERVER_URL`              | URL at which users access Web Modeler in the browser.<br/>_Note_: To use a sub path for Web Modeler, just include the path in the URL.                                                     | `https://modeler.example.com`,<br/>`https://example.com/modeler` | -             |
+| `SERVER_HTTPS_ONLY`       | Enforce the usage of HTTPS when users access Web Modeler (by redirecting from `http://` to `https://`).                                                                                    | `true`                                                           | `false`       |
+| `RESTAPI_HOST`            | [Internal](#notes-on-host-names-and-port-numbers) host name of the `restapi` application.                                                                                                  | `modeler-restapi`                                                | -             |
+| `RESTAPI_PORT`            | [Internal](#notes-on-host-names-and-port-numbers) port number on which the `restapi` serves the regular API endpoints.                                                                     | `8081`                                                           | `8081`        |
+| `RESTAPI_MANAGEMENT_PORT` | [Internal](#notes-on-host-names-and-port-numbers) port number on which the `restapi` serves the management API endpoints.                                                                  | `8091`                                                           | `8091`        |
+| `PLAY_ENABLED`            | [optional]<br/>Enables the [**Play** mode](../../../components/modeler/web-modeler/play-your-process.md) in the BPMN editor, allowing users to test processes in a playground environment. | `true`                                                           | `false`       |
 
 ### Identity / Keycloak
 


### PR DESCRIPTION
## What is the purpose of the change
Link the new configuration page on the _Play_ mode in Web Modeler from the `PLAY_ENABLED` environment variable.

## Are there related marketing activities
no

## When should this change go live?
It can go live any time.

## PR Checklist
- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, ~or they are not for an already released version~.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, ~or they are not for future versions~.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, ~or my changes do not require an Engineering review~.
- [x] ~My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer,~ or my changes do not require a technical writer review.