### PR TITLE
chore(web-modeler): align supported Keycloak versions with Identity

### DIFF
--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -39,7 +39,7 @@ Requirements for the components can be seen below:
 | Tasklist    | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                                                                |
 | Identity    | OpenJDK 17+  | Keycloak 16.1.x, 18.x, 19.x<br/>PostgreSQL 14.x, 15.x                                                                                     |
 | Optimize    | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                                                                |
-| Web Modeler | -            | Keycloak 16.1.1, 19.0.3<br/>PostgreSQL 14.x, Amazon Aurora PostgreSQL 14.x<br/> (other database systems are currently not supported)      |
+| Web Modeler | -            | Keycloak 16.1.x, 18.x, 19.x<br/>PostgreSQL 14.x, Amazon Aurora PostgreSQL 14.x<br/> (other database systems are currently not supported)  |
 
 ### Version Matrix
 

--- a/versioned_docs/version-8.1/reference/supported-environments.md
+++ b/versioned_docs/version-8.1/reference/supported-environments.md
@@ -32,14 +32,14 @@ We highly recommend running Camunda Platform 8 Self-Managed in a Kubernetes envi
 
 Requirements for the components can be seen below:
 
-| Component          | Java version | Other requirements                                                                               |
-| ------------------ | ------------ | ------------------------------------------------------------------------------------------------ |
-| Zeebe              | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x (only if Elastic exporter is used)                                  |
-| Operate            | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x                                                                     |
-| Tasklist           | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x                                                                     |
-| Identity           | OpenJDK 17+  | Keycloak 16.1.x, 18.x, 19.x                                                                      |
-| Optimize           | OpenJDK 11+  | Elasticsearch 7.13.x - 7.15.x, 7.16.2+, 7.17.x                                                   |
-| Web Modeler (Beta) | -            | Keycloak 16.1.1, 19.0.3<br/>PostgreSQL 14.x (other database systems are currently not supported) |
+| Component          | Java version | Other requirements                                                                                   |
+| ------------------ | ------------ | ---------------------------------------------------------------------------------------------------- |
+| Zeebe              | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x (only if Elastic exporter is used)                                      |
+| Operate            | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x                                                                         |
+| Tasklist           | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x                                                                         |
+| Identity           | OpenJDK 17+  | Keycloak 16.1.x, 18.x, 19.x                                                                          |
+| Optimize           | OpenJDK 11+  | Elasticsearch 7.13.x - 7.15.x, 7.16.2+, 7.17.x                                                       |
+| Web Modeler (Beta) | -            | Keycloak 16.1.x, 18.x, 19.x<br/>PostgreSQL 14.x (other database systems are currently not supported) |
 
 :::note Elasticsearch support
 [Elastic's Elasticsearch](https://www.elastic.co/elasticsearch/) is the only supported version of Elastic compatible with Camunda Platform 8.

--- a/versioned_docs/version-8.2/reference/supported-environments.md
+++ b/versioned_docs/version-8.2/reference/supported-environments.md
@@ -39,7 +39,7 @@ Requirements for the components can be seen below:
 | Tasklist    | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                                                                |
 | Identity    | OpenJDK 17+  | Keycloak 16.1.x, 18.x, 19.x<br/>PostgreSQL 14.x, 15.x                                                                                     |
 | Optimize    | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                                                                |
-| Web Modeler | -            | Keycloak 16.1.1, 19.0.3<br/>PostgreSQL 14.x, Amazon Aurora PostgreSQL 14.x<br/> (other database systems are currently not supported)      |
+| Web Modeler | -            | Keycloak 16.1.x, 18.x, 19.x<br/>PostgreSQL 14.x, Amazon Aurora PostgreSQL 14.x<br/> (other database systems are currently not supported)  |
 
 ### Version Matrix
 


### PR DESCRIPTION
## What is the purpose of the change
Align the Keycloak versions supported by Web Modeler with the ones for Identity.

## Are there related marketing activities
no

## When should this change go live?
It can go live any time.

## PR Checklist
- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, ~or they are not for an already released version~.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, ~or they are not for future versions~.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, ~or my changes do not require an Engineering review~.
- [x] ~My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer~, or my changes do not require a technical writer review.