### PR TITLE
chore: use links to 19.0.3 keycloak docs

### DIFF
--- a/docs/self-managed/identity/getting-started/install-identity.md
+++ b/docs/self-managed/identity/getting-started/install-identity.md
@@ -30,7 +30,7 @@ Password: demo
 
 :::note Want to create more users?
 Creating a user in Identity is not currently supported. To create a user, see
-[Keycloak's documentation on creating a user](https://www.keycloak.org/docs/latest/server_admin/#proc-creating-user_server_administration_guide).
+[Keycloak's documentation on creating a user](https://www.keycloak.org/docs/19.0.3/server_admin/#proc-creating-user_server_administration_guide).
 :::
 
 ## Home screen

--- a/docs/self-managed/identity/troubleshooting/common-problems.md
+++ b/docs/self-managed/identity/troubleshooting/common-problems.md
@@ -35,7 +35,7 @@ When the Keycloak service is ready for connections, please start (or restart) th
 ### Solution 2: Identity making requests from an external IP address
 
 By default, Keycloak requires TLS on requests that originate from what it considers to be an external source. The Keycloak
-documentation for [setting up SSL](https://www.keycloak.org/docs/latest/server_installation/#_setting_up_ssl) maintains
+documentation for [setting up SSL](https://www.keycloak.org/docs/19.0.3/server_installation/#_setting_up_ssl) maintains
 a list of what they consider to be an external IP address under the `external requests` section.
 
 The solution to this issue will depend largely on your environment, however as a starting point we would suggest you consider

--- a/docs/self-managed/identity/troubleshooting/common-problems.md
+++ b/docs/self-managed/identity/troubleshooting/common-problems.md
@@ -45,9 +45,9 @@ these options:
    ranges that Keycloak expects.
 2. If configuring the IP ranges is not an option then it is possible to disable the SSL requirement in Keycloak itself.
    to achieve this:
-   1. In the `master` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/16.1/server_admin/#_ssl_modes)
+   1. In the `master` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/19.0.3/server_admin/#_ssl_modes)
    2. Restart the Identity service
-   3. In the `camunda-platform` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/16.1/server_admin/#_ssl_modes)
+   3. In the `camunda-platform` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/19.0.3/server_admin/#_ssl_modes)
    4. Restart the Identity service again
    5. Identity should now start successfully
 

--- a/docs/self-managed/identity/user-guide/configuration/configure-external-identity-provider.md
+++ b/docs/self-managed/identity/user-guide/configuration/configure-external-identity-provider.md
@@ -32,7 +32,7 @@ To configure an external identity provider like OpenID Connect, SAML, LDAP, or A
       ![keycloak-add-user-federation](../img/keycloak-add-user-federation.png)
 
 :::tip
-Keycloak supports a wide variety of authentication options, such as mapping external user groups, roles, or scopes to internal roles, and configuring the login screen and flow when multiple providers are added. Visit the Keycloak documentation for details on [adding a provider](https://www.keycloak.org/docs/16.1/server_admin/index.html#adding-a-provider),
-[configuring authentication](https://www.keycloak.org/docs/16.1/server_admin/index.html#configuring-authentication), and
-[integrating identity providers](https://www.keycloak.org/docs/16.1/server_admin/index.html#_identity_broker).
+Keycloak supports a wide variety of authentication options, such as mapping external user groups, roles, or scopes to internal roles, and configuring the login screen and flow when multiple providers are added. Visit the Keycloak documentation for details on [adding a provider](https://www.keycloak.org/docs/19.0.3/server_admin/index.html#adding-a-provider),
+[configuring authentication](https://www.keycloak.org/docs/19.0.3/server_admin/index.html#configuring-authentication), and
+[integrating identity providers](https://www.keycloak.org/docs/19.0.3/server_admin/index.html#_identity_broker).
 :::

--- a/docs/self-managed/identity/user-guide/configuration/connect-to-an-existing-keycloak.md
+++ b/docs/self-managed/identity/user-guide/configuration/connect-to-an-existing-keycloak.md
@@ -8,8 +8,8 @@ In this guide, we'll demonstrate how to connect the Identity component to your e
 
 ### Prerequisites
 
-- Access to your [Keycloak Admin Console](https://www.keycloak.org/docs/16.1/server_admin/#using-the-admin-console)
-- A basic understanding of [administering realms and clients](https://www.keycloak.org/docs/16.1/server_admin/#assembly-managing-clients_server_administration_guide) in Keycloak
+- Access to your [Keycloak Admin Console](https://www.keycloak.org/docs/19.0.3/server_admin/#using-the-admin-console)
+- A basic understanding of [administering realms and clients](https://www.keycloak.org/docs/19.0.3/server_admin/#assembly-managing-clients_server_administration_guide) in Keycloak
 
 ### Steps
 

--- a/docs/self-managed/platform-deployment/troubleshooting.md
+++ b/docs/self-managed/platform-deployment/troubleshooting.md
@@ -9,7 +9,7 @@ description: "Troubleshooting considerations in Platform deployment."
 
 When deploying the Camunda Platform to a provider, it is important to confirm the IP ranges used
 for container to container communication align with the IP ranges Keycloak considers "local". By default, Keycloak considers all IPs outside those listed in their
-[external requests documentation](https://www.keycloak.org/docs/latest/server_installation/#_setting_up_ssl)
+[external requests documentation](https://www.keycloak.org/docs/19.0.3/server_installation/#_setting_up_ssl)
 to be external and therefore require SSL.
 
 As the [Camunda Platform Helm Charts](https://github.com/camunda/camunda-platform-helm) currently do

--- a/versioned_docs/version-8.0/self-managed/identity/getting-started/install-identity.md
+++ b/versioned_docs/version-8.0/self-managed/identity/getting-started/install-identity.md
@@ -29,7 +29,7 @@ Password: demo
 
 :::note Want to create more users?
 Creating a user in Identity is not currently supported. To create a user, see
-[Keycloak's documentation on creating a user](https://www.keycloak.org/docs/latest/server_admin/#proc-creating-user_server_administration_guide).
+[Keycloak's documentation on creating a user](https://www.keycloak.org/docs/19.0.3/server_admin/#proc-creating-user_server_administration_guide).
 :::
 
 ## Home screen

--- a/versioned_docs/version-8.0/self-managed/identity/troubleshooting/common-problems.md
+++ b/versioned_docs/version-8.0/self-managed/identity/troubleshooting/common-problems.md
@@ -35,7 +35,7 @@ When the Keycloak service is ready for connections, please start (or restart) th
 ### Solution 2: Identity making requests from an external IP address
 
 By default, Keycloak requires TLS on requests that originate from what it considers to be an external source. The Keycloak
-documentation for [setting up SSL](https://www.keycloak.org/docs/latest/server_installation/#_setting_up_ssl) maintains
+documentation for [setting up SSL](https://www.keycloak.org/docs/19.0.3/server_installation/#_setting_up_ssl) maintains
 a list of what they consider to be an external IP address under the `external requests` section.
 
 The solution to this issue will depend largely on your environment, however as a starting point we would suggest you consider

--- a/versioned_docs/version-8.0/self-managed/platform-deployment/known-limitations.md
+++ b/versioned_docs/version-8.0/self-managed/platform-deployment/known-limitations.md
@@ -8,7 +8,7 @@ sidebar_label: "Known limitations"
 
 When deploying the Camunda stack to a provider it is important to confirm that the IP ranges used for container
 to container communication align with the IP ranges that Keycloak consider to be "local". By default, Keycloak
-considers all IPs outside those listed in their [external requests documentation](https://www.keycloak.org/docs/latest/server_installation/#_setting_up_ssl)
+considers all IPs outside those listed in their [external requests documentation](https://www.keycloak.org/docs/19.0.3/server_installation/#_setting_up_ssl)
 to be external and therefore require SSL.
 
 As the [Camunda Platform Helm Charts](https://github.com/camunda/camunda-platform-helm) currently do not provide support

--- a/versioned_docs/version-8.1/self-managed/identity/getting-started/install-identity.md
+++ b/versioned_docs/version-8.1/self-managed/identity/getting-started/install-identity.md
@@ -30,7 +30,7 @@ Password: demo
 
 :::note Want to create more users?
 Creating a user in Identity is not currently supported. To create a user, see
-[Keycloak's documentation on creating a user](https://www.keycloak.org/docs/latest/server_admin/#proc-creating-user_server_administration_guide).
+[Keycloak's documentation on creating a user](https://www.keycloak.org/docs/19.0.3/server_admin/#proc-creating-user_server_administration_guide).
 :::
 
 ## Home screen

--- a/versioned_docs/version-8.1/self-managed/identity/troubleshooting/common-problems.md
+++ b/versioned_docs/version-8.1/self-managed/identity/troubleshooting/common-problems.md
@@ -35,7 +35,7 @@ When the Keycloak service is ready for connections, please start (or restart) th
 ### Solution 2: Identity making requests from an external IP address
 
 By default, Keycloak requires TLS on requests that originate from what it considers to be an external source. The Keycloak
-documentation for [setting up SSL](https://www.keycloak.org/docs/latest/server_installation/#_setting_up_ssl) maintains
+documentation for [setting up SSL](https://www.keycloak.org/docs/19.0.3/server_installation/#_setting_up_ssl) maintains
 a list of what they consider to be an external IP address under the `external requests` section.
 
 The solution to this issue will depend largely on your environment, however as a starting point we would suggest you consider

--- a/versioned_docs/version-8.1/self-managed/identity/troubleshooting/common-problems.md
+++ b/versioned_docs/version-8.1/self-managed/identity/troubleshooting/common-problems.md
@@ -45,9 +45,9 @@ these options:
    ranges that Keycloak expects.
 2. If configuring the IP ranges is not an option then it is possible to disable the SSL requirement in Keycloak itself.
    to achieve this:
-   1. In the `master` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/16.1/server_admin/#_ssl_modes)
+   1. In the `master` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/19.0.3/server_admin/#_ssl_modes)
    2. Restart the Identity service
-   3. In the `camunda-platform` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/16.1/server_admin/#_ssl_modes)
+   3. In the `camunda-platform` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/19.0.3/server_admin/#_ssl_modes)
    4. Restart the Identity service again
    5. Identity should now start successfully
 

--- a/versioned_docs/version-8.1/self-managed/identity/user-guide/configure-external-identity-provider.md
+++ b/versioned_docs/version-8.1/self-managed/identity/user-guide/configure-external-identity-provider.md
@@ -32,7 +32,7 @@ To configure an external identity provider like OpenID Connect, SAML, LDAP, or A
       ![keycloak-add-user-federation](img/keycloak-add-user-federation.png)
 
 :::tip
-Keycloak supports a wide variety of authentication options, such as mapping external user groups, roles, or scopes to internal roles, and configuring the login screen and flow when multiple providers are added. Visit the Keycloak documentation for details on [adding a provider](https://www.keycloak.org/docs/16.1/server_admin/index.html#adding-a-provider),
-[configuring authentication](https://www.keycloak.org/docs/16.1/server_admin/index.html#configuring-authentication), and
-[integrating identity providers](https://www.keycloak.org/docs/16.1/server_admin/index.html#_identity_broker).
+Keycloak supports a wide variety of authentication options, such as mapping external user groups, roles, or scopes to internal roles, and configuring the login screen and flow when multiple providers are added. Visit the Keycloak documentation for details on [adding a provider](https://www.keycloak.org/docs/19.0.3/server_admin/index.html#adding-a-provider),
+[configuring authentication](https://www.keycloak.org/docs/19.0.3/server_admin/index.html#configuring-authentication), and
+[integrating identity providers](https://www.keycloak.org/docs/19.0.3/server_admin/index.html#_identity_broker).
 :::

--- a/versioned_docs/version-8.1/self-managed/identity/user-guide/connect-to-an-existing-keycloak.md
+++ b/versioned_docs/version-8.1/self-managed/identity/user-guide/connect-to-an-existing-keycloak.md
@@ -8,8 +8,8 @@ In this guide, we'll demonstrate how to connect the Identity component to your e
 
 ### Prerequisites
 
-- Access to your [Keycloak Admin Console](https://www.keycloak.org/docs/16.1/server_admin/#using-the-admin-console)
-- A basic understanding of [administering realms and clients](https://www.keycloak.org/docs/16.1/server_admin/#assembly-managing-clients_server_administration_guide) in Keycloak
+- Access to your [Keycloak Admin Console](https://www.keycloak.org/docs/19.0.3/server_admin/#using-the-admin-console)
+- A basic understanding of [administering realms and clients](https://www.keycloak.org/docs/19.0.3/server_admin/#assembly-managing-clients_server_administration_guide) in Keycloak
 
 ### Steps
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/troubleshooting.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/troubleshooting.md
@@ -9,7 +9,7 @@ description: "Troubleshooting considerations in Platform deployment."
 
 When deploying the Camunda Platform to a provider, it is important to confirm the IP ranges used
 for container to container communication align with the IP ranges Keycloak considers "local". By default, Keycloak considers all IPs outside those listed in their
-[external requests documentation](https://www.keycloak.org/docs/latest/server_installation/#_setting_up_ssl)
+[external requests documentation](https://www.keycloak.org/docs/19.0.3/server_installation/#_setting_up_ssl)
 to be external and therefore require SSL.
 
 As the [Camunda Platform Helm Charts](https://github.com/camunda/camunda-platform-helm) currently do

--- a/versioned_docs/version-8.2/self-managed/identity/getting-started/install-identity.md
+++ b/versioned_docs/version-8.2/self-managed/identity/getting-started/install-identity.md
@@ -30,7 +30,7 @@ Password: demo
 
 :::note Want to create more users?
 Creating a user in Identity is not currently supported. To create a user, see
-[Keycloak's documentation on creating a user](https://www.keycloak.org/docs/latest/server_admin/#proc-creating-user_server_administration_guide).
+[Keycloak's documentation on creating a user](https://www.keycloak.org/docs/19.0.3/server_admin/#proc-creating-user_server_administration_guide).
 :::
 
 ## Home screen

--- a/versioned_docs/version-8.2/self-managed/identity/troubleshooting/common-problems.md
+++ b/versioned_docs/version-8.2/self-managed/identity/troubleshooting/common-problems.md
@@ -35,7 +35,7 @@ When the Keycloak service is ready for connections, please start (or restart) th
 ### Solution 2: Identity making requests from an external IP address
 
 By default, Keycloak requires TLS on requests that originate from what it considers to be an external source. The Keycloak
-documentation for [setting up SSL](https://www.keycloak.org/docs/latest/server_installation/#_setting_up_ssl) maintains
+documentation for [setting up SSL](https://www.keycloak.org/docs/19.0.3/server_installation/#_setting_up_ssl) maintains
 a list of what they consider to be an external IP address under the `external requests` section.
 
 The solution to this issue will depend largely on your environment, however as a starting point we would suggest you consider

--- a/versioned_docs/version-8.2/self-managed/identity/troubleshooting/common-problems.md
+++ b/versioned_docs/version-8.2/self-managed/identity/troubleshooting/common-problems.md
@@ -45,9 +45,9 @@ these options:
    ranges that Keycloak expects.
 2. If configuring the IP ranges is not an option then it is possible to disable the SSL requirement in Keycloak itself.
    to achieve this:
-   1. In the `master` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/16.1/server_admin/#_ssl_modes)
+   1. In the `master` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/19.0.3/server_admin/#_ssl_modes)
    2. Restart the Identity service
-   3. In the `camunda-platform` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/16.1/server_admin/#_ssl_modes)
+   3. In the `camunda-platform` realm set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/19.0.3/server_admin/#_ssl_modes)
    4. Restart the Identity service again
    5. Identity should now start successfully
 

--- a/versioned_docs/version-8.2/self-managed/identity/user-guide/configuration/configure-external-identity-provider.md
+++ b/versioned_docs/version-8.2/self-managed/identity/user-guide/configuration/configure-external-identity-provider.md
@@ -32,7 +32,7 @@ To configure an external identity provider like OpenID Connect, SAML, LDAP, or A
       ![keycloak-add-user-federation](../img/keycloak-add-user-federation.png)
 
 :::tip
-Keycloak supports a wide variety of authentication options, such as mapping external user groups, roles, or scopes to internal roles, and configuring the login screen and flow when multiple providers are added. Visit the Keycloak documentation for details on [adding a provider](https://www.keycloak.org/docs/16.1/server_admin/index.html#adding-a-provider),
-[configuring authentication](https://www.keycloak.org/docs/16.1/server_admin/index.html#configuring-authentication), and
-[integrating identity providers](https://www.keycloak.org/docs/16.1/server_admin/index.html#_identity_broker).
+Keycloak supports a wide variety of authentication options, such as mapping external user groups, roles, or scopes to internal roles, and configuring the login screen and flow when multiple providers are added. Visit the Keycloak documentation for details on [adding a provider](https://www.keycloak.org/docs/19.0.3/server_admin/index.html#adding-a-provider),
+[configuring authentication](https://www.keycloak.org/docs/19.0.3/server_admin/index.html#configuring-authentication), and
+[integrating identity providers](https://www.keycloak.org/docs/19.0.3/server_admin/index.html#_identity_broker).
 :::

--- a/versioned_docs/version-8.2/self-managed/identity/user-guide/configuration/connect-to-an-existing-keycloak.md
+++ b/versioned_docs/version-8.2/self-managed/identity/user-guide/configuration/connect-to-an-existing-keycloak.md
@@ -8,8 +8,8 @@ In this guide, we'll demonstrate how to connect the Identity component to your e
 
 ### Prerequisites
 
-- Access to your [Keycloak Admin Console](https://www.keycloak.org/docs/16.1/server_admin/#using-the-admin-console)
-- A basic understanding of [administering realms and clients](https://www.keycloak.org/docs/16.1/server_admin/#assembly-managing-clients_server_administration_guide) in Keycloak
+- Access to your [Keycloak Admin Console](https://www.keycloak.org/docs/19.0.3/server_admin/#using-the-admin-console)
+- A basic understanding of [administering realms and clients](https://www.keycloak.org/docs/19.0.3/server_admin/#assembly-managing-clients_server_administration_guide) in Keycloak
 
 ### Steps
 

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/troubleshooting.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/troubleshooting.md
@@ -9,7 +9,7 @@ description: "Troubleshooting considerations in Platform deployment."
 
 When deploying the Camunda Platform to a provider, it is important to confirm the IP ranges used
 for container to container communication align with the IP ranges Keycloak considers "local". By default, Keycloak considers all IPs outside those listed in their
-[external requests documentation](https://www.keycloak.org/docs/latest/server_installation/#_setting_up_ssl)
+[external requests documentation](https://www.keycloak.org/docs/19.0.3/server_installation/#_setting_up_ssl)
 to be external and therefore require SSL.
 
 As the [Camunda Platform Helm Charts](https://github.com/camunda/camunda-platform-helm) currently do


### PR DESCRIPTION
## What is the purpose of the change

Fixes https://camunda.slack.com/archives/C026U8GBNSW/p1683562739617529. The external links to Keycloak docs now contain the latest supported version (19.0.3) instead of referencing `latest`

## Are there related marketing activities

no

## When should this change go live?

any time

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
