### PR TITLE
docs(tasklist): Fix custom user and password configuration

### DIFF
--- a/docs/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -15,7 +15,7 @@ By default, user storage in Elasticsearch is enabled.
 
 In this mode, the user authenticates with a username and password stored in Elasticsearch.
 
-The **username**, **password**, and **roles** for one user may be set in application.yml:
+The **userId**, **password**, and **roles** for one user may be set in application.yml:
 
 ```
 camunda.tasklist:

--- a/docs/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -19,7 +19,7 @@ The **username**, **password**, and **roles** for one user may be set in applica
 
 ```
 camunda.tasklist:
-  username: anUser
+  userId: aUser
   password: aPassword
   roles:
     - OWNER

--- a/versioned_docs/version-8.0/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.0/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -15,7 +15,7 @@ By default, user storage in Elasticsearch is enabled.
 
 In this mode, the user authenticates with a username and password stored in Elasticsearch.
 
-The **username**, **password**, and **roles** for one user may be set in application.yml:
+The **userId**, **password**, and **roles** for one user may be set in application.yml:
 
 ```
 camunda.tasklist:

--- a/versioned_docs/version-8.0/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.0/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -19,7 +19,7 @@ The **username**, **password**, and **roles** for one user may be set in applica
 
 ```
 camunda.tasklist:
-  username: anUser
+  userId: aUser
   password: aPassword
   roles:
     - OWNER

--- a/versioned_docs/version-8.1/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.1/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -15,11 +15,11 @@ By default, user storage in Elasticsearch is enabled.
 
 In this mode, the user authenticates with a username and password stored in Elasticsearch.
 
-The **username**, **password**, and **roles** for one user may be set in application.yml:
+The **userId**, **password**, and **roles** for one user may be set in application.yml:
 
 ```
 camunda.tasklist:
-  username: anUser
+  userId: aUser
   password: aPassword
   roles:
     - OWNER

--- a/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -15,7 +15,7 @@ By default, user storage in Elasticsearch is enabled.
 
 In this mode, the user authenticates with a username and password stored in Elasticsearch.
 
-The **username**, **password**, and **roles** for one user may be set in application.yml:
+The **userId**, **password**, and **roles** for one user may be set in application.yml:
 
 ```
 camunda.tasklist:

--- a/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -19,7 +19,7 @@ The **username**, **password**, and **roles** for one user may be set in applica
 
 ```
 camunda.tasklist:
-  username: anUser
+  userId: aUser
   password: aPassword
   roles:
     - OWNER


### PR DESCRIPTION
Closes https://github.com/camunda/tasklist/issues/3051

## Description
The yaml configuration for custom user and password is wrong so I'm fixing it. The only change is that the username config doesn't exist, the correct is userId.


<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
