### PR TITLE
chore(docs): warn about engine historic data clean up time

### DIFF
--- a/optimize/self-managed/optimize-deployment/configuration/system-configuration-platform-7.md
+++ b/optimize/self-managed/optimize-deployment/configuration/system-configuration-platform-7.md
@@ -10,7 +10,9 @@ to import data from. Each engine configuration should have a unique alias associ
 with it and represented by `${engineAlias}`.
 
 Note that each connected engine must have its respective history level set to `FULL` in order to see all available data
-in Optimize. Using any other history level will result in less data and/or functionality within Optimize.
+in Optimize. Using any other history level will result in less data and/or functionality within Optimize. Furthermore,
+history in a connected engine should be configured for long enough for Optimize to import it. If data is removed from an
+engine before Optimize has imported it, that data will not be available in Optimize.
 
 | YAML Path                                      | Default Value                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ---------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/configuration/system-configuration-platform-7.md
+++ b/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/configuration/system-configuration-platform-7.md
@@ -10,7 +10,9 @@ to import data from. Each engine configuration should have a unique alias associ
 with it and represented by `${engineAlias}`.
 
 Note that each connected engine must have its respective history level set to `FULL` in order to see all available data
-in Optimize. Using any other history level will result in less data and/or functionality within Optimize.
+in Optimize. Using any other history level will result in less data and/or functionality within Optimize. Furthermore,
+history in a connected engine should be configured for long enough for Optimize to import it. If data is removed from an
+engine before Optimize has imported it, that data will not be available in Optimize.
 
 | YAML Path                                      | Default Value                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ---------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/optimize_versioned_docs/version-3.7.0/self-managed/optimize-deployment/setup/configuration.md
+++ b/optimize_versioned_docs/version-3.7.0/self-managed/optimize-deployment/setup/configuration.md
@@ -174,7 +174,9 @@ to import data from. Each engine configuration should have a unique alias associ
 with it and represented by `${engineAlias}`.
 
 Note that each connected engine must have its respective history level set to `FULL` in order to see all available data
-in Optimize. Using any other history level will result in less data and/or functionality within Optimize.
+in Optimize. Using any other history level will result in less data and/or functionality within Optimize. Furthermore,
+history in a connected engine should be configured for long enough for Optimize to import it. If data is removed from an
+engine before Optimize has imported it, that data will not be available in Optimize.
 
 |YAML Path|Default Value|Description|
 |--- |--- |--- |

--- a/optimize_versioned_docs/version-3.8.0/self-managed/optimize-deployment/configuration/system-configuration-platform-7.md
+++ b/optimize_versioned_docs/version-3.8.0/self-managed/optimize-deployment/configuration/system-configuration-platform-7.md
@@ -10,7 +10,9 @@ to import data from. Each engine configuration should have a unique alias associ
 with it and represented by `${engineAlias}`.
 
 Note that each connected engine must have its respective history level set to `FULL` in order to see all available data
-in Optimize. Using any other history level will result in less data and/or functionality within Optimize.
+in Optimize. Using any other history level will result in less data and/or functionality within Optimize. Furthermore,
+history in a connected engine should be configured for long enough for Optimize to import it. If data is removed from an
+engine before Optimize has imported it, that data will not be available in Optimize.
 
 | YAML Path                                      | Default Value                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ---------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/optimize_versioned_docs/version-3.9.0/self-managed/optimize-deployment/configuration/system-configuration-platform-7.md
+++ b/optimize_versioned_docs/version-3.9.0/self-managed/optimize-deployment/configuration/system-configuration-platform-7.md
@@ -10,7 +10,9 @@ to import data from. Each engine configuration should have a unique alias associ
 with it and represented by `${engineAlias}`.
 
 Note that each connected engine must have its respective history level set to `FULL` in order to see all available data
-in Optimize. Using any other history level will result in less data and/or functionality within Optimize.
+in Optimize. Using any other history level will result in less data and/or functionality within Optimize. Furthermore,
+history in a connected engine should be configured for long enough for Optimize to import it. If data is removed from an
+engine before Optimize has imported it, that data will not be available in Optimize.
 
 | YAML Path                                      | Default Value                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ---------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
relates to OPT-6890

## Description

From a support ticket, we should clarify that engine data needs to remain for enough time for Optimize to import it, or it will be lost

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
