### PR TITLE
chore(connectors): remove topic from Kafka consumer response in the docs

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/kafka-inbound.md
+++ b/docs/components/connectors/out-of-the-box-connectors/kafka-inbound.md
@@ -62,7 +62,6 @@ The following fields are available in the `response` variable:
 - `key`: The key of the message.
 - `value`: The value of the message.
 - `rawValue`: The value of the message as a JSON string.
-- `topic`: Topic name.
 
 You can use an output mapping to map the response:
 

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -718,6 +718,10 @@ module.exports = {
               "components/connectors/out-of-the-box-connectors/kafka/"
             ),
             docsLink(
+              "Kafka Consumer Connector",
+              "components/connectors/out-of-the-box-connectors/kafka-inbound/"
+            ),
+            docsLink(
               "Microsoft Teams Connector",
               "components/connectors/out-of-the-box-connectors/microsoft-teams/"
             ),

--- a/optimize_versioned_sidebars/version-3.10.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.10.0-sidebars.json
@@ -914,6 +914,11 @@
             },
             {
               "type": "link",
+              "label": "Kafka Consumer Connector",
+              "href": "/docs/components/connectors/out-of-the-box-connectors/kafka-inbound/"
+            },
+            {
+              "type": "link",
               "label": "Microsoft Teams Connector",
               "href": "/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/"
             },

--- a/optimize_versioned_sidebars/version-3.9.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.9.0-sidebars.json
@@ -877,6 +877,11 @@
             },
             {
               "type": "link",
+              "label": "Kafka Consumer Connector",
+              "href": "/docs/8.1/components/connectors/out-of-the-box-connectors/kafka-inbound/"
+            },
+            {
+              "type": "link",
               "label": "Microsoft Teams Connector",
               "href": "/docs/8.1/components/connectors/out-of-the-box-connectors/microsoft-teams/"
             },

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/kafka-inbound.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/kafka-inbound.md
@@ -62,7 +62,6 @@ The following fields are available in the `response` variable:
 - `key`: The key of the message.
 - `value`: The value of the message.
 - `rawValue`: The value of the message as a JSON string.
-- `topic`: Topic name.
 
 You can use an output mapping to map the response:
 

--- a/versioned_docs/version-8.1/self-managed/connectors-deployment/install-and-start.md
+++ b/versioned_docs/version-8.1/self-managed/connectors-deployment/install-and-start.md
@@ -49,6 +49,7 @@ at `connectors/{connector name}/element-templates`:
 | Google Maps Platform Connector | [Camunda Platform Self-Managed Free Edition] |
 | GraphQL Connector              | [Camunda Platform Self-Managed Free Edition] |
 | HTTP Webhook Connector         | [Camunda Platform Self-Managed Free Edition] |
+| Kafka Consumer Connector       | [Camunda Platform Self-Managed Free Edition] |
 | Kafka Producer Connector       | [Camunda Platform Self-Managed Free Edition] |
 | Microsoft Teams Connector      | [Camunda Platform Self-Managed Free Edition] |
 | OpenAI Connector               | [Camunda Platform Self-Managed Free Edition] |

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/kafka-inbound.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/kafka-inbound.md
@@ -62,7 +62,6 @@ The following fields are available in the `response` variable:
 - `key`: The key of the message.
 - `value`: The value of the message.
 - `rawValue`: The value of the message as a JSON string.
-- `topic`: Topic name.
 
 You can use an output mapping to map the response:
 

--- a/versioned_docs/version-8.2/self-managed/connectors-deployment/install-and-start.md
+++ b/versioned_docs/version-8.2/self-managed/connectors-deployment/install-and-start.md
@@ -49,6 +49,7 @@ at `connectors/{connector name}/element-templates`:
 | Google Maps Platform Connector | [Camunda Platform Self-Managed Free Edition] |
 | GraphQL Connector              | [Camunda Platform Self-Managed Free Edition] |
 | HTTP Webhook Connector         | [Camunda Platform Self-Managed Free Edition] |
+| Kafka Consumer Connector       | [Camunda Platform Self-Managed Free Edition] |
 | Kafka Producer Connector       | [Camunda Platform Self-Managed Free Edition] |
 | Microsoft Teams Connector      | [Camunda Platform Self-Managed Free Edition] |
 | OpenAI Connector               | [Camunda Platform Self-Managed Free Edition] |


### PR DESCRIPTION
## Description

Fix Kafka Consumer Connector response description. Removed `topic` from response description in relevant docs.

## When should this change go live?

- [x] There is no urgency with this change.
- [x] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.

## Issue
https://github.com/camunda/camunda-platform-docs/issues/2215
