### PR TITLE
chore(docs): mark assignee/candidate group data reports as C7 only

### DIFF
--- a/optimize/components/userguide/process-analysis/report-analysis/define-reports.md
+++ b/optimize/components/userguide/process-analysis/report-analysis/define-reports.md
@@ -88,6 +88,10 @@ User task names, assignees, and candidate groups can be applied as a second "Gro
 
 For example, if your report is grouped by assignee/candidate group, it is possible to add another grouping by user task to see which user task your users/group are working on or have completed in the past. If the report contains multiple process definitions, the data can also be grouped by process as a second "Group by".
 
+:::note
+Reports using assignee/candidate groups are only available in C7
+:::
+
 ![Distributed User Task report](./img/distributed-report.png)
 
 Refer to the table below for an overview of all report combinations that support a second "Group by":

--- a/optimize/components/userguide/process-analysis/report-analysis/define-reports.md
+++ b/optimize/components/userguide/process-analysis/report-analysis/define-reports.md
@@ -89,7 +89,7 @@ User task names, assignees, and candidate groups can be applied as a second "Gro
 For example, if your report is grouped by assignee/candidate group, it is possible to add another grouping by user task to see which user task your users/group are working on or have completed in the past. If the report contains multiple process definitions, the data can also be grouped by process as a second "Group by".
 
 :::note
-Reports using assignee/candidate groups are only available in C7
+Reports using assignee/candidate groups are only available in Camunda Platform 7
 :::
 
 ![Distributed User Task report](./img/distributed-report.png)

--- a/optimize_versioned_docs/version-3.10.0/components/userguide/process-analysis/report-analysis/define-reports.md
+++ b/optimize_versioned_docs/version-3.10.0/components/userguide/process-analysis/report-analysis/define-reports.md
@@ -88,6 +88,10 @@ User task names, assignees, and candidate groups can be applied as a second "Gro
 
 For example, if your report is grouped by assignee/candidate group, it is possible to add another grouping by user task to see which user task your users/group are working on or have completed in the past. If the report contains multiple process definitions, the data can also be grouped by process as a second "Group by".
 
+:::note
+Reports using assignee/candidate groups are only available in C7
+:::
+
 ![Distributed User Task report](./img/distributed-report.png)
 
 Refer to the table below for an overview of all report combinations that support a second "Group by":

--- a/optimize_versioned_docs/version-3.10.0/components/userguide/process-analysis/report-analysis/define-reports.md
+++ b/optimize_versioned_docs/version-3.10.0/components/userguide/process-analysis/report-analysis/define-reports.md
@@ -89,7 +89,7 @@ User task names, assignees, and candidate groups can be applied as a second "Gro
 For example, if your report is grouped by assignee/candidate group, it is possible to add another grouping by user task to see which user task your users/group are working on or have completed in the past. If the report contains multiple process definitions, the data can also be grouped by process as a second "Group by".
 
 :::note
-Reports using assignee/candidate groups are only available in C7
+Reports using assignee/candidate groups are only available in Camunda Platform 7
 :::
 
 ![Distributed User Task report](./img/distributed-report.png)

--- a/optimize_versioned_docs/version-3.7.0/components/userguide/process-analysis/report-analysis/edit-mode.md
+++ b/optimize_versioned_docs/version-3.7.0/components/userguide/process-analysis/report-analysis/edit-mode.md
@@ -126,7 +126,7 @@ User task names, assignees, and candidate groups can be applied as a second "Gro
 For example, if your report is grouped by assignee/candidate group, it is possible to add another grouping by user task to see which user task your users/group are working on or have completed in the past. If the report contains multiple process definitions, the data can also be grouped by process as a second "Group by".
 
 :::note
-Reports using assignee/candidate groups are only available in C7
+Reports using assignee/candidate groups are only available in Camunda Platform 7
 :::
 
 ![Distributed User Task report](./img/distributed-report.png)

--- a/optimize_versioned_docs/version-3.7.0/components/userguide/process-analysis/report-analysis/edit-mode.md
+++ b/optimize_versioned_docs/version-3.7.0/components/userguide/process-analysis/report-analysis/edit-mode.md
@@ -125,6 +125,10 @@ User task names, assignees, and candidate groups can be applied as a second "Gro
 
 For example, if your report is grouped by assignee/candidate group, it is possible to add another grouping by user task to see which user task your users/group are working on or have completed in the past. If the report contains multiple process definitions, the data can also be grouped by process as a second "Group by".
 
+:::note
+Reports using assignee/candidate groups are only available in C7
+:::
+
 ![Distributed User Task report](./img/distributed-report.png)
 
 Refer to the table below for an overview of all report combinations that support a second "Group by":

--- a/optimize_versioned_docs/version-3.8.0/components/userguide/process-analysis/report-analysis/define-reports.md
+++ b/optimize_versioned_docs/version-3.8.0/components/userguide/process-analysis/report-analysis/define-reports.md
@@ -88,6 +88,10 @@ User task names, assignees, and candidate groups can be applied as a second "Gro
 
 For example, if your report is grouped by assignee/candidate group, it is possible to add another grouping by user task to see which user task your users/group are working on or have completed in the past. If the report contains multiple process definitions, the data can also be grouped by process as a second "Group by".
 
+:::note
+Reports using assignee/candidate groups are only available in C7
+:::
+
 ![Distributed User Task report](./img/distributed-report.png)
 
 Refer to the table below for an overview of all report combinations that support a second "Group by":

--- a/optimize_versioned_docs/version-3.8.0/components/userguide/process-analysis/report-analysis/define-reports.md
+++ b/optimize_versioned_docs/version-3.8.0/components/userguide/process-analysis/report-analysis/define-reports.md
@@ -89,7 +89,7 @@ User task names, assignees, and candidate groups can be applied as a second "Gro
 For example, if your report is grouped by assignee/candidate group, it is possible to add another grouping by user task to see which user task your users/group are working on or have completed in the past. If the report contains multiple process definitions, the data can also be grouped by process as a second "Group by".
 
 :::note
-Reports using assignee/candidate groups are only available in C7
+Reports using assignee/candidate groups are only available in Camunda Platform 7
 :::
 
 ![Distributed User Task report](./img/distributed-report.png)

--- a/optimize_versioned_docs/version-3.9.0/components/userguide/process-analysis/report-analysis/define-reports.md
+++ b/optimize_versioned_docs/version-3.9.0/components/userguide/process-analysis/report-analysis/define-reports.md
@@ -88,6 +88,10 @@ User task names, assignees, and candidate groups can be applied as a second "Gro
 
 For example, if your report is grouped by assignee/candidate group, it is possible to add another grouping by user task to see which user task your users/group are working on or have completed in the past. If the report contains multiple process definitions, the data can also be grouped by process as a second "Group by".
 
+:::note
+Reports using assignee/candidate groups are only available in C7
+:::
+
 ![Distributed User Task report](./img/distributed-report.png)
 
 Refer to the table below for an overview of all report combinations that support a second "Group by":

--- a/optimize_versioned_docs/version-3.9.0/components/userguide/process-analysis/report-analysis/define-reports.md
+++ b/optimize_versioned_docs/version-3.9.0/components/userguide/process-analysis/report-analysis/define-reports.md
@@ -89,7 +89,7 @@ User task names, assignees, and candidate groups can be applied as a second "Gro
 For example, if your report is grouped by assignee/candidate group, it is possible to add another grouping by user task to see which user task your users/group are working on or have completed in the past. If the report contains multiple process definitions, the data can also be grouped by process as a second "Group by".
 
 :::note
-Reports using assignee/candidate groups are only available in C7
+Reports using assignee/candidate groups are only available in Camunda Platform 7
 :::
 
 ![Distributed User Task report](./img/distributed-report.png)


### PR DESCRIPTION
relates to OPT-7028

## Description

Some report types aren't available in C8, but this is not necessarily clear to users. We should make this clearer in our docs.

I know we typically use the label for our docs but that doesn't neatly fit this page, as only a small part is C7-specific. Open to alternatives here @christinaausley :) 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
