### PR TITLE
assorted: Archive pre-work

### DIFF
--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -11,7 +11,7 @@ There are various channels where you can reach us.
 
 - We welcome your **bug** reports and **feature requests** through our community channels mentioned above.
 
-- For **security-related issues**, review our [Security notices](../../docs/reference/notices) for the most up-to-date information on known issues and steps to report a vulnerability so we can solve the problem as quickly as possible. Do not use GitHub for security-related issues.
+- For **security-related issues**, review our [Security notices](../docs/reference/notices) for the most up-to-date information on known issues and steps to report a vulnerability so we can solve the problem as quickly as possible. Do not use GitHub for security-related issues.
 
 - **Feedback and Support** can be submitted or requested via JIRA for subscription or enterprise customers in the Support project. Otherwise, use the [Camunda Platform community forum](https://forum.camunda.io/). For more information about Enterprise support and additional support resources please see [Enterprise Support](https://camunda.com/support/).
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -68,9 +68,9 @@ function Feature({ imageUrl, url, title, description }) {
     <div className={clsx("col col--4 component-block", styles.feature)}>
       {imgUrl && (
         <div className="text--center">
-          <a href={url}>
+          <Link to={useBaseUrl(url)}>
             <img className={styles.featureImage} src={imgUrl} alt={title} />
-          </a>
+          </Link>
         </div>
       )}
       <h3 className="component-title">{title}</h3>
@@ -90,9 +90,9 @@ function Feature2({ imageUrl, url, title, description }) {
     >
       {imgUrl && (
         <div className="text--center">
-          <a href={url}>
+          <Link to={useBaseUrl(url)}>
             <img className={styles.featureImage} src={imgUrl} alt={title} />
-          </a>
+          </Link>
         </div>
       )}
       <h3 className="component-title">{title}</h3>

--- a/src/theme/NavbarItem/index.js
+++ b/src/theme/NavbarItem/index.js
@@ -12,8 +12,8 @@ export default function NavbarItemWrapper(props) {
   const { pathname } = useLocation();
 
   const childProps = { ...props };
-  if (type === "docsVersionDropdown") {
-    if (/^\/optimize/.test(pathname)) {
+  if (type === "docsVersionDropdown" || type === "docsVersion") {
+    if (/^\/([0-9.]*\/)?optimize/.test(pathname)) {
       childProps.docsPluginId = "optimize";
     }
   }


### PR DESCRIPTION
## Description

Adjusts a few things in preparation for #1173:

1. Corrects a link on the Contact page, which was incorrectly traveling one ancestor too far. This has no effect on the current docs, but will have an effect on the archived versions.
2. Updates the "feature" links on the home page to do two things: 
   1. Use the `<Link>` element instead of `<a>`, which enables docusaurus to navigate with the client-side router. To the user, this looks like more seamless transitions when they click on the feature.
   2. Wrap the `url` of each link in a `useBaseUrl()` call. This tells docusaurus to use the `baseUrl` property of its configuration when generating the link. This has no effect on the current docs, but will have an effect on the archived versions. 
3. Broadens the scope of the `docsPluginId`-sniffing logic in the `NavbarItem` component, so that archived versions will be able to display the correct version for Optimize documentation. 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
