### PR TITLE
archive(1.0) preparation: add optimize docs removal to isolation script

### DIFF
--- a/hacks/isolateVersion/1-deleteOtherVersions.sh
+++ b/hacks/isolateVersion/1-deleteOtherVersions.sh
@@ -18,6 +18,15 @@ function delete_next() {
   git commit -m "archiving: delete version $VERSION"  
 }
 
+function delete_optimize() {
+  notify "Deleting Optimize docs..."
+  rm -rf ./optimize
+  rm -rf ./optimize_versioned_docs
+  rm -rf ./optimize_versioned_sidebars
+  git add optimize optimize_versioned_docs optimize_versioned_sidebars
+  git commit -m "archiving: delete version $VERSION"  
+}
+
 # list all versions; search for all that don't match the current version; continue even if there are no matches.
 OTHER_VERSIONS=$(ls versioned_docs | grep -xv "version-$ARCHIVED_VERSION" || true) 
 
@@ -27,3 +36,5 @@ for VERSION in ${OTHER_VERSIONS[*]}
   done
 
 delete_next
+
+delete_optimize

--- a/hacks/isolateVersion/1-deleteOtherVersions.sh
+++ b/hacks/isolateVersion/1-deleteOtherVersions.sh
@@ -15,7 +15,7 @@ function delete_next() {
   rm -rf $folder
   rm $sidebars
   git add docs sidebars.js
-  git commit -m "archiving: delete version $VERSION"  
+  git commit -m "archiving: delete version 'next'"  
 }
 
 function delete_optimize() {
@@ -24,7 +24,7 @@ function delete_optimize() {
   rm -rf ./optimize_versioned_docs
   rm -rf ./optimize_versioned_sidebars
   git add optimize optimize_versioned_docs optimize_versioned_sidebars
-  git commit -m "archiving: delete version $VERSION"  
+  git commit -m "archiving: delete optimize docs"  
 }
 
 # list all versions; search for all that don't match the current version; continue even if there are no matches.

--- a/hacks/isolateVersion/allSteps.sh
+++ b/hacks/isolateVersion/allSteps.sh
@@ -2,7 +2,7 @@
 set -e # exit at first error
 
 # Before running this script make sure these versions are correct!
-ARCHIVED_VERSION="0.25"
+ARCHIVED_VERSION="1.0"
 # ARCHIVED_OPTIMIZE_VERSION="3.7.0"
 
 GREEN='\033[0;32m'
@@ -52,8 +52,8 @@ fi
 
 notify "Automated steps are complete! For ease of review, consider PR'ing the deletion commits separate from the rest of the changes."
 notify "Manual steps that remain: 
-5. Update the docusaurus.config.js
-6. Update CI workflows
-7. Fix htaccess rules (this might always be manual)
-8. Fix links (this will always be manual)
+6. Update the docusaurus.config.js
+7. Update CI workflows
+8. Fix htaccess rules (this might always be manual)
+9. Fix links (this will always be manual)
 "


### PR DESCRIPTION
## Description

This PR adds logic to the `1-deleteOtherVersions` isolation step to delete optimize documentation. I did this manually when isolating versions 0.25 and 0.26 because I kept forgetting to automate it. 

It also corrects some information messages output by the script. 


## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
