### PR TITLE
docs(desktop-modeler): enable further debug logging

### DIFF
--- a/docs/components/modeler/desktop-modeler/troubleshooting.md
+++ b/docs/components/modeler/desktop-modeler/troubleshooting.md
@@ -106,5 +106,5 @@ Certificate chain
 You can also start Desktop Modeler with GRPC logging turned on to get detailed [logging output](#how-to-obtain-the-modeler-logs) on communication to Zeebe:
 
 ```sh
-ZEEBE_NODE_LOG_LEVEL=DEBUG GRPC_VERBOSITY=DEBUG GRPC_TRACE=all camunda-modeler
+DEBUG=* ZEEBE_NODE_LOG_LEVEL=DEBUG GRPC_VERBOSITY=DEBUG GRPC_TRACE=all camunda-modeler
 ```

--- a/versioned_docs/version-8.2/components/modeler/desktop-modeler/troubleshooting.md
+++ b/versioned_docs/version-8.2/components/modeler/desktop-modeler/troubleshooting.md
@@ -106,5 +106,5 @@ Certificate chain
 You can also start Desktop Modeler with GRPC logging turned on to get detailed [logging output](#how-to-obtain-the-modeler-logs) on communication to Zeebe:
 
 ```sh
-ZEEBE_NODE_LOG_LEVEL=DEBUG GRPC_VERBOSITY=DEBUG GRPC_TRACE=all camunda-modeler
+DEBUG=* ZEEBE_NODE_LOG_LEVEL=DEBUG GRPC_VERBOSITY=DEBUG GRPC_TRACE=all camunda-modeler
 ```


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

This enables further debug logging that was previously hidden:

![image](https://github.com/camunda/camunda-platform-docs/assets/58601/ab443cea-2b77-4823-bdd3-0a72d737ffde)

This supports nicely further improvements in `zeebe-node` logging: https://github.com/camunda-community-hub/zeebe-client-node-js/pull/321.

## When should this change go live?

- [x] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
