### PR TITLE
docs: adding configuration for users act and view

### DIFF
--- a/docs/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -21,6 +21,7 @@ The **userId**, **password**, and **roles** for one user may be set in applicati
 camunda.tasklist:
   userId: aUser
   password: aPassword
+  displayName: aDisplayName
   roles:
     - OWNER
     - OPERATOR
@@ -30,9 +31,25 @@ On Tasklist startup, the user is created if they did not exist before.
 
 By default, three users are created:
 
-- Role `OWNER` with **userId**/**displayName**/**password** `demo`/`demo`/`demo`.
-- Role `USER` with **userId**/**displayName**/**password** `view`/`view`/`view`.
-- Role `OPERATOR` with **userId**/**displayName**/**password** `act`/`act`/`act`/.
+- Role `OWNER` with **userId**/**displayName**/**password** `demo`/`demo`/`demo`. To change userId, password, displayName or role for user `demo` use the above configuration.
+
+- Role `USER` with **userId**/**displayName**/**password** `view`/`view`/`view`. To change userId, displayName or password for this user the below configuration can be used:
+
+```
+camunda.tasklist:
+  readerUserId: aUser
+  readerPassword: aPassword
+  readerDisplayName: aDisplayName
+```
+
+- Role `OPERATOR` with **userId**/**displayName**/**password** `act`/`act`/`act`/. To change userId, displayName or password for this user the below configuration can be used:
+
+```
+camunda.tasklist:
+  operatorUserId: aUser
+  operatorPassword: aPassword
+  operatorDisplayName: aDisplayName
+```
 
 More users can be added directly to Elasticsearch, to the index `tasklist-user-<version>_`. The password must be encoded with a strong BCrypt hashing function.
 

--- a/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -21,6 +21,7 @@ The **userId**, **password**, and **roles** for one user may be set in applicati
 camunda.tasklist:
   userId: aUser
   password: aPassword
+  displayName: aDisplayName
   roles:
     - OWNER
     - OPERATOR
@@ -30,9 +31,25 @@ On Tasklist startup, the user is created if they did not exist before.
 
 By default, three users are created:
 
-- Role `OWNER` with **userId**/**displayName**/**password** `demo`/`demo`/`demo`.
-- Role `USER` with **userId**/**displayName**/**password** `view`/`view`/`view`.
-- Role `OPERATOR` with **userId**/**displayName**/**password** `act`/`act`/`act`/.
+- Role `OWNER` with **userId**/**displayName**/**password** `demo`/`demo`/`demo`. To change userId, password, displayName or role for user `demo` use the above configuration.
+
+- Role `USER` with **userId**/**displayName**/**password** `view`/`view`/`view`. To change userId, displayName or password for this user the below configuration can be used:
+
+```
+camunda.tasklist:
+  readerUserId: aUser
+  readerPassword: aPassword
+  readerDisplayName: aDisplayName
+```
+
+- Role `OPERATOR` with **userId**/**displayName**/**password** `act`/`act`/`act`/. To change userId, displayName or password for this user the below configuration can be used:
+
+```
+camunda.tasklist:
+  operatorUserId: aUser
+  operatorPassword: aPassword
+  operatorDisplayName: aDisplayName
+```
 
 More users can be added directly to Elasticsearch, to the index `tasklist-user-<version>_`. The password must be encoded with a strong BCrypt hashing function.
 


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->
On TaskList we are adding extra configurations for users that are created automatically when starting ("act" and "view") to make possible to change the userIds, display names or passwords.

## When should this change go live?
This change is part of the next patch release (8.2.8).

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
