### PR TITLE
operate_8_2_6_support_notice

### DIFF
--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -27,7 +27,7 @@ You should not update directly from 8.1.x to 8.2.6 (it will require manual inter
 
 To prevent this entirely we removed the Operate 8.2.6 artifacts from this release.
 
-Camunda Platform 8.2.7 is scheduled to be officially released on Tuesday Jun 13th.
+As Camunda Platform 8.2.7 was already released on Tuesday Jun 13th, you can just update to 8.2.7 directly, skipping 8.2.6.
 
 ### OpenSearch 1.3.x support
 

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -19,6 +19,16 @@ End of maintenance: 8th of October 2024
 [Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.2.0)
 [Release blog](https://camunda.com/blog/2023/04/camunda-platform-8-2-key-to-scaling-automation/)
 
+### Do not update from Camunda Platform 8.1.X to 8.2.6
+
+An issue in the Operate 8.2.6 patch was discovered after it was published on June 8th.
+
+You should not update directly from 8.1.x to 8.2.6 (it will require manual intervention as indices break), you either first update to 8.2.5 then 8.2.6 or straight from 8.1.x to 8.2.7.
+
+To prevent this entirely we removed the Operate 8.2.6 artifacts from this release.
+
+Camunda Platform 8.2.7 is scheduled to be officially released on Tuesday Jun 13th.
+
 ### OpenSearch 1.3.x support
 
 - Operate version 8.2+ now also support OpenSearch 1.3.x.

--- a/versioned_docs/version-8.2/reference/announcements.md
+++ b/versioned_docs/version-8.2/reference/announcements.md
@@ -13,6 +13,16 @@ End of maintenance: 8th of October 2024
 [Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.2.0)
 [Release blog](https://camunda.com/blog/2023/04/camunda-platform-8-2-key-to-scaling-automation/)
 
+### Do not update from Camunda Platform 8.1.X to 8.2.6
+
+An issue in the Operate 8.2.6 patch was discovered after it was published on June 8th.
+
+You should not update directly from 8.1.x to 8.2.6 (it will require manual intervention as indices break), you either first update to 8.2.5 then 8.2.6 or straight from 8.1.x to 8.2.7.
+
+To prevent this entirely we removed the Operate 8.2.6 artifacts from this release.
+
+Camunda Platform 8.2.7 is scheduled to be officially released on Tuesday Jun 13th.
+
 ### OpenSearch 1.3.x support
 
 - Operate version 8.2+ now also support OpenSearch 1.3.x.

--- a/versioned_docs/version-8.2/reference/announcements.md
+++ b/versioned_docs/version-8.2/reference/announcements.md
@@ -21,7 +21,7 @@ You should not update directly from 8.1.x to 8.2.6 (it will require manual inter
 
 To prevent this entirely we removed the Operate 8.2.6 artifacts from this release.
 
-Camunda Platform 8.2.7 is scheduled to be officially released on Tuesday Jun 13th.
+As Camunda Platform 8.2.7 was already released on Tuesday Jun 13th, you can just update to 8.2.7 directly, skipping 8.2.6.
 
 ### OpenSearch 1.3.x support
 


### PR DESCRIPTION
## Description

Added text to the announcements section to warn users to not directly udpate from 8.1.x to 8.2.6.

## When should this change go live?

asap

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
