### PR TITLE
fix(data-handling): correct variable scope documentation

### DIFF
--- a/docs/components/modeler/data-handling.md
+++ b/docs/components/modeler/data-handling.md
@@ -22,4 +22,4 @@ The provided data schema is only used by the FEEL editor to provide variable sug
 
 ![Variable suggestions with additional Variables](img/data-handling-example-json.png)
 
-Data provided this way is added to the nearest scope. If an element has output mappings, the data will only be available in the element itself. Otherwise, all variables will be passed to the parent scope. Check the [variable concepts page](../concepts/variables.md) for more information on variables and variable scopes.
+Data provided this way is added to scope of the element. To use the data in other parts of your process, you can use output mappings to make the variables available in the parent scope. Check the [variable concepts page](../concepts/variables.md) for more information on variables, scopes, and output mappings.

--- a/versioned_docs/version-8.2/components/modeler/data-handling.md
+++ b/versioned_docs/version-8.2/components/modeler/data-handling.md
@@ -22,4 +22,4 @@ The provided data schema is only used by the FEEL editor to provide variable sug
 
 ![Variable suggestions with additional Variables](img/data-handling-example-json.png)
 
-Data provided this way is added to the nearest scope. If an element has output mappings, the data will only be available in the element itself. Otherwise, all variables will be passed to the parent scope. Check the [variable concepts page](../concepts/variables.md) for more information on variables and variable scopes.
+Data provided this way is added to scope of the element. To use the data in other parts of your process, you can use output mappings to make the variables available in the parent scope. Check the [variable concepts page](../concepts/variables.md) for more information on variables, scopes, and output mappings.


### PR DESCRIPTION
## Description

This fixes the documentation about scoped example variables to reflect the latest changes from https://github.com/camunda/example-data-properties-provider/pull/8 .

related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/934 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
