### PR TITLE
retro review public process

### DIFF
--- a/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md
+++ b/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md
@@ -15,12 +15,13 @@ import PublicFormImg from '../img/public-form.png';
 
 <span class="badge badge--cloud">Camunda Platform 8 SaaS only</span>
 
-Camunda Platform 8 SaaS offers a convenient solution for process developers who want to make their processes accessible to users without requiring them to sign up to the platform or understand how tasks and processes work. This feature is particularly useful when you want to gather data or initiate a process from users who are not part of your organization or do not have direct access to Camunda. It also allows you to rapidly test a process with your peers in a development environment.
+Camunda Platform 8 SaaS offers a convenient solution for process developers who want to make their processes accessible to users without requiring them to sign up to the platform or understand how tasks and processes work.
+
+This feature is particularly useful when you want to gather data or initiate a process from users who are not part of your organization or do not have direct access to Camunda. It also allows you to rapidly test a process with your peers in a development environment.
 
 <img src={PublicFormImg} alt="A public form" />
 
-With this feature, developers can easily publish a process with a form embedded into the start event and enable a public link that can be shared with anyone.
-Users can simply open the link, fill out the form, and submit it to initiate a process instance.
+With this feature, developers can publish a process with a form embedded into the start event and enable a public link that can be shared with anyone. Users can open the link, fill out the form, and submit it to initiate a process instance.
 
 This documentation provides step-by-step instructions on how to leverage public forms to streamline process initiation and to improve adoption of process solutions in your organization.
 
@@ -29,7 +30,7 @@ This documentation provides step-by-step instructions on how to leverage public 
 To create a form for public access, follow these steps:
 
 1. Navigate back to your project root or folder.
-2. Click on **New**, and select **Form** in the drop down menu.
+2. Click on **New**, and select **Form** in the dropdown menu.
    <img src={CreateFormImg} style={{width: 300}} alt="Creating a new form" />
 
 3. Name your form.
@@ -42,16 +43,12 @@ Once ready, return to your process. You can read more about form creation in the
 To embed the form in a start event, follow these steps:
 
 1. Make sure you are in **Implement** mode.
-
-<img src={ImplementModeImg} style={{width: 250}} alt="Active implement mode tab" />
-
+   <img src={ImplementModeImg} style={{width: 250}} alt="Active implement mode tab" />
 2. Select the start event.
-
-<img src={SelectStartEventImg} style={{width: 800}} alt="Start event of a human workflow" />
-
-1. Ensure the start event is a [none start event](../../bpmn/none-events/none-events.md#none-start-events). If it is not, change the start event type accordingly using the **wrench tool**.
-2. Use the blue **form icon** to open the form browser. If the icon does not appear, select the start event again.
-3. Select the form you have created and click on **Embed** to confirm.
+   <img src={SelectStartEventImg} style={{width: 800}} alt="Start event of a human workflow" />
+3. Ensure the start event is a [none start event](../../bpmn/none-events/none-events.md#none-start-events). If it is not, change the start event type accordingly using the **wrench tool**.
+4. Use the blue **form icon** to open the form browser. If the icon does not appear, select the start event again.
+5. Select the form you have created and click **Embed** to confirm.
 
 <img src={EmbedStartFormImg} style={{width: 400}} alt="Embedding a start form" />
 
@@ -65,7 +62,7 @@ To enable public access, follow these steps:
 
 <img src={PublicationSectionImg} style={{width: 400}} alt="Enabling public access in the properties panel" />
 
-2. Click on **Deploy** to [deploy](#deploy-a-process) the process and to activate the public form.
+2. Click **Deploy** to [deploy](#deploy-a-process) the process and to activate the public form.
 
 ## Get and share public link
 
@@ -91,7 +88,7 @@ To unpublish a process and disable the public access again, follow these steps:
 To update a public form, follow these steps:
 
 1. Select the start event with the embedded form.
-2. Click on the blue **form icon** under the start event.
+2. Click the blue **form icon** under the start event.
 3. Remove the form by clicking the corresponding action.
 4. Click the **form icon** again.
 5. Select the same form again, and click **Embed** to confirm.
@@ -135,5 +132,5 @@ Yes, your links will no longer be accessible when you delete your account, as th
 As long as the process is deployed to Operate with an active publication flag, it remains available via the public link. Deleting a process from Modeler does not unpublish it. [Disable the public access](#disable-public-access-again) before deleting a process!
 
 :::note
-It is important to consider the security and privacy implications when using a public form. Ensure that any sensitive or confidential information is handled appropriately and that access to the form and the resulting process instances is controlled and monitored according to your organization's policies and regulatory requirements.
+It is important to consider the security and privacy implications when using a public form. Ensure any sensitive or confidential information is handled appropriately and access to the form and the resulting process instances is controlled and monitored according to your organization's policies and regulatory requirements.
 :::

--- a/docs/components/modeler/web-modeler/run-or-publish-your-process.md
+++ b/docs/components/modeler/web-modeler/run-or-publish-your-process.md
@@ -117,12 +117,23 @@ Publishing a process means that you make it available to other users inside and 
 
 You have the following options to publish a process:
 
-- [Deploy to run programmatically](#deploy-to-run-programmatically)
-- [Publish via webhook](#publish-via-webhook)
-- [Publish to Tasklist](#publish-to-tasklist)
-- [Publish via a public form](#publish-via-a-public-form)
-- [Listen to message or signal events](#listen-to-message-or-signal-events)
-- [Best practices for publishing a process](#best-practices-for-publishing-a-process)
+- [Deploy a process](#deploy-a-process)
+  - [Before deploying a process](#before-deploying-a-process)
+- [Run a process](#run-a-process)
+  - [Test run using Play mode](#test-run-using-play-mode)
+  - [Run manually from Modeler](#run-manually-from-modeler)
+  - [Schedule via timer](#schedule-via-timer)
+  - [Best practices for running a process](#best-practices-for-running-a-process)
+- [Publishing a process](#publishing-a-process)
+  - [Deploy to run programmatically](#deploy-to-run-programmatically)
+  - [Publish via webhook](#publish-via-webhook)
+  - [Publish to Tasklist](#publish-to-tasklist)
+  - [Publish via a public form](#publish-via-a-public-form)
+    - [Add a start form](#add-a-start-form)
+    - [Deploy process to the public](#deploy-process-to-the-public)
+    - [Get the public link and share it](#get-the-public-link-and-share-it)
+  - [Listen to message or signal events](#listen-to-message-or-signal-events)
+  - [Best practices for publishing a process](#best-practices-for-publishing-a-process)
 
 ### Deploy to run programmatically
 
@@ -188,7 +199,7 @@ To publish a process via a public form, follow these steps:
 
 <img src={EmbedStartFormImg} style={{width: 400}} alt="Embedding a start form" />
 
-6. Optionally define the [output mapping](../../concepts/variables.md#output-mappings) for the fields of the form, and consume the data in following steps. If you leave the output mapping empty, you can access all output variables of the form.
+6. Optionally, define the [output mapping](../../concepts/variables.md#output-mappings) for the fields of the form, and consume the data in following steps. If you leave the output mapping empty, you can access all output variables of the form.
 
 #### Deploy process to the public
 
@@ -196,7 +207,7 @@ To publish a process via a public form, follow these steps:
 
 <img src={PublicationSectionImg} style={{width: 400}} alt="Enabling public access in the properties panel" />
 
-2. Click on **Deploy** to [deploy](#deploy-a-process) the process and to activate the public form.
+2. Click **Deploy** to [deploy](#deploy-a-process) the process and to activate the public form.
 
 Once the process is deployed, a public URL for the form is generated on the target cluster.
 
@@ -208,7 +219,7 @@ You can access the URL in the **Publication** tab of the **properties panel**, a
 
 When an external user accesses the public form URL, they can fill in the form fields and submit the data. Upon submission, a new process instance is automatically started in Camunda Platform 8, using the submitted data as input.
 
-For further configuration and how to unpublish a process again, please refer to the [full documentation](./advanced-modeling/publish-public-processes.md).
+For further configuration and how to unpublish a process again, refer to the [full documentation](./advanced-modeling/publish-public-processes.md).
 
 ### Listen to message or signal events
 

--- a/docs/components/tasklist/userguide/starting-processes.md
+++ b/docs/components/tasklist/userguide/starting-processes.md
@@ -1,12 +1,12 @@
 ---
 id: starting-processes
-title: Starting Processes
+title: Starting processes
 description: "How to start a process from Tasklist."
 ---
 
 ## Processes tab
 
-It is possible to start processes by demand using Tasklist. To do this, click **Processes** in the top menu. All the processes you have access to start will be listed in the **Processes** page.
+It is possible to start processes by demand using Tasklist. To do this, click **Processes** in the top menu. All the processes you have access to start will be listed on the **Processes** page.
 
 ![tasklist-processes](img/tasklist-processes.png)
 
@@ -33,7 +33,7 @@ For all the above scenarios, contact your administrator to understand why no pro
 
 <span class="badge badge--cloud">Camunda Platform 8 SaaS only</span>
 
-Tasklist offers a convenient method to start processes with a form from a public URL. This functionality relies on process configuration performed in [Web Modeler](/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md), enabling users to create and manage processes effortlessly.
+Tasklist offers a convenient method to start processes with a form from a public URL. This functionality relies on process configuration performed in [Web Modeler](/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md), enabling users to create and manage processes.
 
 In scenarios where processes can be triggered through a form, Tasklist hosts the form on a URL that is accessible to all users, eliminating the need for authentication. By submitting the form, the associated process is launched. This feature proves advantageous when you want to expose processes to users outside your organization, as it allows anyone to start a process.
 


### PR DESCRIPTION
## Description

Retroactive review of https://github.com/camunda/camunda-platform-docs/pull/2194.

## When should this change go live?

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
