### PR TITLE
docs(ootbc): dynamoDb add internal link to item operations

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb.md
+++ b/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb.md
@@ -45,7 +45,7 @@ Choose one of the following methods:
 - [Describe table](#describe-table): Returns information about a DynamoDB table.
 - [Scan table](#scan-table): Returns one or more items and their attributes by accessing every item in a table. You can use filter expressions to selectively scan for items that meet certain criteria.
 
-#### Item
+#### [Item](#item-operations)
 
 - [Add item](#add-item): Creates a new item or replaces an existing item with a new item.
 - [Delete item](#delete-item): Deletes a single item in a table by primary key.

--- a/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/aws-dynamodb.md
+++ b/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/aws-dynamodb.md
@@ -45,7 +45,7 @@ Choose one of the following methods:
 - [Describe table](#describe-table): Returns information about a DynamoDB table.
 - [Scan table](#scan-table): Returns one or more items and their attributes by accessing every item in a table. You can use filter expressions to selectively scan for items that meet certain criteria.
 
-#### Item
+#### [Item](#item-operations)
 
 - [Add item](#add-item): Creates a new item or replaces an existing item with a new item.
 - [Delete item](#delete-item): Deletes a single item in a table by primary key.

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/aws-dynamodb.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/aws-dynamodb.md
@@ -45,7 +45,7 @@ Choose one of the following methods:
 - [Describe table](#describe-table): Returns information about a DynamoDB table.
 - [Scan table](#scan-table): Returns one or more items and their attributes by accessing every item in a table. You can use filter expressions to selectively scan for items that meet certain criteria.
 
-#### Item
+#### [Item](#item-operations)
 
 - [Add item](#add-item): Creates a new item or replaces an existing item with a new item.
 - [Delete item](#delete-item): Deletes a single item in a table by primary key.

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/aws-dynamodb.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/aws-dynamodb.md
@@ -45,7 +45,7 @@ Choose one of the following methods:
 - [Describe table](#describe-table): Returns information about a DynamoDB table.
 - [Scan table](#scan-table): Returns one or more items and their attributes by accessing every item in a table. You can use filter expressions to selectively scan for items that meet certain criteria.
 
-#### Item
+#### [Item](#item-operations)
 
 - [Add item](#add-item): Creates a new item or replaces an existing item with a new item.
 - [Delete item](#delete-item): Deletes a single item in a table by primary key.


### PR DESCRIPTION
## What is the purpose of the change

Added internal link to Item operations : `[Item](#item-operations)` in aws dynamoDB connector docs

## Are there related marketing activities

https://github.com/camunda/camunda-platform-docs/issues/2066

## When should this change go live?

TBD

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory