### PR TITLE
Common sidebar entry for RabbitMQ connectors

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -287,8 +287,12 @@ module.exports = {
             "components/connectors/out-of-the-box-connectors/openai",
             "components/connectors/out-of-the-box-connectors/operate",
             "components/connectors/out-of-the-box-connectors/power-automate",
-            "components/connectors/out-of-the-box-connectors/rabbitmq",
-            "components/connectors/out-of-the-box-connectors/rabbitmq-inbound",
+            {
+              RabbitMQ: [
+                "components/connectors/out-of-the-box-connectors/rabbitmq",
+                "components/connectors/out-of-the-box-connectors/rabbitmq-inbound",
+              ],
+            },
             "components/connectors/out-of-the-box-connectors/sendgrid",
             "components/connectors/out-of-the-box-connectors/slack",
             "components/connectors/out-of-the-box-connectors/twilio",

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -336,8 +336,12 @@
             "components/connectors/out-of-the-box-connectors/openai",
             "components/connectors/out-of-the-box-connectors/operate",
             "components/connectors/out-of-the-box-connectors/power-automate",
-            "components/connectors/out-of-the-box-connectors/rabbitmq",
-            "components/connectors/out-of-the-box-connectors/rabbitmq-inbound",
+            {
+              "RabbitMQ": [
+                "components/connectors/out-of-the-box-connectors/rabbitmq",
+                "components/connectors/out-of-the-box-connectors/rabbitmq-inbound"
+              ]
+            },
             "components/connectors/out-of-the-box-connectors/sendgrid",
             "components/connectors/out-of-the-box-connectors/slack",
             "components/connectors/out-of-the-box-connectors/twilio",

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -353,8 +353,12 @@
             "components/connectors/out-of-the-box-connectors/openai",
             "components/connectors/out-of-the-box-connectors/operate",
             "components/connectors/out-of-the-box-connectors/power-automate",
-            "components/connectors/out-of-the-box-connectors/rabbitmq",
-            "components/connectors/out-of-the-box-connectors/rabbitmq-inbound",
+            {
+              "RabbitMQ": [
+                "components/connectors/out-of-the-box-connectors/rabbitmq",
+                "components/connectors/out-of-the-box-connectors/rabbitmq-inbound"
+              ]
+            },
             "components/connectors/out-of-the-box-connectors/sendgrid",
             "components/connectors/out-of-the-box-connectors/slack",
             "components/connectors/out-of-the-box-connectors/twilio",


### PR DESCRIPTION
## Description

This PR adds a common sidebar entry for RabbitMQ Connectors:
```
| RabbitMQ
| - RabbitMQ Producer Connector
| - RabbitMQ Consumer Connector
```

We have previously done the same for Kafka and GitHub

## When should this change go live?

Any time.

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
