### PR TITLE
fix the call of adress variable

### DIFF
--- a/versioned_docs/version-8.2/apis-tools/java-client/index.md
+++ b/versioned_docs/version-8.2/apis-tools/java-client/index.md
@@ -43,13 +43,13 @@ In Java code, instantiate the client as follows:
     OAuthCredentialsProvider credentialsProvider =
         new OAuthCredentialsProviderBuilder()
             .authorizationServerUrl(oAuthAPI)
-            .audience(zeebeAPI)
+            .audience(zeebeAddress)
             .clientId(clientId)
             .clientSecret(clientSecret)
             .build();
 
     try (ZeebeClient client = ZeebeClient.newClientBuilder()
-            .gatewayAddress(zeebeAPI)
+            .gatewayAddress(zeebeAddress)
             .credentialsProvider(credentialsProvider)
             .build()) {
       client.newTopologyRequest().send().join();


### PR DESCRIPTION
* build: two methods in client instantiation now call "zeebeAdress" instead of "zeebeAPI"

## What is the purpose of the change

_The code change is to replace the use of the "zeebeAPI" variable with "zeebeAddress" in two client instantiation methods. The configurations are needed for the code to work correctly after the upgrade._

## Are there related marketing activities

_No._

## When should this change go live?

_As soon as possible. This can help other developers who may be working on the same code avoid errors and issues._

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
