### PR TITLE
docs(micronaut): change link in next

### DIFF
--- a/docs/apis-tools/community-clients/micronaut.md
+++ b/docs/apis-tools/community-clients/micronaut.md
@@ -11,5 +11,5 @@ The Micronaut Framework is known for its efficient use of resources. Native imag
 
 - [Documentation and source code](https://github.com/camunda-community-hub/micronaut-zeebe-client)
 - [Integrate Camunda's External Task Clients into Micronaut Framework projects](https://github.com/camunda-community-hub/micronaut-camunda-external-client)
-- [Create application with Micronaut Launch](https://micronaut.io/launch?name=jobworker&features=zeebe)
+- [Create application with Micronaut Launch](https://micronaut.io/launch?name=jobworker&features=camunda-zeebe)
 - [Releases on Maven Central](https://search.maven.org/artifact/info.novatec/micronaut-zeebe-client-feature)


### PR DESCRIPTION
## What is the purpose of the change

Adding link change in #2042 to `/next/`.

## Are there related marketing activities

No.

## When should this change go live?

This link is broken. Could be considered a bug.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
