### PR TITLE
chore(web-modeler): update supported PostgreSQL versions

### DIFF
--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -39,7 +39,7 @@ Requirements for the components can be seen below:
 | Tasklist    | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                                                                |
 | Identity    | OpenJDK 17+  | Keycloak 21.x<br/>PostgreSQL 14.x, 15.x                                                                                                   |
 | Optimize    | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                                                                |
-| Web Modeler | -            | Keycloak 21.x<br/>PostgreSQL 14.x, Amazon Aurora PostgreSQL 14.x (other database systems are currently not supported)                     |
+| Web Modeler | -            | Keycloak 21.x<br/>PostgreSQL 13.x, 14.x, 15.x, Amazon Aurora PostgreSQL 14.x (other database systems are currently not supported)         |
 
 ### Version Matrix
 

--- a/versioned_docs/version-8.2/reference/supported-environments.md
+++ b/versioned_docs/version-8.2/reference/supported-environments.md
@@ -32,14 +32,14 @@ We highly recommend running Camunda Platform 8 Self-Managed in a Kubernetes envi
 
 Requirements for the components can be seen below:
 
-| Component   | Java version | Other requirements                                                                                                                        |
-| ----------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Zeebe       | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x (only if Elastic exporter is used), 8.5.x, 8.6.x, AWS OpenSearch 1.3.x (only if OpenSearch exporter is used) |
-| Operate     | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x, AWS OpenSearch 1.3.x                                                                          |
-| Tasklist    | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                                                                |
-| Identity    | OpenJDK 17+  | Keycloak 16.1.x, 18.x, 19.x<br/>PostgreSQL 14.x, 15.x                                                                                     |
-| Optimize    | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                                                                |
-| Web Modeler | -            | Keycloak 16.1.x, 18.x, 19.x<br/>PostgreSQL 14.x, Amazon Aurora PostgreSQL 14.x (other database systems are currently not supported)       |
+| Component   | Java version | Other requirements                                                                                                                              |
+| ----------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Zeebe       | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x (only if Elastic exporter is used), 8.5.x, 8.6.x, AWS OpenSearch 1.3.x (only if OpenSearch exporter is used)       |
+| Operate     | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x, AWS OpenSearch 1.3.x                                                                                |
+| Tasklist    | OpenJDK 17+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                                                                      |
+| Identity    | OpenJDK 17+  | Keycloak 16.1.x, 18.x, 19.x<br/>PostgreSQL 14.x, 15.x                                                                                           |
+| Optimize    | OpenJDK 11+  | Elasticsearch 7.16.x, 7.17.x, 8.5.x, 8.6.x                                                                                                      |
+| Web Modeler | -            | Keycloak 16.1.x, 18.x, 19.x<br/>PostgreSQL 13.x, 14.x, 15.x, Amazon Aurora PostgreSQL 14.x (other database systems are currently not supported) |
 
 ### Version Matrix
 


### PR DESCRIPTION
## Description
Web Modeler actually supports all PostgreSQL versions >= 13, not just 14.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, ~or they are not for an **already released version**~.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), ~or they are not for **future versions**~.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] ~My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer,~ or my changes do not require a technical writer review.