### PR TITLE
fix(modeler): correct windows app path

### DIFF
--- a/docs/components/modeler/desktop-modeler/troubleshooting.md
+++ b/docs/components/modeler/desktop-modeler/troubleshooting.md
@@ -15,7 +15,7 @@ Depending on your operating system, you can find Desktop Modeler logs in differe
 ### Windows
 
 ```plain
-%APPDATA%\Camunda Modeler\logs
+%APPDATA%\camunda-modeler\logs
 ```
 
 ### MacOS

--- a/versioned_docs/version-8.2/components/modeler/desktop-modeler/troubleshooting.md
+++ b/versioned_docs/version-8.2/components/modeler/desktop-modeler/troubleshooting.md
@@ -15,7 +15,7 @@ Depending on your operating system, you can find Desktop Modeler logs in differe
 ### Windows
 
 ```plain
-%APPDATA%\Camunda Modeler\logs
+%APPDATA%\camunda-modeler\logs
 ```
 
 ### MacOS


### PR DESCRIPTION
## Description

The documented path for Windows logs does not exist. It used `camunda-modeler` instead of `Camunda Modeler` in the path

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
