### PR TITLE
Update deploy-to-self-managed.md

### DIFF
--- a/versioned_docs/version-8.2/self-managed/modeler/desktop-modeler/deploy-to-self-managed.md
+++ b/versioned_docs/version-8.2/self-managed/modeler/desktop-modeler/deploy-to-self-managed.md
@@ -27,7 +27,7 @@ Secured connections to a remote endpoint will only be established if the remote 
 4. Select **OAuth**, and input the credentials in case your gateway requires authentication:
 
 :::note
-OAuth for gateway can be implemented with [zeebe-keycloak-interceptor](https://github.com/camunda-community-hub/zeebe-keycloak-interceptor).
+The OAuth URL needs to contain the full path to the token endpoint: `https://<keycloak base url>/realms/camunda-platform/protocol/openid-connect/token`
 :::
 
 ![oauth configuration](./img/deploy-with-oauth.png)


### PR DESCRIPTION
The interceptor is not required in 8.2 anymore. Instead, here is a useful piece of information about the oauth url

## Description

Until 8.2, it was required to use some kind of interceptor to achieve oauth behaviour on zeebe. As of 8.2, zeebe has an embedded oauth mode.

Now, it becomes more relevant to document the oauth url for the self-managed setup.

## When should this change go live?

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
