### PR TITLE
feat: add an archival script for updating theme components

### DIFF
--- a/hacks/isolateVersion/5-updateThemeComponents.sh
+++ b/hacks/isolateVersion/5-updateThemeComponents.sh
@@ -1,0 +1,8 @@
+notify "Updating theme components..."
+
+rm -rf src/theme/AnnouncementBar
+mkdir -p src/theme/DocVersionBanner
+cp hacks/isolateVersion/assets/theme/DocVersionBanner/index.js src/theme/DocVersionBanner/index.js
+
+git add src/theme
+git commit -m "archiving: update theme components"

--- a/hacks/isolateVersion/allSteps.sh
+++ b/hacks/isolateVersion/allSteps.sh
@@ -46,11 +46,14 @@ if [[ "$script_index" == 4 || -z "$script_index" ]]; then
   source $script_directory/4-fixDockerfile.sh
 fi
 
+if [[ "$script_index" == 5 || -z "$script_index" ]]; then
+  source $script_directory/5-updateThemeComponents.sh
+fi
+
 notify "Automated steps are complete!"
 notify "Manual steps that remain: 
 5. Update the docusaurus.config.js
-6. Update the theme components
-7. Update CI workflows
-8. Fix htaccess rules (this might always be manual)
-9. Fix links (this will always be manual)
+6. Update CI workflows
+7. Fix htaccess rules (this might always be manual)
+8. Fix links (this will always be manual)
 "

--- a/hacks/isolateVersion/assets/README.md
+++ b/hacks/isolateVersion/assets/README.md
@@ -1,0 +1,3 @@
+# What is this folder?
+
+This folder contains assets that are used by the automated steps of the archival process.

--- a/hacks/isolateVersion/assets/theme/DocVersionBanner/index.js
+++ b/hacks/isolateVersion/assets/theme/DocVersionBanner/index.js
@@ -1,0 +1,101 @@
+// Why is this swizzled?
+//   To override the message displayed by `LatestVersionSuggestionLabel`. The built-in version
+//    of this component can only link to another internal version, and the message includes a version
+//     defined in this app. In an archived version of our documentation, neither of those pre-requisites are met.
+//   In the `main` branch of these docs, this component exists in an `archive/` folder, so that it is
+//    ignored by docusaurus. In an archived branch of these docs, the component is moved outside of the `archive/`
+//    folder, so that it is recognized by docusaurus.
+//   This is a very simplified version of the built-in DocVersionBanner file, not intended to support
+//    all use cases. It's only intended to meet the needs of an archived version of the docs.
+// Swizzled from version 2.3.1.
+
+import React from "react";
+import clsx from "clsx";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Link from "@docusaurus/Link";
+import Translate from "@docusaurus/Translate";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import { useDocsVersion } from "@docusaurus/theme-common/internal";
+
+function UnmaintainedVersionLabel({ siteTitle, versionMetadata }) {
+  return (
+    <Translate
+      id="theme.docs.versions.unmaintainedVersionLabels"
+      description="The label used to tell the user that they're browsing an unmaintained doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}
+    >
+      {
+        "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained."
+      }
+    </Translate>
+  );
+}
+
+function BannerLabel(props) {
+  return <UnmaintainedVersionLabel {...props} />;
+}
+
+function LatestVersionSuggestionLabel({ versionLabel }) {
+  return (
+    <Translate
+      id="theme.docs.versions.latestVersionSuggestionLabel"
+      description="The label used to tell the user to check the latest version"
+      values={{
+        versionLabel,
+        latestVersionLink: (
+          <b>
+            <Link to="https://docs.camunda.io">
+              <Translate
+                id="theme.docs.versions.latestVersionLinkLabel"
+                description="The label used for the latest version suggestion link label"
+              >
+                latest version
+              </Translate>
+            </Link>
+          </b>
+        ),
+      }}
+    >
+      {"For up-to-date documentation, see the {latestVersionLink}."}
+    </Translate>
+  );
+}
+
+function DocVersionBannerEnabled({ className, versionMetadata }) {
+  const {
+    siteConfig: { title: siteTitle },
+  } = useDocusaurusContext();
+  return (
+    <div
+      className={clsx(
+        className,
+        ThemeClassNames.docs.docVersionBanner,
+        "alert alert--warning margin-bottom--md"
+      )}
+      role="alert"
+    >
+      <div>
+        <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
+      </div>
+      <div className="margin-top--md">
+        <LatestVersionSuggestionLabel />
+      </div>
+    </div>
+  );
+}
+
+export default function DocVersionBanner({ className }) {
+  const versionMetadata = useDocsVersion();
+  if (versionMetadata.banner) {
+    return (
+      <DocVersionBannerEnabled
+        className={className}
+        versionMetadata={versionMetadata}
+      />
+    );
+  }
+  return null;
+}


### PR DESCRIPTION
## Description

Part of #1173.

Adds an archival script, and associated assets, for making the theme changes that an isolated site needs. 

The end result of running this step is [this commit](https://github.com/camunda/camunda-platform-docs/pull/2167/commits/bfb4071aa7c492f5db947cb3a3593005ac5c1747), from [this 0.25 isolation PR](https://github.com/camunda/camunda-platform-docs/pull/2167).

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
