### PR TITLE
feat(archiving): Automate workflow updates

### DIFF
--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -1,15 +1,24 @@
 notify "Updating CI workflows..."
 
-# 1. linkcheck: delete the file
+# 1. linkcheck: delete the file.
 rm .github/workflows/linkcheck.yaml
 
-# 2. build-docs: remove everything after the line `NODE_OPTIONS: --max_old_space_size=4096`
+# 2. build-docs: remove everything after the line `NODE_OPTIONS: --max_old_space_size=4096`.
 sed -i '' '/NODE_OPTIONS: --max_old_space_size=4096/q' .github/workflows/build-docs.yaml
 
 # 3. publish-prod: 
-#   1. remove every line after `tags:` until a blank line
-#   2. add a line after `tags:` that says `{version}.[0-9]+`
-#   3. replace `secrets.AWS_PROD_PUBLISH_PATH` with `secrets.AWS_PROD_PUBLISH_PATH_UNSUPPORTED }}/{version}`
+
+#   1. remove every line after `tags:` until the first blank line.
+sed -i '' '/tags:/,/^$/ { /tags:/! { /^$/!d; }; }' .github/workflows/publish-prod.yaml
+
+#   2. add a line after `tags:` that says `{ARCHIVED_VERSION}.[0-9]+`, so that only this archived version's tags trigger a production build.
+sed -i '' "/tags:/a\\
+      - \"$ARCHIVED_VERSION.[0-9]+\"
+" .github/workflows/publish-prod.yaml
+
+#   3. replace the main docs remote_path with this isolated version's remote_path.
+sed -i '' "s/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
+
 # 4. publish-stage:
 #   1. replace `branches: - main` with `branches: - unsupported/{version}`
 #   2. remove `disable indexing` step

--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -35,5 +35,5 @@ sed -i '' 's/https:\/\/stage.docs.camunda.io/https:\/\/stage.unsupported.docs.ca
 sed -i '' "s/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
 
 
-# git add .github/workflows
-# git commit -m "archiving: update CI workflows"
+git add .github/workflows
+git commit -m "archiving: update CI workflows"

--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -1,0 +1,22 @@
+notify "Updating CI workflows..."
+
+# 1. linkcheck: delete the file
+rm .github/workflows/linkcheck.yaml
+
+# 2. build-docs: remove everything after the line `NODE_OPTIONS: --max_old_space_size=4096`
+sed -i '' '/NODE_OPTIONS: --max_old_space_size=4096/q' .github/workflows/build-docs.yaml
+
+# 3. publish-prod: 
+#   1. remove every line after `tags:` until a blank line
+#   2. add a line after `tags:` that says `{version}.[0-9]+`
+#   3. replace `secrets.AWS_PROD_PUBLISH_PATH` with `secrets.AWS_PROD_PUBLISH_PATH_UNSUPPORTED }}/{version}`
+# 4. publish-stage:
+#   1. replace `branches: - main` with `branches: - unsupported/{version}`
+#   2. remove `disable indexing` step
+#   3. replace `https://docs.camunda.io` with `https://unsupported.docs.camunda.io`
+#   4. replace `https://stage.docs.camunda.io` with `https://stage.unsupported.docs.camunda.io`
+#   5. replace `${{ secrets.AWS_STAGE_PUBLISH_PATH }}` with `${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}/{version}`
+
+
+# git add .github/workflows
+# git commit -m "archiving: update CI workflows"

--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -8,23 +8,31 @@ sed -i '' '/NODE_OPTIONS: --max_old_space_size=4096/q' .github/workflows/build-d
 
 # 3. publish-prod: 
 
-#   1. remove every line after `tags:` until the first blank line.
+#   a. remove every line after `tags:` until the first blank line.
 sed -i '' '/tags:/,/^$/ { /tags:/! { /^$/!d; }; }' .github/workflows/publish-prod.yaml
 
-#   2. add a line after `tags:` that says `{ARCHIVED_VERSION}.[0-9]+`, so that only this archived version's tags trigger a production build.
+#   b. add a line after `tags:` that says `{ARCHIVED_VERSION}.[0-9]+`, so that only this archived version's tags trigger a production build.
 sed -i '' "/tags:/a\\
       - \"$ARCHIVED_VERSION.[0-9]+\"
 " .github/workflows/publish-prod.yaml
 
-#   3. replace the main docs remote_path with this isolated version's remote_path.
+#   c. replace the main docs remote_path with this isolated version's remote_path.
 sed -i '' "s/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
 
 # 4. publish-stage:
-#   1. replace `branches: - main` with `branches: - unsupported/{version}`
-#   2. remove `disable indexing` step
-#   3. replace `https://docs.camunda.io` with `https://unsupported.docs.camunda.io`
-#   4. replace `https://stage.docs.camunda.io` with `https://stage.unsupported.docs.camunda.io`
-#   5. replace `${{ secrets.AWS_STAGE_PUBLISH_PATH }}` with `${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}/{version}`
+sed -i '' '/Disable Indexing/{N; d;}' .github/workflows/publish-stage.yaml
+
+#   a. replace `branches: - main` with `branches: - unsupported/{version}`
+sed -i '' "s/- \"main\"/- \"unsupported\/$ARCHIVED_VERSION\"/" .github/workflows/publish-stage.yaml
+
+#   b. remove `disable indexing` step
+
+#   c. add `unsupported.` to docs URLs
+sed -i '' 's/https:\/\/docs.camunda.io/https:\/\/unsupported.docs.camunda.io/' .github/workflows/publish-stage.yaml
+sed -i '' 's/https:\/\/stage.docs.camunda.io/https:\/\/stage.unsupported.docs.camunda.io/' .github/workflows/publish-stage.yaml
+
+#   d. replace `${{ secrets.AWS_STAGE_PUBLISH_PATH }}` with `${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}/{version}`
+sed -i '' "s/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
 
 
 # git add .github/workflows

--- a/hacks/isolateVersion/allSteps.sh
+++ b/hacks/isolateVersion/allSteps.sh
@@ -50,10 +50,13 @@ if [[ "$script_index" == 5 || -z "$script_index" ]]; then
   source $script_directory/5-updateThemeComponents.sh
 fi
 
+if [[ "$script_index" == 6 || -z "$script_index" ]]; then
+  source $script_directory/6-updateCIWorkflows.sh
+fi
+
 notify "Automated steps are complete! For ease of review, consider PR'ing the deletion commits separate from the rest of the changes."
 notify "Manual steps that remain: 
-6. Update the docusaurus.config.js
-7. Update CI workflows
+7. Update the docusaurus.config.js
 8. Fix htaccess rules (this might always be manual)
 9. Fix links (this will always be manual)
 "


### PR DESCRIPTION
## Description

Part of #1173.

This PR automates the CI workflow updates involved in archiving an unsupported version. 

See the changes in https://github.com/camunda/camunda-platform-docs/pull/2235/files, specifically within the `.github/workflows` folder, for a snapshot of all the changes included in this automated step.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
