### PR TITLE
feat(backups): clearer generation

### DIFF
--- a/docs/components/concepts/backups.md
+++ b/docs/components/concepts/backups.md
@@ -20,7 +20,7 @@ Backups are created and managed on a per-cluster basis. It is important to be aw
 Exercise caution when deleting clusters to avoid unintended loss of backups.
 :::
 
-Your cluster generation needs to be greater or equal to `8.2.4-alpha1` to support backups.
+Your cluster generation needs to be greater or equal to `8.2.4` to support backups.
 
 ## Rate limits
 

--- a/versioned_docs/version-8.2/components/concepts/backups.md
+++ b/versioned_docs/version-8.2/components/concepts/backups.md
@@ -20,7 +20,7 @@ Backups are created and managed on a per-cluster basis. It is important to be aw
 Exercise caution when deleting clusters to avoid unintended loss of backups.
 :::
 
-Your cluster generation needs to be greater or equal to `8.2.4-alpha1` to support backups.
+Your cluster generation needs to be greater or equal to `8.2.4` to support backups.
 
 ## Rate limits
 


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

The `alpha1` suffix on the generation is a bit confusing (also technically true). It might make customers think that its not supported on stable versions.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
