### PR TITLE
docs(web-modeler): upgrade Laravel to v10

### DIFF
--- a/docs/self-managed/modeler/web-modeler/configuration/configuration.md
+++ b/docs/self-managed/modeler/web-modeler/configuration/configuration.md
@@ -127,7 +127,7 @@ Refer to the [Advanced Logging Configuration Guide](./logging.md#logging-configu
 
 ## Configuration of the `websocket` component
 
-The [WebSocket](https://en.wikipedia.org/wiki/WebSocket) server shipped with Web Modeler Self-Managed is based on the [laravel-websockets](https://laravel.com/docs/9.x/broadcasting#open-source-alternatives-php) open source package and implements the [Pusher Channels Protocol](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/).
+The [WebSocket](https://en.wikipedia.org/wiki/WebSocket) server shipped with Web Modeler Self-Managed is based on the [laravel-websockets](https://laravel.com/docs/10.x/broadcasting#open-source-alternatives-php) open source package and implements the [Pusher Channels Protocol](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/).
 
 | Environment variable | Description                                                                                                                                                              | Example value | Default value |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- | ------------- |
@@ -138,9 +138,9 @@ The [WebSocket](https://en.wikipedia.org/wiki/WebSocket) server shipped with Web
 
 ### Logging
 
-| Environment variable | Description                                                                                                                    | Example value | Default Value |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------- | ------------- |
-| `LOG_CHANNEL`        | [optional]<br/>Log channel driver, see [Laravel documentation](https://laravel.com/docs/8.x/logging#available-channel-drivers) | `single`      | `stack`       |
+| Environment variable | Description                                                                                                                     | Example value | Default Value |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------- |
+| `LOG_CHANNEL`        | [optional]<br/>Log channel driver, see [Laravel documentation](https://laravel.com/docs/10.x/logging#available-channel-drivers) | `single`      | `stack`       |
 
 Refer to the [Advanced Logging Configuration Guide](./logging.md#logging-configuration-for-the-websocket-component) for additional details on how to customize the `websocket` logging output.
 

--- a/versioned_docs/version-8.1/self-managed/web-modeler/configuration.md
+++ b/versioned_docs/version-8.1/self-managed/web-modeler/configuration.md
@@ -111,7 +111,7 @@ The `webapp` component sends certain events (e.g. "user opened diagram", "user l
 
 ### Configuration of the `websocket` component
 
-The [WebSocket](https://en.wikipedia.org/wiki/WebSocket) server shipped with Web Modeler Self-Managed is based on the [laravel-websockets](https://laravel.com/docs/9.x/broadcasting#open-source-alternatives-php) open source package and implements the [Pusher Channels Protocol](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/).
+The [WebSocket](https://en.wikipedia.org/wiki/WebSocket) server shipped with Web Modeler Self-Managed is based on the [laravel-websockets](https://laravel.com/docs/8.x/broadcasting#open-source-alternatives-php) open source package and implements the [Pusher Channels Protocol](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/).
 
 | Environment variable | Description                                                                                                                                                              | Example value | Default value |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- | ------------- |

--- a/versioned_docs/version-8.2/self-managed/modeler/web-modeler/configuration/configuration.md
+++ b/versioned_docs/version-8.2/self-managed/modeler/web-modeler/configuration/configuration.md
@@ -127,7 +127,7 @@ Refer to the [Advanced Logging Configuration Guide](./logging.md#logging-configu
 
 ## Configuration of the `websocket` component
 
-The [WebSocket](https://en.wikipedia.org/wiki/WebSocket) server shipped with Web Modeler Self-Managed is based on the [laravel-websockets](https://laravel.com/docs/9.x/broadcasting#open-source-alternatives-php) open source package and implements the [Pusher Channels Protocol](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/).
+The [WebSocket](https://en.wikipedia.org/wiki/WebSocket) server shipped with Web Modeler Self-Managed is based on the [laravel-websockets](https://laravel.com/docs/10.x/broadcasting#open-source-alternatives-php) open source package and implements the [Pusher Channels Protocol](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/).
 
 | Environment variable | Description                                                                                                                                                              | Example value | Default value |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- | ------------- |
@@ -138,9 +138,9 @@ The [WebSocket](https://en.wikipedia.org/wiki/WebSocket) server shipped with Web
 
 ### Logging
 
-| Environment variable | Description                                                                                                                    | Example value | Default Value |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------- | ------------- |
-| `LOG_CHANNEL`        | [optional]<br/>Log channel driver, see [Laravel documentation](https://laravel.com/docs/8.x/logging#available-channel-drivers) | `single`      | `stack`       |
+| Environment variable | Description                                                                                                                     | Example value | Default Value |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------- |
+| `LOG_CHANNEL`        | [optional]<br/>Log channel driver, see [Laravel documentation](https://laravel.com/docs/10.x/logging#available-channel-drivers) | `single`      | `stack`       |
 
 Refer to the [Advanced Logging Configuration Guide](./logging.md#logging-configuration-for-the-websocket-component) for additional details on how to customize the `websocket` logging output.
 


### PR DESCRIPTION
## What is the purpose of the change

Updates the version to the Laravel documentation to version 10 used by the latest websockets image.

## Are there related marketing activities

No.

## When should this change go live?

With the next Web Modeler SM patch/alpha release.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, ~or they are not for an already released version.~
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, ~or they are not for future versions.~
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, ~or my changes do not require an Engineering review.~
- [x] ~My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer,~ or my changes do not require a technical writer review.
