### PR TITLE
chore: clean up remaining dangling :::note terminators

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/google-maps-platform.md
+++ b/docs/components/connectors/out-of-the-box-connectors/google-maps-platform.md
@@ -28,7 +28,8 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `GOOGLE_MAPS_PLATFORM_API_KEY`) so you can reference it later in the Connector.
-   :::
+
+:::
 
 ## Operation types
 

--- a/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/automation-anywhere.md
+++ b/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/automation-anywhere.md
@@ -35,7 +35,8 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `AUTOMATION_ANYWHERE_PASSWORD`) so you can reference it later in the Connector.
-   :::
+
+:::
 
 ### _Authenticate (username and password)_ authentication
 

--- a/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/google-maps-platform.md
+++ b/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/google-maps-platform.md
@@ -28,7 +28,8 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `GOOGLE_MAPS_PLATFORM_API_KEY`) so you can reference it later in the Connector.
-   :::
+
+:::
 
 ## Operation types
 

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/automation-anywhere.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/automation-anywhere.md
@@ -35,7 +35,8 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `AUTOMATION_ANYWHERE_PASSWORD`) so you can reference it later in the Connector.
-   :::
+
+:::
 
 ### _Authenticate (username and password)_ authentication
 

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/google-maps-platform.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/google-maps-platform.md
@@ -28,7 +28,8 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `GOOGLE_MAPS_PLATFORM_API_KEY`) so you can reference it later in the Connector.
-   :::
+
+:::
 
 ## Operation types
 

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/google-maps-platform.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/google-maps-platform.md
@@ -28,7 +28,8 @@ We advise you to keep your authentications and secrets data safe and avoid expos
 
 1. Follow our [guide for creating secrets](../../console/manage-clusters/manage-secrets.md).
 2. Name your secret (i.e `GOOGLE_MAPS_PLATFORM_API_KEY`) so you can reference it later in the Connector.
-   :::
+
+:::
 
 ## Operation types
 


### PR DESCRIPTION
## What is the purpose of the change

Inspired by #2053, cleans up the remaining "dangling" `:::note` terminators.

Prettier gets confused when a `:::note` block is terminated with a `:::` on the line _immediately_ following a list. If we put a blank line after the last list item, it understands properly. 

In other words, prettier gets confused by this:

```
:::note
1. thing
2. thing
:::
```

And it indents the final `:::`. 

But if we do this, it leaves the closing tag out-dented: 

```
:::note
1. thing
2. thing

:::
```

There might be a way to lint for this, but I think that's a pretty low-priority improvement, and these prettier mistakes are easy to find & fix manually.


## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
