### PR TITLE
chore(desktop-modeler): backport about page to stable (8.2)

### DIFF
--- a/versioned_docs/version-8.2/components/connectors/custom-built-connectors/connector-templates.md
+++ b/versioned_docs/version-8.2/components/connectors/custom-built-connectors/connector-templates.md
@@ -618,6 +618,6 @@ You can develop Connector templates using the [`element template` feature](/comp
 
 When using [Web Modeler](/components/modeler/web-modeler/launch-cloud-modeler.md), you can create **Connector templates** [directly within the application](/components/connectors/manage-connector-templates.md) and share them with your respective organization.
 
-When using [Desktop Modeler](/components/modeler/desktop-modeler/install-the-modeler.md), you must place the **Connector templates** [within the file system](/components/modeler/desktop-modeler/element-templates/configuring-templates.md) so the modeler will pick them up.
+When using [Desktop Modeler](/components/modeler/desktop-modeler/index.md), you must place the **Connector templates** [within the file system](/components/modeler/desktop-modeler/element-templates/configuring-templates.md) so the modeler will pick them up.
 
 Once available, process developers can directly [use the **Connector templates** from within the modeling canvas](/components/connectors/use-connectors/index.md).

--- a/versioned_docs/version-8.2/components/modeler/about-modeler.md
+++ b/versioned_docs/version-8.2/components/modeler/about-modeler.md
@@ -16,7 +16,7 @@ In tandem, different events and implementation details (such as the conditions w
 Camunda offers a few tools to design your diagrams and implement them:
 
 - [Web Modeler](./web-modeler/launch-cloud-modeler.md)
-- [Desktop Modeler](./desktop-modeler/install-the-modeler.md)
+- [Desktop Modeler](./desktop-modeler/index.md)
 
 Web Modeler and Desktop Modeler differ mainly in their environment. Web Modeler is part of Cloud Console and offers a seamless integration into Camunda Platform 8 to model BPMN. Desktop Modeler is a desktop application that can be installed and used locally, all while integrating your local development environment.
 

--- a/versioned_docs/version-8.2/components/modeler/desktop-modeler/index.md
+++ b/versioned_docs/version-8.2/components/modeler/desktop-modeler/index.md
@@ -1,0 +1,34 @@
+---
+id: index
+title: Desktop Modeler
+sidebar_label: About
+description: "Camunda Desktop Modeler is a desktop app for modeling BPMN, DMN, and Forms, compatible with Camunda Platform 7 and Camunda Platform 8."
+---
+
+<span class="badge badge--cloud">Camunda Platform 7 and 8</span>
+
+Desktop Modeler is a desktop application for modeling BPMN, DMN, and Forms and supports you in building executable diagrams with Camunda.
+
+![Desktop Modeler Screenshot](./img/new-diagram.png)
+
+## Features
+
+- Design [BPMN](../bpmn/bpmn.md), [DMN](../dmn/dmn.md), and [Forms](../forms/camunda-forms-reference.md)
+- Implement process applications for Camunda Platform 7 and 8
+- Deploy and run processes directly from the application
+- Validate your diagrams using [configurable lint rules](https://github.com/camunda/camunda-modeler-custom-linter-rules-plugin)
+- [Customize](./flags/flags.md) and [extend](./plugins/plugins.md) the application
+
+## Download
+
+Download the app for Windows, Linux, or MacOS from the [Camunda downloads page](https://camunda.com/download/modeler/).
+
+## Get started
+
+Learn how to [develop your first process](./model-your-first-diagram.md) and [deploy it](./connect-to-camunda-cloud.md) to Camunda Platform 8.
+
+## Resources
+
+- [Report an issue](https://github.com/camunda/camunda-modeler/issues)
+- [Source code](https://github.com/camunda/camunda-modeler)
+- [Troubleshooting](./troubleshooting.md)

--- a/versioned_docs/version-8.2/components/modeler/desktop-modeler/install-the-modeler.md
+++ b/versioned_docs/version-8.2/components/modeler/desktop-modeler/install-the-modeler.md
@@ -1,9 +1,8 @@
 ---
 id: install-the-modeler
 title: Install Desktop Modeler
-description: "Camunda Modeler is the desktop application for modeling processes with BPMN."
+sidebar_label: Installation
+description: "Learn how to install Camunda Desktop Modeler."
 ---
 
-[Desktop Modeler](https://github.com/camunda/camunda-modeler) is the desktop application for modeling processes with BPMN.
-
-The application can be run on Windows, MacOS, and Linux. The corresponding packages can be found on the [downloads page](https://camunda.com/download/modeler/).
+Download [Desktop Modeler](./index.md) for Windows, MacOS, and Linux from the [Camunda downloads page](https://camunda.com/download/modeler/).

--- a/versioned_docs/version-8.2/components/modeler/desktop-modeler/model-your-first-diagram.md
+++ b/versioned_docs/version-8.2/components/modeler/desktop-modeler/model-your-first-diagram.md
@@ -3,7 +3,7 @@ id: model-your-first-diagram
 title: Model your first diagram
 ---
 
-After [downloading](./install-the-modeler.md) and starting Desktop Modeler, you can model your first BPMN diagram. Follow the steps below:
+After starting [Desktop Modeler](./index.md), you can model your first BPMN diagram. Follow the steps below:
 
 1. Create a BPMN diagram:
 

--- a/versioned_docs/version-8.2/guides/create-decision-tables-using-dmn.md
+++ b/versioned_docs/version-8.2/guides/create-decision-tables-using-dmn.md
@@ -12,7 +12,7 @@ Decision Model and Notation (DMN) is a modeling approach owned by an institution
 
 In [DMN](../components/modeler/dmn/dmn.md), decisions are modeled and executed using a language both business analysts and developers can understand. Model a set of rules within a table, and this will yield a decision to rapidly execute a process using a decision engine like Camunda.
 
-In this guide, we'll step through the lightweight implementation of a DMN diagram in [Camunda Platform 8](../components/concepts/what-is-camunda-platform-8.md), as both Camunda [Desktop](../components/modeler/desktop-modeler/install-the-modeler.md) and [Web Modeler](../components/modeler/about-modeler.md) both offer the same modeling experience for DMN 1.3 models.
+In this guide, we'll step through the lightweight implementation of a DMN diagram in [Camunda Platform 8](../components/concepts/what-is-camunda-platform-8.md), as both Camunda [Desktop](../components/modeler/desktop-modeler/index.md) and [Web Modeler](../components/modeler/about-modeler.md) both offer the same modeling experience for DMN 1.3 models.
 
 ## Set up
 

--- a/versioned_docs/version-8.2/guides/introduction-to-camunda-platform-8.md
+++ b/versioned_docs/version-8.2/guides/introduction-to-camunda-platform-8.md
@@ -11,7 +11,7 @@ description: "Step through an introduction to Camunda Platform 8, creating an ac
 Camunda Platform 8 consists of six [components](/components/components-overview.md):
 
 - [Console](/components/console/introduction-to-console.md) - Configure and deploy clusters with Console.
-- [Web Modeler](/components/modeler/about-modeler.md) - Collaborate, model processes, and deploy or start new instances. Note that Camunda Platform 8 can be used with both [Desktop Modeler](/components/modeler/desktop-modeler/install-the-modeler.md) and [Web Modeler](/components/modeler/web-modeler/new-web-modeler.md).
+- [Web Modeler](/components/modeler/about-modeler.md) - Collaborate, model processes, and deploy or start new instances. Note that Camunda Platform 8 can be used with both [Desktop Modeler](/components/modeler/desktop-modeler/index.md) and [Web Modeler](/components/modeler/web-modeler/new-web-modeler.md).
 - [Zeebe](/components/zeebe/zeebe-overview.md) - The cloud-native process engine of Camunda Platform 8.
 - [Tasklist](/components/tasklist/introduction-to-tasklist.md) - Complete tasks which require human input.
 - [Operate](/components/operate/operate-introduction.md) - Manage, monitor, and troubleshoot your processes.

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/overview.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/overview.md
@@ -45,5 +45,5 @@ We work to keep the Helm chart updated with the latest version of Camunda Platfo
 
 ## Useful tools related to Camunda Platform
 
-- **Camunda Modeler**: to model/modify business processes. [Install Camunda Modeler](/components/modeler/desktop-modeler/install-the-modeler.md).
+- **Camunda Desktop Modeler**: to model/modify business processes. [Learn more](/components/modeler/desktop-modeler/index.md).
 - **Zeebe CTL (`zbctl`)**: command line tool to interact with a Zeebe cluster (local/remote). You can get the `zbctl` tool from the official [Zeebe release page](https://github.com/camunda-cloud/zeebe/releases).

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -146,6 +146,7 @@
         },
         {
           "Desktop Modeler": [
+            "components/modeler/desktop-modeler/index",
             "components/modeler/desktop-modeler/install-the-modeler",
             "components/modeler/desktop-modeler/model-your-first-diagram",
             "components/modeler/desktop-modeler/connect-to-camunda-cloud",


### PR DESCRIPTION
## Description

This backports https://github.com/camunda/camunda-platform-docs/pull/2029 to stable (8.2).

## When should this change go live?

Any time.

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
