### PR TITLE
docs(modeler/flags): document engine version flags

### DIFF
--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -96,7 +96,7 @@ Additional information adapted from the [upstream documentation](https://nodejs.
 
 ### Default execution platform version
 
-To change default execution platform version, configure your `flags.json` like this:
+To change default execution platform version, configure your `flags.json` as follows:
 
 ```json
 {
@@ -105,4 +105,4 @@ To change default execution platform version, configure your `flags.json` like t
 }
 ```
 
-New diagrams created in Desktop Modeler will use configured version instead of the latest stable.
+New diagrams created in Desktop Modeler will use the configured version instead of the latest stable version.

--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -40,6 +40,8 @@ Flags passed as command line arguments take precedence over those configured via
 | "user-data-dir"                                    | [Electron default](../search-paths) |
 | ["display-version"](#custom-display-version-label) | `undefined`                         |
 | ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
+| "c7-engine-version"                                | `undefined`                         |
+| "c8-engine-version"                                | `undefined`                         |
 
 ## Examples
 
@@ -91,3 +93,16 @@ Configure your `flags.json` like this:
 Additional information adapted from the [upstream documentation](https://nodejs.org/docs/latest/api/tls.html#tlscreatesecurecontextoptions):
 
 > The peer (Camunda Platform 8) certificate must be chainable to a CA trusted by the app for the connection to be authenticated. When using certificates that are not chainable to a well-known CA, the certificate's CA must be explicitly specified as trusted or the connection will fail to authenticate. If the peer uses a certificate that doesn't match or chain to one of the default CAs, provide a CA certificate that the peer's certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided.
+
+### Default execution platform version
+
+To change default execution platform version, configure your `flags.json` like this:
+
+```json
+{
+  "c7-engine-version": "7.18.0",
+  "c8-engine-version": "8.0.0"
+}
+```
+
+New diagrams created in Desktop Modeler will use configured version instead of the latest stable.


### PR DESCRIPTION
## Description

Documents flags introduced via https://github.com/camunda/camunda-modeler/pull/3720.

The flags will be available with Desktop Modeler release on 8th August, and in tomorrow's nightly build.
<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
