### PR TITLE
chore(docs): remove C7 label from common problems documentation

### DIFF
--- a/optimize/self-managed/optimize-deployment/configuration/common-problems.md
+++ b/optimize/self-managed/optimize-deployment/configuration/common-problems.md
@@ -4,8 +4,6 @@ title: "Common problems"
 description: "Information to help troubleshoot common problems."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 This section aims to provide initial help to troubleshoot common issues. This guide is not intended to be a complete list of possible problems, nor does it provide detailed step-by-step solutions; its intention is merely to point you in the right direction when investigating what may be causing the issue you are experiencing.
 
 ## Optimize is missing some or all definitions

--- a/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/configuration/common-problems.md
+++ b/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/configuration/common-problems.md
@@ -4,8 +4,6 @@ title: "Common problems"
 description: "Information to help troubleshoot common problems."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 This section aims to provide initial help to troubleshoot common issues. This guide is not intended to be a complete list of possible problems, nor does it provide detailed step-by-step solutions; its intention is merely to point you in the right direction when investigating what may be causing the issue you are experiencing.
 
 ## Optimize is missing some or all definitions

--- a/optimize_versioned_docs/version-3.7.0/self-managed/optimize-deployment/setup/common-problems.md
+++ b/optimize_versioned_docs/version-3.7.0/self-managed/optimize-deployment/setup/common-problems.md
@@ -4,8 +4,6 @@ title: "Common problems"
 description: "Information to help troubleshoot common problems."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 This section aims to provide initial help to troubleshoot common issues. This guide is not intended to be a complete list of possible problems, nor does it provide detailed step-by-step solutions; its intention is merely to point you in the right direction when investigating what may be causing the issue you are experiencing.  
 
 ## Optimize is missing some or all definitions

--- a/optimize_versioned_docs/version-3.8.0/self-managed/optimize-deployment/configuration/common-problems.md
+++ b/optimize_versioned_docs/version-3.8.0/self-managed/optimize-deployment/configuration/common-problems.md
@@ -4,8 +4,6 @@ title: "Common problems"
 description: "Information to help troubleshoot common problems."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 This section aims to provide initial help to troubleshoot common issues. This guide is not intended to be a complete list of possible problems, nor does it provide detailed step-by-step solutions; its intention is merely to point you in the right direction when investigating what may be causing the issue you are experiencing.
 
 ## Optimize is missing some or all definitions

--- a/optimize_versioned_docs/version-3.9.0/self-managed/optimize-deployment/configuration/common-problems.md
+++ b/optimize_versioned_docs/version-3.9.0/self-managed/optimize-deployment/configuration/common-problems.md
@@ -4,8 +4,6 @@ title: "Common problems"
 description: "Information to help troubleshoot common problems."
 ---
 
-<span class="badge badge--platform">Camunda Platform 7 only</span>
-
 This section aims to provide initial help to troubleshoot common issues. This guide is not intended to be a complete list of possible problems, nor does it provide detailed step-by-step solutions; its intention is merely to point you in the right direction when investigating what may be causing the issue you are experiencing.
 
 ## Optimize is missing some or all definitions


### PR DESCRIPTION
relates to OPT-6948

## What is the purpose of the change

We no longer require the C7 label, we will allow users to find the problems that apply (they can be C8 too)

## Are there related marketing activities

N/A

## When should this change go live?

Any time

## PR Checklist

- [ ] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [ ] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
