### PR TITLE
chore(ci): prevent 0.25.x tags from accidentally being deployed to docs.camunda.io

### DIFF
--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+      - "!0.25.[0-9]+"
 
 permissions:
   id-token: write


### PR DESCRIPTION
Part of #1173. 

This PR is BLOCKING the deployment of 0.25 to unsupported.docs.camunda.io/0.25.

## Description

Excludes any 0.25.x tags from the publish-prod workflow, so that a 0.25 isolated website isn't accidentally deployed to the main/supported/active docs site (docs.camunda.io).

[The GitHub docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-branches-and-tags) describe this approach of combining include & exclude tags, as well as the importance of the order.

Context for this PR is discussed [here](https://github.com/camunda/camunda-platform-docs/pull/2167#discussion_r1214887291).

## Testing

After this is merged, I'll tag a 0.25.x release, and make sure (1) the 0.25 site gets deployed to unsupported.docs.camunda.io, and (2) no deployment occurs to docs.camunda.io. If this change doesn't work, and the 0.25 site gets deployed to docs.camunda.io, I will immediately trigger another full-sized production publish to correct things. 

Because of this risk of potential down-time, I'll save the tagging test for US evening time.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.
- [x] This change is blocking other infrastructure work, but is not urgent for existing users.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
