### PR TITLE
Correct merge conflict in Tasklist API

### DIFF
--- a/docs/apis-tools/tasklist-api/inputs/task-query.mdx
+++ b/docs/apis-tools/tasklist-api/inputs/task-query.mdx
@@ -130,9 +130,4 @@ input TaskQuery {
 
 ### Member of
 
-<<<<<<< HEAD:docs/apis-tools/tasklist-api/inputs/task-query.mdx
-[`tasks`](../queries/tasks.mdx) <Badge class="secondary" text="query"/>
-=======
-[`tasks`](/docs/apis-tools/tasklist-api/queries/tasks.mdx) <Badge class="secondary" text="query"/>
-
-> > > > > > > main:docs/apis-tools/tasklist-api/inputs/task-query.mdx
+[`tasks`](/apis-tools/tasklist-api/queries/tasks.mdx) <Badge class="secondary" text="query"/>

--- a/versioned_docs/version-8.2/apis-tools/tasklist-api/inputs/task-query.mdx
+++ b/versioned_docs/version-8.2/apis-tools/tasklist-api/inputs/task-query.mdx
@@ -130,9 +130,4 @@ input TaskQuery {
 
 ### Member of
 
-<<<<<<< HEAD:docs/apis-tools/tasklist-api/inputs/task-query.mdx
-[`tasks`](../queries/tasks.mdx) <Badge class="secondary" text="query"/>
-=======
-[`tasks`](/docs/apis-tools/tasklist-api/queries/tasks.mdx) <Badge class="secondary" text="query"/>
-
-> > > > > > > main:docs/apis-tools/tasklist-api/inputs/task-query.mdx
+[`tasks`](/apis-tools/tasklist-api/queries/tasks.mdx) <Badge class="secondary" text="query"/>


### PR DESCRIPTION
## Description

<img width="1134" alt="image" src="https://github.com/camunda/camunda-platform-docs/assets/1051363/e1076371-9e0d-4b10-86ef-67a14278fe69">

This presented itself in the Bing Webmaster tools console -

> There are multiple `<h1>` tags on the page.

Looks like there was a merge conflict and this PR cleans that up. I did not see any issues in 8.1 or 8.0.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
