### PR TITLE
Cleanup Connectors update guides

### DIFF
--- a/docs/guides/update-guide/connectors/010-to-020.md
+++ b/docs/guides/update-guide/connectors/010-to-020.md
@@ -4,6 +4,9 @@ title: Update 0.1 to 0.2
 description: "Review which adjustments must be made to migrate from Connector SDK 0.1.x to 0.2.0."
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 <span class="badge badge--primary">Intermediate</span>
 
 The following sections explain which adjustments must be made to migrate from

--- a/docs/guides/update-guide/connectors/010-to-020.md
+++ b/docs/guides/update-guide/connectors/010-to-020.md
@@ -4,9 +4,6 @@ title: Update 0.1 to 0.2
 description: "Review which adjustments must be made to migrate from Connector SDK 0.1.x to 0.2.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--primary">Intermediate</span>
 
 The following sections explain which adjustments must be made to migrate from

--- a/docs/guides/update-guide/connectors/0100-to-0110.md
+++ b/docs/guides/update-guide/connectors/0100-to-0110.md
@@ -4,9 +4,6 @@ title: Update 0.10 to 0.11
 description: "Review which adjustments must be made to migrate from Connector SDK 0.10.x to 0.11.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 :::note

--- a/docs/guides/update-guide/connectors/020-to-030.md
+++ b/docs/guides/update-guide/connectors/020-to-030.md
@@ -4,9 +4,6 @@ title: Update 0.2 to 0.3
 description: "Review which adjustments must be made to migrate from Connector SDK 0.2.x to 0.3.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--primary">Intermediate</span>
 
 The following sections explain which adjustments must be made to migrate from

--- a/docs/guides/update-guide/connectors/030-to-040.md
+++ b/docs/guides/update-guide/connectors/030-to-040.md
@@ -4,9 +4,6 @@ title: Update 0.3 to 0.4
 description: "Review which adjustments must be made to migrate from Connector SDK 0.3.x to 0.4.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--primary">Intermediate</span>
 
 The following sections explain which adjustments must be made to migrate from

--- a/docs/guides/update-guide/connectors/040-to-050.md
+++ b/docs/guides/update-guide/connectors/040-to-050.md
@@ -4,9 +4,6 @@ title: Update 0.4 to 0.5
 description: "Review which adjustments must be made to migrate from Connector SDK 0.4.x to 0.5.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/docs/guides/update-guide/connectors/050-to-060.md
+++ b/docs/guides/update-guide/connectors/050-to-060.md
@@ -4,9 +4,6 @@ title: Update 0.5 to 0.6
 description: "Review which adjustments must be made to migrate from Connector SDK 0.5.x to 0.6.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/docs/guides/update-guide/connectors/060-to-070.md
+++ b/docs/guides/update-guide/connectors/060-to-070.md
@@ -4,8 +4,7 @@ title: Update 0.6 to 0.7
 description: "Review which adjustments must be made to migrate from Connector SDK 0.6.x to 0.7.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
+<span class="badge badge--beginner">Beginner</span>
 
 With the Connector SDK [0.7.0 release](https://github.com/camunda/connector-sdk/releases/tag/0.7.0), we made
 breaking changes to the inbound Connectors. Please update

--- a/docs/guides/update-guide/connectors/070-to-080.md
+++ b/docs/guides/update-guide/connectors/070-to-080.md
@@ -4,9 +4,6 @@ title: Update 0.7 to 0.8
 description: "Review which adjustments must be made to migrate from Connector SDK 0.7.x to 0.8.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/docs/guides/update-guide/connectors/080-to-090.md
+++ b/docs/guides/update-guide/connectors/080-to-090.md
@@ -4,9 +4,6 @@ title: Update 0.8 to 0.9
 description: "Review which adjustments must be made to migrate from Connector SDK 0.8.x to 0.9.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/docs/guides/update-guide/connectors/090-to-0100.md
+++ b/docs/guides/update-guide/connectors/090-to-0100.md
@@ -4,9 +4,6 @@ title: Update 0.9 to 0.10
 description: "Review which adjustments must be made to migrate from Connector SDK 0.9.x to 0.10.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/docs/guides/update-guide/connectors/introduction.md
+++ b/docs/guides/update-guide/connectors/introduction.md
@@ -1,6 +1,6 @@
 ---
 id: introduction
-title: Introduction Connector SDK updates
+title: Connector SDK updates
 ---
 
 These documents guide you through the process of updating your Camunda Platform 8

--- a/sidebars.js
+++ b/sidebars.js
@@ -37,15 +37,15 @@ module.exports = {
         {
           Connectors: [
             "guides/update-guide/connectors/introduction",
-            "guides/update-guide/connectors/010-to-020",
-            "guides/update-guide/connectors/020-to-030",
-            "guides/update-guide/connectors/030-to-040",
-            "guides/update-guide/connectors/040-to-050",
-            "guides/update-guide/connectors/050-to-060",
-            "guides/update-guide/connectors/060-to-070",
-            "guides/update-guide/connectors/070-to-080",
-            "guides/update-guide/connectors/080-to-090",
             "guides/update-guide/connectors/090-to-0100",
+            "guides/update-guide/connectors/080-to-090",
+            "guides/update-guide/connectors/070-to-080",
+            "guides/update-guide/connectors/060-to-070",
+            "guides/update-guide/connectors/050-to-060",
+            "guides/update-guide/connectors/040-to-050",
+            "guides/update-guide/connectors/030-to-040",
+            "guides/update-guide/connectors/020-to-030",
+            "guides/update-guide/connectors/010-to-020",
           ],
         },
         {

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/0100-to-0110.md
@@ -4,9 +4,6 @@ title: Update 0.10 to 0.11
 description: "Review which adjustments must be made to migrate from Connector SDK 0.10.x to 0.11.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 :::note

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/020-to-030.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/020-to-030.md
@@ -4,9 +4,6 @@ title: Update 0.2 to 0.3
 description: "Review which adjustments must be made to migrate from Connector SDK 0.2.x to 0.3.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--primary">Intermediate</span>
 
 The following sections explain which adjustments must be made to migrate from

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/030-to-040.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/030-to-040.md
@@ -4,9 +4,6 @@ title: Update 0.3 to 0.4
 description: "Review which adjustments must be made to migrate from Connector SDK 0.3.x to 0.4.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--primary">Intermediate</span>
 
 The following sections explain which adjustments must be made to migrate from

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/040-to-050.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/040-to-050.md
@@ -4,9 +4,6 @@ title: Update 0.4 to 0.5
 description: "Review which adjustments must be made to migrate from Connector SDK 0.4.x to 0.5.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/050-to-060.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/050-to-060.md
@@ -4,9 +4,6 @@ title: Update 0.5 to 0.6
 description: "Review which adjustments must be made to migrate from Connector SDK 0.5.x to 0.6.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/060-to-070.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/060-to-070.md
@@ -4,8 +4,7 @@ title: Update 0.6 to 0.7
 description: "Review which adjustments must be made to migrate from Connector SDK 0.6.x to 0.7.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
+<span class="badge badge--beginner">Beginner</span>
 
 With the Connector SDK [0.7.0 release](https://github.com/camunda/connector-sdk/releases/tag/0.7.0), we made
 breaking changes to the inbound Connectors. Please update

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/070-to-080.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/070-to-080.md
@@ -4,9 +4,6 @@ title: Update 0.7 to 0.8
 description: "Review which adjustments must be made to migrate from Connector SDK 0.7.x to 0.8.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustments are necessary to migrate from

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/080-to-090.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/080-to-090.md
@@ -4,9 +4,6 @@ title: Update 0.8 to 0.9
 description: "Review which adjustments must be made to migrate from Connector SDK 0.8.x to 0.9.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/090-to-0100.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/090-to-0100.md
@@ -4,9 +4,6 @@ title: Update 0.9 to 0.10
 description: "Review which adjustments must be made to migrate from Connector SDK 0.9.x to 0.10.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/introduction.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/introduction.md
@@ -1,6 +1,6 @@
 ---
 id: introduction
-title: Introduction Connector SDK updates
+title: Connector SDK updates
 ---
 
 These documents guide you through the process of updating your Camunda Platform 8

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/0100-to-0110.md
@@ -4,9 +4,6 @@ title: Update 0.10 to 0.11
 description: "Review which adjustments must be made to migrate from Connector SDK 0.10.x to 0.11.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 :::note

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/020-to-030.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/020-to-030.md
@@ -4,9 +4,6 @@ title: Update 0.2 to 0.3
 description: "Review which adjustments must be made to migrate from Connector SDK 0.2.x to 0.3.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--primary">Intermediate</span>
 
 The following sections explain which adjustments must be made to migrate from

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/030-to-040.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/030-to-040.md
@@ -4,9 +4,6 @@ title: Update 0.3 to 0.4
 description: "Review which adjustments must be made to migrate from Connector SDK 0.3.x to 0.4.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--primary">Intermediate</span>
 
 The following sections explain which adjustments must be made to migrate from

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/040-to-050.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/040-to-050.md
@@ -4,9 +4,6 @@ title: Update 0.4 to 0.5
 description: "Review which adjustments must be made to migrate from Connector SDK 0.4.x to 0.5.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/050-to-060.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/050-to-060.md
@@ -4,9 +4,6 @@ title: Update 0.5 to 0.6
 description: "Review which adjustments must be made to migrate from Connector SDK 0.5.x to 0.6.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/060-to-070.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/060-to-070.md
@@ -4,8 +4,7 @@ title: Update 0.6 to 0.7
 description: "Review which adjustments must be made to migrate from Connector SDK 0.6.x to 0.7.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
+<span class="badge badge--beginner">Beginner</span>
 
 With the Connector SDK [0.7.0 release](https://github.com/camunda/connector-sdk/releases/tag/0.7.0), we made
 breaking changes to the inbound Connectors. Please update

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/070-to-080.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/070-to-080.md
@@ -4,9 +4,6 @@ title: Update 0.7 to 0.8
 description: "Review which adjustments must be made to migrate from Connector SDK 0.7.x to 0.8.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/080-to-090.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/080-to-090.md
@@ -4,9 +4,6 @@ title: Update 0.8 to 0.9
 description: "Review which adjustments must be made to migrate from Connector SDK 0.8.x to 0.9.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/090-to-0100.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/090-to-0100.md
@@ -4,9 +4,6 @@ title: Update 0.9 to 0.10
 description: "Review which adjustments must be made to migrate from Connector SDK 0.9.x to 0.10.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/introduction.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/introduction.md
@@ -1,6 +1,6 @@
 ---
 id: introduction
-title: Introduction Connector SDK updates
+title: Connector SDK updates
 ---
 
 These documents guide you through the process of updating your Camunda Platform 8

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/0100-to-0110.md
@@ -4,9 +4,6 @@ title: Update 0.10 to 0.11
 description: "Review which adjustments must be made to migrate from Connector SDK 0.10.x to 0.11.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 :::note

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/020-to-030.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/020-to-030.md
@@ -4,9 +4,6 @@ title: Update 0.2 to 0.3
 description: "Review which adjustments must be made to migrate from Connector SDK 0.2.x to 0.3.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--primary">Intermediate</span>
 
 The following sections explain which adjustments must be made to migrate from

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/030-to-040.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/030-to-040.md
@@ -4,9 +4,6 @@ title: Update 0.3 to 0.4
 description: "Review which adjustments must be made to migrate from Connector SDK 0.3.x to 0.4.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--primary">Intermediate</span>
 
 The following sections explain which adjustments must be made to migrate from

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/040-to-050.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/040-to-050.md
@@ -4,9 +4,6 @@ title: Update 0.4 to 0.5
 description: "Review which adjustments must be made to migrate from Connector SDK 0.4.x to 0.5.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/050-to-060.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/050-to-060.md
@@ -4,9 +4,6 @@ title: Update 0.5 to 0.6
 description: "Review which adjustments must be made to migrate from Connector SDK 0.5.x to 0.6.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/060-to-070.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/060-to-070.md
@@ -4,8 +4,7 @@ title: Update 0.6 to 0.7
 description: "Review which adjustments must be made to migrate from Connector SDK 0.6.x to 0.7.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
+<span class="badge badge--beginner">Beginner</span>
 
 With the Connector SDK [0.7.0 release](https://github.com/camunda/connector-sdk/releases/tag/0.7.0), we made
 breaking changes to the inbound Connectors. Please update

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/070-to-080.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/070-to-080.md
@@ -4,9 +4,6 @@ title: Update 0.7 to 0.8
 description: "Review which adjustments must be made to migrate from Connector SDK 0.7.x to 0.8.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/080-to-090.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/080-to-090.md
@@ -4,9 +4,6 @@ title: Update 0.8 to 0.9
 description: "Review which adjustments must be made to migrate from Connector SDK 0.8.x to 0.9.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/090-to-0100.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/090-to-0100.md
@@ -4,9 +4,6 @@ title: Update 0.9 to 0.10
 description: "Review which adjustments must be made to migrate from Connector SDK 0.9.x to 0.10.0."
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <span class="badge badge--beginner">Beginner</span>
 
 No manual adjustment necessary to migrate from

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/introduction.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/introduction.md
@@ -1,6 +1,6 @@
 ---
 id: introduction
-title: Introduction Connector SDK updates
+title: Connector SDK updates
 ---
 
 These documents guide you through the process of updating your Camunda Platform 8

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -29,15 +29,15 @@
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
-            "guides/update-guide/connectors/010-to-020",
-            "guides/update-guide/connectors/020-to-030",
-            "guides/update-guide/connectors/030-to-040",
-            "guides/update-guide/connectors/040-to-050",
-            "guides/update-guide/connectors/050-to-060",
-            "guides/update-guide/connectors/060-to-070",
-            "guides/update-guide/connectors/070-to-080",
+            "guides/update-guide/connectors/090-to-0100",
             "guides/update-guide/connectors/080-to-090",
-            "guides/update-guide/connectors/090-to-0100"
+            "guides/update-guide/connectors/070-to-080",
+            "guides/update-guide/connectors/060-to-070",
+            "guides/update-guide/connectors/050-to-060",
+            "guides/update-guide/connectors/040-to-050",
+            "guides/update-guide/connectors/030-to-040",
+            "guides/update-guide/connectors/020-to-030",
+            "guides/update-guide/connectors/010-to-020"
           ]
         },
         "guides/update-guide/130-to-800",

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -34,7 +34,7 @@
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
-            "guides/update-guide/connectors/0100-to-0110"
+            "guides/update-guide/connectors/0100-to-0110",
             "guides/update-guide/connectors/090-to-0100",
             "guides/update-guide/connectors/080-to-090",
             "guides/update-guide/connectors/070-to-080",

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -35,7 +35,7 @@
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
-            "guides/update-guide/connectors/0100-to-0110"
+            "guides/update-guide/connectors/0100-to-0110",
             "guides/update-guide/connectors/090-to-0100",
             "guides/update-guide/connectors/080-to-090",
             "guides/update-guide/connectors/070-to-080",

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -29,15 +29,15 @@
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
-            "guides/update-guide/connectors/010-to-020",
-            "guides/update-guide/connectors/020-to-030",
-            "guides/update-guide/connectors/030-to-040",
-            "guides/update-guide/connectors/040-to-050",
-            "guides/update-guide/connectors/050-to-060",
-            "guides/update-guide/connectors/060-to-070",
-            "guides/update-guide/connectors/070-to-080",
+            "guides/update-guide/connectors/090-to-0100",
             "guides/update-guide/connectors/080-to-090",
-            "guides/update-guide/connectors/090-to-0100"
+            "guides/update-guide/connectors/070-to-080",
+            "guides/update-guide/connectors/060-to-070",
+            "guides/update-guide/connectors/050-to-060",
+            "guides/update-guide/connectors/040-to-050",
+            "guides/update-guide/connectors/030-to-040",
+            "guides/update-guide/connectors/020-to-030",
+            "guides/update-guide/connectors/010-to-020"
           ]
         },
         "guides/update-guide/800-to-810",

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -29,15 +29,15 @@
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
-            "guides/update-guide/connectors/010-to-020",
-            "guides/update-guide/connectors/020-to-030",
-            "guides/update-guide/connectors/030-to-040",
-            "guides/update-guide/connectors/040-to-050",
-            "guides/update-guide/connectors/050-to-060",
-            "guides/update-guide/connectors/060-to-070",
-            "guides/update-guide/connectors/070-to-080",
+            "guides/update-guide/connectors/090-to-0100",
             "guides/update-guide/connectors/080-to-090",
-            "guides/update-guide/connectors/090-to-0100"
+            "guides/update-guide/connectors/070-to-080",
+            "guides/update-guide/connectors/060-to-070",
+            "guides/update-guide/connectors/050-to-060",
+            "guides/update-guide/connectors/040-to-050",
+            "guides/update-guide/connectors/030-to-040",
+            "guides/update-guide/connectors/020-to-030",
+            "guides/update-guide/connectors/010-to-020"
           ]
         },
         {

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -36,7 +36,7 @@
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
-            "guides/update-guide/connectors/0100-to-0110"
+            "guides/update-guide/connectors/0100-to-0110",
             "guides/update-guide/connectors/090-to-0100",
             "guides/update-guide/connectors/080-to-090",
             "guides/update-guide/connectors/070-to-080",


### PR DESCRIPTION
## Description

Reversed the list of Connectors update guides. Removed extraneous tab import statements.

The only time tabs are used (and therefore, the import statements are needed) are on the first Connectors update guide - 0.10 to 0.20.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
