### PR TITLE
chore: isolation of version 0.26, followup: fix htaccess rules

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -8,8 +8,8 @@ Options -Indexes -MultiViews
 
 # Redirect pages - https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule
 
-RewriteRule ^docs/components/overview/(.*)$ /0.26/components/components-overview/$1 [R=301,L]
-RewriteRule ^docs/components/overview$ /0.26/components/components-overview/ [R=301,L]
+RewriteRule ^docs/components/overview/(.*)$ /0.26/docs/components/$1 [R=301,L]
+RewriteRule ^docs/components/overview$ /0.26/docs/components/ [R=301,L]
 
 # Add yaml mime type
 AddType text/vnd.yaml   yaml


### PR DESCRIPTION
Note that this is targeting the `unsupported/0.26` branch, not `main`.

## Description

The rules in the htaccess file for the 0.26 site were incorrect. This fixes them!

I don't consider this blocking the release of `main`, as it's a very minor edge-case that we probably don't care much about anyway. But I'll get this out today, if it receives approval.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
