### PR TITLE
Document support for time date events

### DIFF
--- a/docs/components/modeler/bpmn/timer-events/timer-events.md
+++ b/docs/components/modeler/bpmn/timer-events/timer-events.md
@@ -18,15 +18,21 @@ When a timer is triggered, a new process instance is created and the correspondi
 
 ## Intermediate timer catch events
 
-An intermediate timer catch event must have a time duration definition that defines when it is triggered.
+An intermediate timer catch event can either be a time duration, or a time date.
 
 When an intermediate timer catch event is entered, a corresponding timer is scheduled. The process instance stops at this point and waits until the timer is triggered. When the timer is triggered, the catch event is completed and the process instance continues.
 
 ## Timer boundary events
 
-An interrupting timer boundary event must have a time duration definition. When the corresponding timer is triggered, the activity is terminated. Interrupting timer boundary events are often used to model timeouts; for example, canceling the processing after five minutes and doing something else.
+An interrupting timer boundary event must have a time duration, or a time date definition. When the corresponding timer
+is triggered, the activity is terminated. Interrupting timer boundary events are often used to model timeouts; for
+example, canceling the processing after five minutes and doing something else.
 
-A non-interrupting timer boundary event must have either a time duration or time cycle definition. When the activity is entered, it schedules a corresponding timer. If the timer is triggered and defined as time cycle with repetitions greater than zero, it schedules the timer again until the defined number of repetitions is reached.
+A non-interrupting timer boundary event must have either a time duration, a time cycle definition, or a time date
+definition. When the activity is entered, it schedules a corresponding timer. If the timer is triggered and defined as
+time cycle with repetitions greater than zero, it schedules the timer again until the defined number of repetitions is
+reached. It's important to note that a non-interrupting timer boundary event that's defined with a time duration will
+only trigger a single time once the date is reached.
 
 Non-interrupting timer boundary events are often used to model notifications; for example, contacting support if the processing takes longer than an hour.
 


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->
As of 8.3 Zeebe officially supports Timers defined with a time date in intermediate and boundary events.

For non-interrupting boundary events there is a slight caveat. Usually these are repeatable and can be triggered multiple times. For a time date the event will only be triggered once, as this is not repeatable.

closes #2012

[This](https://camunda.slack.com/archives/C02UMKN3DTL/p1683214870123299?thread_ts=1682677528.275489&cid=C02UMKN3DTL) (internal) slack link provides a nice overview of the supported timer events. This might help out with the technical review.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.
- [x] Part of the 8.3 release

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
