### PR TITLE
docs(identity): fix the log appender options to match reality

### DIFF
--- a/docs/self-managed/identity/user-guide/configuration/configure-logging.md
+++ b/docs/self-managed/identity/user-guide/configuration/configure-logging.md
@@ -66,7 +66,7 @@ Identity provides support for configuring the log level:
 
 As part of configuration Identity provides multiple appenders for outputting logs, to configure which logging appender
 is
-used, set the `IDENTITY_LOG_APPENDER` environment variable to one of the following `Console`, `Stackdriver`, or `Log`:
+used, set the `IDENTITY_LOG_APPENDER` environment variable to one of the following `Console`, `Stackdriver`, or `File`:
 
 <Tabs groupId="loggingAppenders" defaultValue="console"
 values={[{label: 'Console', value: 'console', }, {label: 'Stackdriver', value: 'stackdriver', }, {label: 'File', value: 'file', },]} >

--- a/versioned_docs/version-8.1/self-managed/identity/user-guide/configure-logging.md
+++ b/versioned_docs/version-8.1/self-managed/identity/user-guide/configure-logging.md
@@ -55,7 +55,7 @@ Identity provides support for configuring the log level:
 
 As part of configuration Identity provides multiple appenders for outputting logs, to configure which logging appender
 is
-used, set the `IDENTITY_LOG_APPENDER` environment variable to one of the following `Console`, `Stackdriver`, or `Log`:
+used, set the `IDENTITY_LOG_APPENDER` environment variable to one of the following `Console`, or `Stackdriver`:
 
 <Tabs groupId="loggingAppenders" defaultValue="console"
 values={[{label: 'Console', value: 'console', }, {label: 'Stackdriver', value: 'stackdriver', },]} >

--- a/versioned_docs/version-8.2/self-managed/identity/user-guide/configuration/configure-logging.md
+++ b/versioned_docs/version-8.2/self-managed/identity/user-guide/configuration/configure-logging.md
@@ -66,7 +66,7 @@ Identity provides support for configuring the log level:
 
 As part of configuration Identity provides multiple appenders for outputting logs, to configure which logging appender
 is
-used, set the `IDENTITY_LOG_APPENDER` environment variable to one of the following `Console`, `Stackdriver`, or `Log`:
+used, set the `IDENTITY_LOG_APPENDER` environment variable to one of the following `Console`, `Stackdriver`, or `File`:
 
 <Tabs groupId="loggingAppenders" defaultValue="console"
 values={[{label: 'Console', value: 'console', }, {label: 'Stackdriver', value: 'stackdriver', }, {label: 'File', value: 'file', },]} >


### PR DESCRIPTION
## What is the purpose of the change
It was picked up by QA that the docs around the logging configuration for Identity. We do not have a `Log` appender, this should be `File`.

## Are there related marketing activities
Nope

## When should this change go live?
This change can be included in an upcoming release but is not urgent to trigger a release of its own.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
