### PR TITLE
[Zeebe] Removed resource from Deployment:CREATED event

### DIFF
--- a/docs/guides/update-guide/820-to-830.md
+++ b/docs/guides/update-guide/820-to-830.md
@@ -1,0 +1,15 @@
+---
+id: 820-to-830
+title: Update 8.2 to 8.3
+description: "Review which adjustments must be made to migrate from Camunda Platform 8.2.x to Camunda Platform 8.3.0."
+---
+
+<span class="badge badge--primary">Intermediate</span>
+
+The following sections explain which adjustments must be made to migrate from Camunda Platform 8.2.x to 8.3.0 for each component.
+
+## Zeebe
+
+### Resource not more available in Deployment:CREATED event
+
+Resource into **Deployment:CREATED** event are no longer available. Resource are available in **Process:CREATED** events for BPMN models or in **DecisionRequirements:CREATED** events for DMN models

--- a/docs/guides/update-guide/820-to-830.md
+++ b/docs/guides/update-guide/820-to-830.md
@@ -10,6 +10,6 @@ The following sections explain which adjustments must be made to migrate from Ca
 
 ## Zeebe
 
-### Resource not more available in Deployment:CREATED event
+### Resources no longer available in the Deployment:CREATED event
 
-Resource into **Deployment:CREATED** event are no longer available. Resource are available in **Process:CREATED** events for BPMN models or in **DecisionRequirements:CREATED** events for DMN models
+Resources in the **Deployment:CREATED** event are no longer available. Custom Exporters using the resources from this event must be modified to get them from the **Process:CREATED** event for BPMN models and the **DecisionRequirements:CREATED** event for DMN models.

--- a/docs/guides/update-guide/introduction.md
+++ b/docs/guides/update-guide/introduction.md
@@ -20,6 +20,15 @@ Versions prior to Camunda Platform 8 are listed below and identified as Camunda 
 
 There is a dedicated update guide for each version:
 
+### [Camunda Platform 8.2 to Camunda Platform 8.3](../820-to-830)
+
+Update from 8.2.x to 8.3.0
+
+<!-- ADD LINK WHEN AVAILABLE
+[Release notes](/)
+[Release blog](/)
+-->
+
 ### [Camunda Platform 8.1 to Camunda Platform 8.2](../810-to-820)
 
 Update from 8.1.x to 8.2.0

--- a/sidebars.js
+++ b/sidebars.js
@@ -34,6 +34,7 @@ module.exports = {
     {
       "Update guide": [
         "guides/update-guide/introduction",
+        "guides/update-guide/820-to-830",
         "guides/update-guide/810-to-820",
         "guides/update-guide/800-to-810",
         "guides/update-guide/130-to-800",


### PR DESCRIPTION
## Description

Closes #2339 
Related [issue](https://github.com/camunda/zeebe/issues/13233)

Removed resource from `Deployment:CREATED` event. Resource is still available in `Process:CREATED` or `DecisionRequirements:CREATED`

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
