### PR TITLE
Fix note block

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/automation-anywhere.md
+++ b/docs/components/connectors/out-of-the-box-connectors/automation-anywhere.md
@@ -35,7 +35,7 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `AUTOMATION_ANYWHERE_PASSWORD`) so you can reference it later in the Connector.
-:::
+   :::
 
 ### _Authenticate (username and password)_ authentication
 

--- a/docs/components/connectors/out-of-the-box-connectors/automation-anywhere.md
+++ b/docs/components/connectors/out-of-the-box-connectors/automation-anywhere.md
@@ -35,7 +35,7 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `AUTOMATION_ANYWHERE_PASSWORD`) so you can reference it later in the Connector.
-   :::
+:::
 
 ### _Authenticate (username and password)_ authentication
 

--- a/docs/components/connectors/out-of-the-box-connectors/automation-anywhere.md
+++ b/docs/components/connectors/out-of-the-box-connectors/automation-anywhere.md
@@ -35,7 +35,8 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `AUTOMATION_ANYWHERE_PASSWORD`) so you can reference it later in the Connector.
-   :::
+
+:::
 
 ### _Authenticate (username and password)_ authentication
 

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/automation-anywhere.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/automation-anywhere.md
@@ -35,7 +35,7 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `AUTOMATION_ANYWHERE_PASSWORD`) so you can reference it later in the Connector.
-:::
+   :::
 
 ### _Authenticate (username and password)_ authentication
 

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/automation-anywhere.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/automation-anywhere.md
@@ -35,7 +35,7 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `AUTOMATION_ANYWHERE_PASSWORD`) so you can reference it later in the Connector.
-   :::
+:::
 
 ### _Authenticate (username and password)_ authentication
 

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/automation-anywhere.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/automation-anywhere.md
@@ -35,7 +35,8 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `AUTOMATION_ANYWHERE_PASSWORD`) so you can reference it later in the Connector.
-   :::
+
+:::
 
 ### _Authenticate (username and password)_ authentication
 


### PR DESCRIPTION
## What is the purpose of the change

A note block was declared with an indented end, leading to the whole document below was shown as note.

## Are there related marketing activities

no

## When should this change go live?

asap

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
