### PR TITLE
Move update guides up sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -34,6 +34,13 @@ module.exports = {
     {
       "Update guide": [
         "guides/update-guide/introduction",
+        "guides/update-guide/810-to-820",
+        "guides/update-guide/800-to-810",
+        "guides/update-guide/130-to-800",
+        "guides/update-guide/120-to-130",
+        "guides/update-guide/110-to-120",
+        "guides/update-guide/100-to-110",
+        "guides/update-guide/026-to-100",
         {
           Connectors: [
             "guides/update-guide/connectors/introduction",
@@ -51,13 +58,6 @@ module.exports = {
         {
           Elasticsearch: ["guides/update-guide/elasticsearch/7-to-8"],
         },
-        "guides/update-guide/810-to-820",
-        "guides/update-guide/800-to-810",
-        "guides/update-guide/130-to-800",
-        "guides/update-guide/120-to-130",
-        "guides/update-guide/110-to-120",
-        "guides/update-guide/100-to-110",
-        "guides/update-guide/026-to-100",
       ],
     },
     "guides/migrating-from-cawemo",

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -26,6 +26,11 @@
     {
       "Update guide": [
         "guides/update-guide/introduction",
+        "guides/update-guide/130-to-800",
+        "guides/update-guide/120-to-130",
+        "guides/update-guide/110-to-120",
+        "guides/update-guide/100-to-110",
+        "guides/update-guide/026-to-100",
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
@@ -39,12 +44,7 @@
             "guides/update-guide/connectors/080-to-090",
             "guides/update-guide/connectors/090-to-0100"
           ]
-        },
-        "guides/update-guide/130-to-800",
-        "guides/update-guide/120-to-130",
-        "guides/update-guide/110-to-120",
-        "guides/update-guide/100-to-110",
-        "guides/update-guide/026-to-100"
+        }
       ]
     },
     "guides/migrating-from-cawemo",

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -26,6 +26,12 @@
     {
       "Update guide": [
         "guides/update-guide/introduction",
+        "guides/update-guide/800-to-810",
+        "guides/update-guide/130-to-800",
+        "guides/update-guide/120-to-130",
+        "guides/update-guide/110-to-120",
+        "guides/update-guide/100-to-110",
+        "guides/update-guide/026-to-100",
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
@@ -39,13 +45,7 @@
             "guides/update-guide/connectors/080-to-090",
             "guides/update-guide/connectors/090-to-0100"
           ]
-        },
-        "guides/update-guide/800-to-810",
-        "guides/update-guide/130-to-800",
-        "guides/update-guide/120-to-130",
-        "guides/update-guide/110-to-120",
-        "guides/update-guide/100-to-110",
-        "guides/update-guide/026-to-100"
+        }
       ]
     },
     "guides/migrating-from-cawemo",

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -26,6 +26,13 @@
     {
       "Update guide": [
         "guides/update-guide/introduction",
+        "guides/update-guide/810-to-820",
+        "guides/update-guide/800-to-810",
+        "guides/update-guide/130-to-800",
+        "guides/update-guide/120-to-130",
+        "guides/update-guide/110-to-120",
+        "guides/update-guide/100-to-110",
+        "guides/update-guide/026-to-100",
         {
           "Connectors": [
             "guides/update-guide/connectors/introduction",
@@ -42,14 +49,7 @@
         },
         {
           "Elasticsearch": ["guides/update-guide/elasticsearch/7-to-8"]
-        },
-        "guides/update-guide/810-to-820",
-        "guides/update-guide/800-to-810",
-        "guides/update-guide/130-to-800",
-        "guides/update-guide/120-to-130",
-        "guides/update-guide/110-to-120",
-        "guides/update-guide/100-to-110",
-        "guides/update-guide/026-to-100"
+        }
       ]
     },
     "guides/migrating-from-cawemo",


### PR DESCRIPTION
## Description

Connectors and Elasticsearch appear above the Camunda Platform 8 guides in the sidebar and I'm concerned that could create confusion. This moves those directories below the individual guide pages.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
