### PR TITLE
feat(docs): describe the process for archiving an unsupported version of the docs

### DIFF
--- a/howtos/versioning.md
+++ b/howtos/versioning.md
@@ -27,6 +27,34 @@ It's likely that the structure will drift over time. To resolve the drift, see [
 
 New versions are created as part of the [release process](/howtos/release-procedure.md).
 
+## Archiving a version
+
+Docusaurus builds the documentation for all versions in the project, even those that are no longer supported. With a large number of versions, this can slow down the build process significantly. We archive versions that are no longer supported to speed up build workflows.
+
+Our current policy is to support versions for 18 months. Any version older than 18 months is suitable for archiving.
+
+When a version is archived, it is removed from the main docs, isolated on a branch named `unsupported/x.xx` where `x.xx` is the version, and deployed to the URLs `https://unsupported.docs.camunda.io/x.xx/` and `https://stage.unsupported.docs.camunda.io/x.xx/`.
+
+### Archival steps
+
+1. Create a new branch named `unsupported/x.xx` where `x.xx` is the version to be archived. The branch should be created from the latest commit on the `main` branch.
+2. On the `main` branch:
+   1. Configure the `publish-prod` workflow to ignore tags for the archived version. See [this PR](https://github.com/camunda/camunda-platform-docs/pull/2172) as an example.
+      - It's important to do this before publishing a production release for the archived version, to avoid accidentally publishing the archived version as the main docs.
+3. On the `unsupported/x.xx` branch:
+   1. Confirm the version number(s) to be archived at the top of the `./hacks/isolateVersion/allSteps.sh` script.
+   2. Run the `./hacks/isolateVersion/allSteps.sh` script. This automates a handful of basic steps; see the script for more details.
+      - For the sake of review-ability, you might consider breaking these changes into multiple PRs. See [this very large PR](https://github.com/camunda/camunda-platform-docs/pull/2165) and [this much smaller PR](https://github.com/camunda/camunda-platform-docs/pull/2166) as examples.
+   3. Make the manual changes described by the output of the `allSteps.sh` script. See [this PR](https://github.com/camunda/camunda-platform-docs/pull/2167) as an example.
+   4. After they're all merged, confirm that these changes publish to the associated staging location: `https://stage.unsupported.docs.camunda.io/x.xx/`.
+   5. Publish the production release for the archived version, by adding a tag to the HEAD of the `unsupported/x.xx` branch.
+      - Name the tag `x.xx.0` where `x.xx` is the version number.
+      - Choose the `unsupported/x.xx` branch as the target.
+      - Deselect the `Set as the latest release` option.
+4. On the `main` branch:
+   1. Remove the archived version from the docs.
+   2. Link to the external unsupported version in the top navigation bar.
+
 ## Further information
 
 The Docusaurus documentation provides a detailed explanation of versioning at [https://v2.docusaurus.io/docs/versioning/](https://v2.docusaurus.io/docs/versioning/).


### PR DESCRIPTION
## Description

Adds a rough initial description of the process for archiving an unsupported version of the docs.

I'll be updating this new content as I learn things during the archival process.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
