### PR TITLE
docs(ootbc): add eventBridge documentation

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -28,8 +28,9 @@ import TabItem from "@theme/TabItem";
 ## Outbound Connectors
 
 - [Amazon DynamoDB Connector](/components/connectors/out-of-the-box-connectors/aws-dynamodb.md) - Interact with [Amazon DynamoDB NoSQL database service](https://aws.amazon.com/dynamodb/) within your BPMN process, enabling you to store and retrieve data from tables, as well as perform queries and scans.
-- [Amazon SNS outbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns.md) - Send messages to [Amazon Simple Notification Service](https://aws.amazon.com/sns/) from your BPMN process.
-- [Amazon SNS inbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns-inbound.md) - Trigger your BPMN process with an [Amazon Simple Notification Service](https://aws.amazon.com/sns/) notification via HTTPS.
+- [Amazon EventBridge Service Connector](/components/connectors/out-of-the-box-connectors/aws-eventbridge.md) - Send events using [Amazon EventBridge service](https://aws.amazon.com/eventbridge/) within your BPMN process.
+- [Amazon SNS Outbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns.md) - Send messages to [Amazon Simple Notification Service](https://aws.amazon.com/sns/) from your BPMN process.
+- [Amazon SNS Inbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns-inbound.md) - Trigger your BPMN process with an [Amazon Simple Notification Service](https://aws.amazon.com/sns/) notification via HTTPS.
 - [Amazon SQS Connector](/components/connectors/out-of-the-box-connectors/aws-sqs.md) - Send messages to [Amazon Simple Queue Service](https://aws.amazon.com/sqs/) from your BPMN process.
 - [Asana Connector](/components/connectors/out-of-the-box-connectors/asana.md) - Manage [Asana](https://asana.com/) projects and tasks from your BPMN process.
 - [Automation Anywhere Connector](/components/connectors/out-of-the-box-connectors/automation-anywhere.md) - Orchestrate your [Automation Anywhere](https://www.automationanywhere.com/) queue from your BPMN process.

--- a/docs/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
+++ b/docs/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
@@ -1,0 +1,76 @@
+---
+id: aws-eventbridge
+title: Amazon EventBridge Connector
+description: Send events to AWS EventBridge from your BPMN process.
+---
+
+The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge Service](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
+
+For more information, see the [AWS EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/index.html).
+
+## Prerequisites
+
+Before using the **Amazon EventBridge Connector**, ensure that you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
+
+:::note
+**Note:** It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create an Amazon EventBridge Connector task
+
+To use the **Amazon EventBridge Connector** in your process, you can either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Refer to our [guide on using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+
+## Configure the Amazon EventBridge Connector
+
+Follow these steps to configure the Amazon EventBridge Connector:
+
+1. In the **Authentication** section, enter the relevant IAM key and secret pair of the user with permissions to send events to [AWS EventBridge](https://aws.amazon.com/eventbridge).
+2. In the **Configuration** section, specify the AWS region where your EventBridge resides.
+3. In the **Event Details** section, provide the following information:
+   - **Event bus name**: Enter the name of the destination event bus. Refer to the [AWS EventBridge documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-event-bus.html) for more details on event buses.
+   - **Source**: Enter the value that identifies the service that generated the event.
+   - **Detail type**: Enter the type of event being sent. Refer to the [official documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events-structure.html) for more information on these properties.
+4. In the **Event Payload** section, enter a JSON object that contains information about the event.
+5. (Optional) In the **Output Mapping** section, you can set a **Result variable** or **Result expression**. See the [response mapping documentation](/docs/components/connectors/use-connectors/index.md#response-mapping) to learn more.
+6. (Optional) In the **Error Handling** section, define the **Error expression** to handle errors that may occur during the event sending process. See the [response mapping documentation](/docs/components/connectors/use-connectors/index.md#bpmn-errors) to learn more.
+
+## Amazon EventBridge Connector response
+
+The **Amazon EventBridge Connector** returns the [original response](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html) from the Amazon EventBridge service, including the **sdkResponseMetadata** and **sdkHttpMetadata**. Here is an example of the response:
+
+```json
+{
+  "sdkResponseMetadata": {
+    "requestId": "766647a2-835a-418b-9161-94245d0c93a3"
+  },
+  "sdkHttpMetadata": {
+    "httpHeaders": {
+      "Content-Length": "85",
+      "Content-Type": "application/x-amz-json-1.1",
+      "Date": "Fri, 23 Jun 2023 08:39:22 GMT",
+      "x-amzn-RequestId": "766647a2-835a-418b-9161-94245d0c93a3"
+    },
+    "httpStatusCode": 200,
+    "allHttpHeaders": {
+      "x-amzn-RequestId": ["766647a2-835a-418b-9161-94245d0c93a3"],
+      "Content-Length": ["85"],
+      "Date": ["Fri, 23 Jun 2023 08:39:22 GMT"],
+      "Content-Type": ["application/x-amz-json-1.1"]
+    }
+  },
+  "failedEntryCount": 0,
+  "entries": [
+    {
+      "eventId": "bb86b1af-9abb-0f8e-28c2-c69c24c35e05",
+      "errorCode": null,
+      "errorMessage": null
+    }
+  ]
+}
+```
+
+## Next Steps
+
+- [Amazon EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/)
+- Learn about [other connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
+- Learn more about using connectors [here](../use-connectors/index.md).

--- a/docs/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
+++ b/docs/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
@@ -4,16 +4,16 @@ title: Amazon EventBridge Connector
 description: Send events to AWS EventBridge from your BPMN process.
 ---
 
-The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge Service](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
+The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
 
-For more information, see the [AWS EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/index.html).
+For more information, see the [AWS EventBridge documentation](https://docs.aws.amazon.com/eventbridge/index.html).
 
 ## Prerequisites
 
-Before using the **Amazon EventBridge Connector**, ensure that you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
+Before using the **Amazon EventBridge Connector**, ensure you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
 
 :::note
-**Note:** It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
 ## Create an Amazon EventBridge Connector task
@@ -69,8 +69,8 @@ The **Amazon EventBridge Connector** returns the [original response](https://doc
 }
 ```
 
-## Next Steps
+## Next steps
 
-- [Amazon EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/)
-- Learn about [other connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
-- Learn more about using connectors [here](../use-connectors/index.md).
+- [Amazon EventBridge documentation](https://docs.aws.amazon.com/eventbridge/)
+- Learn about [other Connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
+- Learn more about using Connectors [here](../use-connectors/index.md).

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -654,6 +654,10 @@ module.exports = {
               "components/connectors/out-of-the-box-connectors/aws-dynamodb/"
             ),
             docsLink(
+              "Amazon EventBridge Connector",
+              "components/connectors/out-of-the-box-connectors/aws-eventbridge/"
+            ),
+            docsLink(
               "Amazon SNS Connector",
               "components/connectors/out-of-the-box-connectors/aws-sns/"
             ),

--- a/sidebars.js
+++ b/sidebars.js
@@ -262,6 +262,7 @@ module.exports = {
             {
               AWS: [
                 "components/connectors/out-of-the-box-connectors/aws-dynamodb",
+                "components/connectors/out-of-the-box-connectors/aws-eventbridge",
                 "components/connectors/out-of-the-box-connectors/aws-lambda",
                 "components/connectors/out-of-the-box-connectors/aws-sns",
                 "components/connectors/out-of-the-box-connectors/aws-sns-inbound",

--- a/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -27,6 +27,7 @@ import TabItem from "@theme/TabItem";
 ## Outbound Connectors
 
 - [Amazon DynamoDB Connector](/components/connectors/out-of-the-box-connectors/aws-dynamodb.md) - Interact with [Amazon DynamoDB NoSQL database service](https://aws.amazon.com/dynamodb/) within your BPMN process, enabling you to store and retrieve data from tables, as well as perform queries and scans.
+- [Amazon EventBridge Service Connector](/components/connectors/out-of-the-box-connectors/aws-eventbridge.md) - Send events using [Amazon EventBridge service](https://aws.amazon.com/eventbridge/) within your BPMN process.
 - [Amazon SNS Connector](/components/connectors/out-of-the-box-connectors/aws-sns.md) - Send messages to [Amazon Simple Notification Service](https://aws.amazon.com/sns/) from your BPMN process.
 - [Amazon SQS Connector](/components/connectors/out-of-the-box-connectors/aws-sqs.md) - Send messages to [Amazon Simple Queue Service](https://aws.amazon.com/sqs/) from your BPMN process.
 - [Asana Connector](/components/connectors/out-of-the-box-connectors/asana.md) - Manage [Asana](https://asana.com/) projects and tasks from your BPMN process.

--- a/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
+++ b/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
@@ -1,0 +1,76 @@
+---
+id: aws-eventbridge
+title: Amazon EventBridge Connector
+description: Send events to AWS EventBridge from your BPMN process.
+---
+
+The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge Service](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
+
+For more information, see the [AWS EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/index.html).
+
+## Prerequisites
+
+Before using the **Amazon EventBridge Connector**, ensure that you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
+
+:::note
+**Note:** It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create an Amazon EventBridge Connector task
+
+To use the **Amazon EventBridge Connector** in your process, you can either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Refer to our [guide on using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+
+## Configure the Amazon EventBridge Connector
+
+Follow these steps to configure the Amazon EventBridge Connector:
+
+1. In the **Authentication** section, enter the relevant IAM key and secret pair of the user with permissions to send events to [AWS EventBridge](https://aws.amazon.com/eventbridge).
+2. In the **Configuration** section, specify the AWS region where your EventBridge resides.
+3. In the **Event Details** section, provide the following information:
+   - **Event bus name**: Enter the name of the destination event bus. Refer to the [AWS EventBridge documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-event-bus.html) for more details on event buses.
+   - **Source**: Enter the value that identifies the service that generated the event.
+   - **Detail type**: Enter the type of event being sent. Refer to the [official documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events-structure.html) for more information on these properties.
+4. In the **Event Payload** section, enter a JSON object that contains information about the event.
+5. (Optional) In the **Output Mapping** section, you can set a **Result variable** or **Result expression**. See the [response mapping documentation](/docs/components/connectors/use-connectors/index.md#response-mapping) to learn more.
+6. (Optional) In the **Error Handling** section, define the **Error expression** to handle errors that may occur during the event sending process. See the [response mapping documentation](/docs/components/connectors/use-connectors/index.md#bpmn-errors) to learn more.
+
+## Amazon EventBridge Connector response
+
+The **Amazon EventBridge Connector** returns the [original response](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html) from the Amazon EventBridge service, including the **sdkResponseMetadata** and **sdkHttpMetadata**. Here is an example of the response:
+
+```json
+{
+  "sdkResponseMetadata": {
+    "requestId": "766647a2-835a-418b-9161-94245d0c93a3"
+  },
+  "sdkHttpMetadata": {
+    "httpHeaders": {
+      "Content-Length": "85",
+      "Content-Type": "application/x-amz-json-1.1",
+      "Date": "Fri, 23 Jun 2023 08:39:22 GMT",
+      "x-amzn-RequestId": "766647a2-835a-418b-9161-94245d0c93a3"
+    },
+    "httpStatusCode": 200,
+    "allHttpHeaders": {
+      "x-amzn-RequestId": ["766647a2-835a-418b-9161-94245d0c93a3"],
+      "Content-Length": ["85"],
+      "Date": ["Fri, 23 Jun 2023 08:39:22 GMT"],
+      "Content-Type": ["application/x-amz-json-1.1"]
+    }
+  },
+  "failedEntryCount": 0,
+  "entries": [
+    {
+      "eventId": "bb86b1af-9abb-0f8e-28c2-c69c24c35e05",
+      "errorCode": null,
+      "errorMessage": null
+    }
+  ]
+}
+```
+
+## Next Steps
+
+- [Amazon EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/)
+- Learn about [other connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
+- Learn more about using connectors [here](../use-connectors/index.md).

--- a/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
+++ b/versioned_docs/version-8.0/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
@@ -4,16 +4,16 @@ title: Amazon EventBridge Connector
 description: Send events to AWS EventBridge from your BPMN process.
 ---
 
-The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge Service](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
+The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
 
-For more information, see the [AWS EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/index.html).
+For more information, see the [AWS EventBridge documentation](https://docs.aws.amazon.com/eventbridge/index.html).
 
 ## Prerequisites
 
-Before using the **Amazon EventBridge Connector**, ensure that you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
+Before using the **Amazon EventBridge Connector**, ensure you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
 
 :::note
-**Note:** It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
 ## Create an Amazon EventBridge Connector task
@@ -69,8 +69,8 @@ The **Amazon EventBridge Connector** returns the [original response](https://doc
 }
 ```
 
-## Next Steps
+## Next steps
 
-- [Amazon EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/)
-- Learn about [other connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
-- Learn more about using connectors [here](../use-connectors/index.md).
+- [Amazon EventBridge documentation](https://docs.aws.amazon.com/eventbridge/)
+- Learn about [other Connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
+- Learn more about using Connectors [here](../use-connectors/index.md).

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -28,8 +28,9 @@ import TabItem from "@theme/TabItem";
 ## Outbound Connectors
 
 - [Amazon DynamoDB Connector](/components/connectors/out-of-the-box-connectors/aws-dynamodb.md) - Interact with [Amazon DynamoDB NoSQL database service](https://aws.amazon.com/dynamodb/) within your BPMN process, enabling you to store and retrieve data from tables, as well as perform queries and scans.
-- [Amazon SNS outbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns.md) - Send messages to [Amazon Simple Notification Service](https://aws.amazon.com/sns/) from your BPMN process.
-- [Amazon SNS inbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns-inbound.md) - Trigger your BPMN process with an [Amazon Simple Notification Service](https://aws.amazon.com/sns/) notification via HTTPS.
+- [Amazon EventBridge Service Connector](/components/connectors/out-of-the-box-connectors/aws-eventbridge.md) - Send events using [Amazon EventBridge service](https://aws.amazon.com/eventbridge/) within your BPMN process.
+- [Amazon SNS Outbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns.md) - Send messages to [Amazon Simple Notification Service](https://aws.amazon.com/sns/) from your BPMN process.
+- [Amazon SNS Inbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns-inbound.md) - Trigger your BPMN process with an [Amazon Simple Notification Service](https://aws.amazon.com/sns/) notification via HTTPS.
 - [Amazon SQS Connector](/components/connectors/out-of-the-box-connectors/aws-sqs.md) - Send messages to [Amazon Simple Queue Service](https://aws.amazon.com/sqs/) from your BPMN process.
 - [Asana Connector](/components/connectors/out-of-the-box-connectors/asana.md) - Manage [Asana](https://asana.com/) projects and tasks from your BPMN process.
 - [Automation Anywhere Connector](/components/connectors/out-of-the-box-connectors/automation-anywhere.md) - Orchestrate your [Automation Anywhere](https://www.automationanywhere.com/) queue from your BPMN process.

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
@@ -1,0 +1,76 @@
+---
+id: aws-eventbridge
+title: Amazon EventBridge Connector
+description: Send events to AWS EventBridge from your BPMN process.
+---
+
+The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge Service](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
+
+For more information, see the [AWS EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/index.html).
+
+## Prerequisites
+
+Before using the **Amazon EventBridge Connector**, ensure that you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
+
+:::note
+**Note:** It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create an Amazon EventBridge Connector task
+
+To use the **Amazon EventBridge Connector** in your process, you can either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Refer to our [guide on using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+
+## Configure the Amazon EventBridge Connector
+
+Follow these steps to configure the Amazon EventBridge Connector:
+
+1. In the **Authentication** section, enter the relevant IAM key and secret pair of the user with permissions to send events to [AWS EventBridge](https://aws.amazon.com/eventbridge).
+2. In the **Configuration** section, specify the AWS region where your EventBridge resides.
+3. In the **Event Details** section, provide the following information:
+   - **Event bus name**: Enter the name of the destination event bus. Refer to the [AWS EventBridge documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-event-bus.html) for more details on event buses.
+   - **Source**: Enter the value that identifies the service that generated the event.
+   - **Detail type**: Enter the type of event being sent. Refer to the [official documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events-structure.html) for more information on these properties.
+4. In the **Event Payload** section, enter a JSON object that contains information about the event.
+5. (Optional) In the **Output Mapping** section, you can set a **Result variable** or **Result expression**. See the [response mapping documentation](/docs/components/connectors/use-connectors/index.md#response-mapping) to learn more.
+6. (Optional) In the **Error Handling** section, define the **Error expression** to handle errors that may occur during the event sending process. See the [response mapping documentation](/docs/components/connectors/use-connectors/index.md#bpmn-errors) to learn more.
+
+## Amazon EventBridge Connector response
+
+The **Amazon EventBridge Connector** returns the [original response](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html) from the Amazon EventBridge service, including the **sdkResponseMetadata** and **sdkHttpMetadata**. Here is an example of the response:
+
+```json
+{
+  "sdkResponseMetadata": {
+    "requestId": "766647a2-835a-418b-9161-94245d0c93a3"
+  },
+  "sdkHttpMetadata": {
+    "httpHeaders": {
+      "Content-Length": "85",
+      "Content-Type": "application/x-amz-json-1.1",
+      "Date": "Fri, 23 Jun 2023 08:39:22 GMT",
+      "x-amzn-RequestId": "766647a2-835a-418b-9161-94245d0c93a3"
+    },
+    "httpStatusCode": 200,
+    "allHttpHeaders": {
+      "x-amzn-RequestId": ["766647a2-835a-418b-9161-94245d0c93a3"],
+      "Content-Length": ["85"],
+      "Date": ["Fri, 23 Jun 2023 08:39:22 GMT"],
+      "Content-Type": ["application/x-amz-json-1.1"]
+    }
+  },
+  "failedEntryCount": 0,
+  "entries": [
+    {
+      "eventId": "bb86b1af-9abb-0f8e-28c2-c69c24c35e05",
+      "errorCode": null,
+      "errorMessage": null
+    }
+  ]
+}
+```
+
+## Next Steps
+
+- [Amazon EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/)
+- Learn about [other connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
+- Learn more about using connectors [here](../use-connectors/index.md).

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
@@ -4,16 +4,16 @@ title: Amazon EventBridge Connector
 description: Send events to AWS EventBridge from your BPMN process.
 ---
 
-The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge Service](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
+The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
 
-For more information, see the [AWS EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/index.html).
+For more information, see the [AWS EventBridge documentation](https://docs.aws.amazon.com/eventbridge/index.html).
 
 ## Prerequisites
 
-Before using the **Amazon EventBridge Connector**, ensure that you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
+Before using the **Amazon EventBridge Connector**, ensure you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
 
 :::note
-**Note:** It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
 ## Create an Amazon EventBridge Connector task
@@ -69,8 +69,8 @@ The **Amazon EventBridge Connector** returns the [original response](https://doc
 }
 ```
 
-## Next Steps
+## Next steps
 
-- [Amazon EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/)
-- Learn about [other connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
-- Learn more about using connectors [here](../use-connectors/index.md).
+- [Amazon EventBridge documentation](https://docs.aws.amazon.com/eventbridge/)
+- Learn about [other Connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
+- Learn more about using Connectors [here](../use-connectors/index.md).

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -28,8 +28,9 @@ import TabItem from "@theme/TabItem";
 ## Outbound Connectors
 
 - [Amazon DynamoDB Connector](/components/connectors/out-of-the-box-connectors/aws-dynamodb.md) - Interact with [Amazon DynamoDB NoSQL database service](https://aws.amazon.com/dynamodb/) within your BPMN process, enabling you to store and retrieve data from tables, as well as perform queries and scans.
-- [Amazon SNS outbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns.md) - Send messages to [Amazon Simple Notification Service](https://aws.amazon.com/sns/) from your BPMN process.
-- [Amazon SNS inbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns-inbound.md) - Trigger your BPMN process with an [Amazon Simple Notification Service](https://aws.amazon.com/sns/) notification via HTTPS.
+- [Amazon EventBridge Service Connector](/components/connectors/out-of-the-box-connectors/aws-eventbridge.md) - Send events using [Amazon EventBridge service](https://aws.amazon.com/eventbridge/) within your BPMN process.
+- [Amazon SNS Outbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns.md) - Send messages to [Amazon Simple Notification Service](https://aws.amazon.com/sns/) from your BPMN process.
+- [Amazon SNS Inbound Connector](/components/connectors/out-of-the-box-connectors/aws-sns-inbound.md) - Trigger your BPMN process with an [Amazon Simple Notification Service](https://aws.amazon.com/sns/) notification via HTTPS.
 - [Amazon SQS Connector](/components/connectors/out-of-the-box-connectors/aws-sqs.md) - Send messages to [Amazon Simple Queue Service](https://aws.amazon.com/sqs/) from your BPMN process.
 - [Asana Connector](/components/connectors/out-of-the-box-connectors/asana.md) - Manage [Asana](https://asana.com/) projects and tasks from your BPMN process.
 - [Automation Anywhere Connector](/components/connectors/out-of-the-box-connectors/automation-anywhere.md) - Orchestrate your [Automation Anywhere](https://www.automationanywhere.com/) queue from your BPMN process.

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
@@ -1,0 +1,76 @@
+---
+id: aws-eventbridge
+title: Amazon EventBridge Connector
+description: Send events to AWS EventBridge from your BPMN process.
+---
+
+The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge Service](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
+
+For more information, see the [AWS EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/index.html).
+
+## Prerequisites
+
+Before using the **Amazon EventBridge Connector**, ensure that you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
+
+:::note
+**Note:** It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create an Amazon EventBridge Connector task
+
+To use the **Amazon EventBridge Connector** in your process, you can either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Refer to our [guide on using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+
+## Configure the Amazon EventBridge Connector
+
+Follow these steps to configure the Amazon EventBridge Connector:
+
+1. In the **Authentication** section, enter the relevant IAM key and secret pair of the user with permissions to send events to [AWS EventBridge](https://aws.amazon.com/eventbridge).
+2. In the **Configuration** section, specify the AWS region where your EventBridge resides.
+3. In the **Event Details** section, provide the following information:
+   - **Event bus name**: Enter the name of the destination event bus. Refer to the [AWS EventBridge documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-event-bus.html) for more details on event buses.
+   - **Source**: Enter the value that identifies the service that generated the event.
+   - **Detail type**: Enter the type of event being sent. Refer to the [official documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events-structure.html) for more information on these properties.
+4. In the **Event Payload** section, enter a JSON object that contains information about the event.
+5. (Optional) In the **Output Mapping** section, you can set a **Result variable** or **Result expression**. See the [response mapping documentation](/docs/components/connectors/use-connectors/index.md#response-mapping) to learn more.
+6. (Optional) In the **Error Handling** section, define the **Error expression** to handle errors that may occur during the event sending process. See the [response mapping documentation](/docs/components/connectors/use-connectors/index.md#bpmn-errors) to learn more.
+
+## Amazon EventBridge Connector response
+
+The **Amazon EventBridge Connector** returns the [original response](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html) from the Amazon EventBridge service, including the **sdkResponseMetadata** and **sdkHttpMetadata**. Here is an example of the response:
+
+```json
+{
+  "sdkResponseMetadata": {
+    "requestId": "766647a2-835a-418b-9161-94245d0c93a3"
+  },
+  "sdkHttpMetadata": {
+    "httpHeaders": {
+      "Content-Length": "85",
+      "Content-Type": "application/x-amz-json-1.1",
+      "Date": "Fri, 23 Jun 2023 08:39:22 GMT",
+      "x-amzn-RequestId": "766647a2-835a-418b-9161-94245d0c93a3"
+    },
+    "httpStatusCode": 200,
+    "allHttpHeaders": {
+      "x-amzn-RequestId": ["766647a2-835a-418b-9161-94245d0c93a3"],
+      "Content-Length": ["85"],
+      "Date": ["Fri, 23 Jun 2023 08:39:22 GMT"],
+      "Content-Type": ["application/x-amz-json-1.1"]
+    }
+  },
+  "failedEntryCount": 0,
+  "entries": [
+    {
+      "eventId": "bb86b1af-9abb-0f8e-28c2-c69c24c35e05",
+      "errorCode": null,
+      "errorMessage": null
+    }
+  ]
+}
+```
+
+## Next Steps
+
+- [Amazon EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/)
+- Learn about [other connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
+- Learn more about using connectors [here](../use-connectors/index.md).

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/aws-eventbridge.md
@@ -4,16 +4,16 @@ title: Amazon EventBridge Connector
 description: Send events to AWS EventBridge from your BPMN process.
 ---
 
-The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge Service](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
+The **AWS EventBridge Connector** integrates your BPMN service with [Amazon EventBridge](https://aws.amazon.com/eventbridge/), enabling the sending of events from your workflows for further processing or routing to other AWS services. It provides seamless event-driven integration within your business processes.
 
-For more information, see the [AWS EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/index.html).
+For more information, see the [AWS EventBridge documentation](https://docs.aws.amazon.com/eventbridge/index.html).
 
 ## Prerequisites
 
-Before using the **Amazon EventBridge Connector**, ensure that you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
+Before using the **Amazon EventBridge Connector**, ensure you have the necessary permissions in your AWS account to send events to EventBridge. You will need an access key and secret key of a user with the appropriate permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) for more information.
 
 :::note
-**Note:** It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+It is highly recommended not to expose your AWS IAM credentials as plain text. Instead, use Camunda secrets. Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
 ## Create an Amazon EventBridge Connector task
@@ -69,8 +69,8 @@ The **Amazon EventBridge Connector** returns the [original response](https://doc
 }
 ```
 
-## Next Steps
+## Next steps
 
-- [Amazon EventBridge Documentation](https://docs.aws.amazon.com/eventbridge/)
-- Learn about [other connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
-- Learn more about using connectors [here](../use-connectors/index.md).
+- [Amazon EventBridge documentation](https://docs.aws.amazon.com/eventbridge/)
+- Learn about [other Connectors available](./available-connectors-overview.md) in Camunda to integrate with different systems and services.
+- Learn more about using Connectors [here](../use-connectors/index.md).

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -268,6 +268,7 @@
             {
               "AWS": [
                 "components/connectors/out-of-the-box-connectors/aws-dynamodb",
+                "components/connectors/out-of-the-box-connectors/aws-eventbridge",
                 "components/connectors/out-of-the-box-connectors/aws-lambda",
                 "components/connectors/out-of-the-box-connectors/aws-sns",
                 "components/connectors/out-of-the-box-connectors/aws-sqs"

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -308,6 +308,7 @@
             {
               "AWS": [
                 "components/connectors/out-of-the-box-connectors/aws-dynamodb",
+                "components/connectors/out-of-the-box-connectors/aws-eventbridge",
                 "components/connectors/out-of-the-box-connectors/aws-lambda",
                 "components/connectors/out-of-the-box-connectors/aws-sns",
                 "components/connectors/out-of-the-box-connectors/aws-sns-inbound",

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -328,6 +328,7 @@
             {
               "AWS": [
                 "components/connectors/out-of-the-box-connectors/aws-dynamodb",
+                "components/connectors/out-of-the-box-connectors/aws-eventbridge",
                 "components/connectors/out-of-the-box-connectors/aws-lambda",
                 "components/connectors/out-of-the-box-connectors/aws-sns",
                 "components/connectors/out-of-the-box-connectors/aws-sns-inbound",


### PR DESCRIPTION
## Description

Added AWS EventBridge docs, 
Related : 
https://github.com/camunda/product-hub/issues/467

## When should this change go live?

- [ ] This change is not yet live and should not be merged until 11 July (after release)

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory
- [ ] I have added changes to the main `/docs` directory (aka `/next/`)
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer
