### PR TITLE
docs: (tasklist) update tasklist-rest-api overview

### DIFF
--- a/docs/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/docs/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -12,20 +12,23 @@ Requests and responses are in JSON notation. Some objects have additional endpoi
 
 ## API documentation as Swagger
 
-A detailed API description is also available as Swagger UI at `https://${base-url}/swagger-ui/index.html`. For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/swagger-ui/index.html`, and for Self-Managed installations: `http://localhost:8080/swagger-ui/index.html`.
+A detailed API description is also available as Swagger UI at `https://${base-url}/swagger-ui/index.html`.<br/>
+For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/swagger-ui/index.html`,<br/>
+and for Self-Managed installations: [`http://localhost:8080/swagger-ui/index.html`](http://localhost:8080/swagger-ui/index.html).
 
 ## Endpoints
 
-| Endpoint (HTTP verb + URL path)            |                                                                   Description |
-| :----------------------------------------- | ----------------------------------------------------------------------------: |
-| **Tasks**                                  |                                                                               |
-| `GET /v1/tasks/{taskId}`                   |                                                      Return a task by taskId. |
-| `POST /v1/tasks/search`                    |                 Returns the list of tasks that satisfy search request params. |
-| `POST /v1/tasks/{taskId}/variables/search` |   Returns a list of task variables for the specified taskId and variableName. |
-| `PATCH /v1/tasks/{taskId}/assign`          |                 Assign a task with `taskId` to `assignee` or the active user. |
-| `PATCH /v1/tasks/{taskId}/unassign`        |                                       Unassign a task with provided `taskId`. |
-| `PATCH /v1/tasks/{taskId}/complete`        |                           Complete a task with taskId and optional variables. |
-| **Forms**                                  |                                                                               |
-| `POST /v1/forms/{formId}`                  | Get the form details by formId and processDefinitionKey required query param. |
-| **Variables**                              |                                                                               |
-| `POST /v1/variables/{variableId}`          |                                      Get the variable details by variable id. |
+| Endpoint (HTTP verb + URL path)                                                                                                                                 |                                                                       Description |
+| :-------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------: |
+| **Tasks**                                                                                                                                                       |                                                                                   |
+| [`GET /v1/tasks/{taskId}`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#get-task)                                             |                                                        Return a task by `taskId`. |
+| [`POST /v1/tasks/search`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#search-tasks)                                          |                     Returns the list of tasks that satisfy search request params. |
+| [`POST /v1/tasks/{taskId}/variables`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#save-draft-task-variables)                 |                                        Saves draft variables for a specific task. |
+| [`POST /v1/tasks/{taskId}/variables/search`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#search-task-variables)              |  Returns a list of task variables for the specified `taskId` and `variableNames`. |
+| [`PATCH /v1/tasks/{taskId}/assign`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#assign-task)                                 |                     Assign a task with `taskId` to `assignee` or the active user. |
+| [`PATCH /v1/tasks/{taskId}/unassign`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#unassign-task)                             |                                           Unassign a task with provided `taskId`. |
+| [`PATCH /v1/tasks/{taskId}/complete`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#complete-task)                             |                             Complete a task with `taskId` and optional variables. |
+| **Forms**                                                                                                                                                       |                                                                                   |
+| [`GET /v1/forms/{formId}?processDefinitionKey={processDefinitionKey}`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-form-controller.md#get-form) | Get the form details by `formId` and `processDefinitionKey` required query param. |
+| **Variables**                                                                                                                                                   |                                                                                   |
+| [`GET /v1/variables/{variableId}`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-variables-controller.md#get-variable)                            |                                         Get the variable details by `variableId`. |

--- a/versioned_docs/version-8.2/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/versioned_docs/version-8.2/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -12,20 +12,22 @@ Requests and responses are in JSON notation. Some objects have additional endpoi
 
 ## API documentation as Swagger
 
-A detailed API description is also available as Swagger UI at `https://${base-url}/swagger-ui/index.html`.
+A detailed API description is also available as Swagger UI at `https://${base-url}/swagger-ui/index.html`.<br/>
+For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/swagger-ui/index.html`,<br/>
+and for Self-Managed installations: [`http://localhost:8080/swagger-ui/index.html`](http://localhost:8080/swagger-ui/index.html).
 
 ## Endpoints
 
-| Endpoint (HTTP verb + URL path)            |                                                                   Description |
-| :----------------------------------------- | ----------------------------------------------------------------------------: |
-| **Tasks**                                  |                                                                               |
-| `GET /v1/tasks/{taskId}`                   |                                                      Return a task by taskId. |
-| `POST /v1/tasks/search`                    |                 Returns the list of tasks that satisfy search request params. |
-| `POST /v1/tasks/{taskId}/variables/search` |   Returns a list of task variables for the specified taskId and variableName. |
-| `PATCH /v1/tasks/{taskId}/assign`          |                 Assign a task with `taskId` to `assignee` or the active user. |
-| `PATCH /v1/tasks/{taskId}/unassign`        |                                       Unassign a task with provided `taskId`. |
-| `PATCH /v1/tasks/{taskId}/complete`        |                           Complete a task with taskId and optional variables. |
-| **Forms**                                  |                                                                               |
-| `POST /v1/forms/{formId}`                  | Get the form details by formId and processDefinitionKey required query param. |
-| **Variables**                              |                                                                               |
-| `POST /v1/variables/{variableId}`          |                                      Get the variable details by variable id. |
+| Endpoint (HTTP verb + URL path)                                                                                                                                 |                                                                       Description |
+| :-------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------: |
+| **Tasks**                                                                                                                                                       |                                                                                   |
+| [`GET /v1/tasks/{taskId}`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#get-task)                                             |                                                        Return a task by `taskId`. |
+| [`POST /v1/tasks/search`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#search-tasks)                                          |                     Returns the list of tasks that satisfy search request params. |
+| [`POST /v1/tasks/{taskId}/variables/search`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#search-task-variables)              |  Returns a list of task variables for the specified `taskId` and `variableNames.` |
+| [`PATCH /v1/tasks/{taskId}/assign`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#assign-task)                                 |                     Assign a task with `taskId` to `assignee` or the active user. |
+| [`PATCH /v1/tasks/{taskId}/unassign`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#unassign-task)                             |                                           Unassign a task with provided `taskId`. |
+| [`PATCH /v1/tasks/{taskId}/complete`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#complete-task)                             |                             Complete a task with `taskId` and optional variables. |
+| **Forms**                                                                                                                                                       |                                                                                   |
+| [`GET /v1/forms/{formId}?processDefinitionKey={processDefinitionKey}`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-form-controller.md#get-form) | Get the form details by `formId` and `processDefinitionKey` required query param. |
+| **Variables**                                                                                                                                                   |                                                                                   |
+| [`GET /v1/variables/{variableId}`](/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-variables-controller.md#get-variable)                            |                                         Get the variable details by `variableId`. |


### PR DESCRIPTION
## Description
This PR addresses the issues raised in [ticket #2310](https://github.com/camunda/camunda-platform-docs/issues/2310). 

The changes made include the correction of incorrect HTTP methods, with GET replacing POST where necessary. 
The [Save draft task variables](https://github.com/camunda/product-hub/issues/1154) endpoint has been added for the endpoints overview for the `next` version. 
In addition, for both `8.2` and `next` versions, a link has been added to each endpoint, redirecting users to a more detailed description of the endpoint. This should assist with providing more comprehensive information about each endpoint. 


<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
