### PR TITLE
Update Connectors docs to reflect the latest SDK changes

### DIFF
--- a/docs/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/docs/components/connectors/custom-built-connectors/connector-sdk.md
@@ -274,7 +274,6 @@ public class MyConnectorFunction implements OutboundConnectorFunction {
   }
 
   private MyConnectorResult executeConnector(final MyConnectorRequest connectorRequest) {
-    LOGGER.info("Executing my connector with request {}", connectorRequest);
     String message = connectorRequest.getMessage();
     // (3)
     if (message != null && message.toLowerCase().startsWith("fail")) {
@@ -319,7 +318,7 @@ method shown in **(1)**.
 
 Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string
 containing the input data into Java objects, and perform the input validation.
-This deserialization depends on the Connector runtime environment your Connector function runs in.
+The JSON deserialization depends on the Connector runtime environment your Connector function runs in.
 
 Thus, use this deserialization approach with caution.
 While it works reliably for many input data types like string, boolean, integer, and nested

--- a/docs/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/docs/components/connectors/custom-built-connectors/connector-sdk.md
@@ -317,14 +317,14 @@ You can either fetch this data as a raw JSON string using the context's `getVari
 or deserialize the data into your own request object directly with the `bindVariables`
 method shown in **(1)**.
 
-Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string 
+Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string
 containing the input data into Java objects, and perform the input validation.
 This deserialization depends on the Connector runtime environment your Connector function runs in.
 
 Thus, use this deserialization approach with caution.
 While it works reliably for many input data types like string, boolean, integer, and nested
 objects, you might want to consider deserializing your Connector's input data in a custom fashion
-using `getVariables` and a library like [Jackson](https://github.com/FasterXML/jackson)or 
+using `getVariables` and a library like [Jackson](https://github.com/FasterXML/jackson)or
 [Gson](https://github.com/google/gson).
 
 The `bindVariables` method and tools like Jackson or Gson can properly reflect nested data
@@ -488,7 +488,7 @@ The implementation must release all resources used by the subscription.
 
 #### Validation
 
-Validating input data is a common task in a Connector function. The SDK provides 
+Validating input data is a common task in a Connector function. The SDK provides
 an out-of-the-box solution for input validation.
 A default implementation of the SDK's core validation API is provided in a separate,
 optional artifact `connector-validation`. If you want to use validation in your
@@ -813,7 +813,7 @@ public class Authentication {
 }
 ```
 
-In the input model above, the Runtime will attempt to find and replace secrets in all String fields 
+In the input model above, the Runtime will attempt to find and replace secrets in all String fields
 of the `Authentication` and `MyConnectorRequest` classes.
 
 ## Testing

--- a/docs/guides/update-guide/connectors/0100-to-0110.md
+++ b/docs/guides/update-guide/connectors/0100-to-0110.md
@@ -10,20 +10,18 @@ import TabItem from "@theme/TabItem";
 <span class="badge badge--beginner">Beginner</span>
 
 :::note
-Please migrate directly to the version 0.11.2 of the SDK. It contains a fix for several issues in the 0.11.0 release.
+Migrate directly to version 0.11.2 of the SDK. This contains a fix for several issues in the 0.11.0 release.
 :::
 
-This SDK release is not backwards-compatible.
-We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
+This SDK release is not backwards-compatible. We are moving towards a stable Connectors release and continue to improve the experience of developing custom Connectors.
 
-In this SDK version, we changed the OutboundConnectorContext and InboundConnectorContext interfaces significantly.
-You can no longer use the `getVariablesAsType` or `getPropertiesAsType` methods in outbound and inbound connectors, respectively.
-Use the new bindVariables method instead: it takes care of secret replacement, payload validation and deserialization automatically.
+In this SDK version, we changed the `OutboundConnectorContext` and `InboundConnectorContext interfaces significantly.` You can no longer use the `getVariablesAsType` or `getPropertiesAsType` methods in outbound and inbound Connectors, respectively.
+Use the new `bindVariables` method instead, as it takes care of secret replacement, payload validation, and deserialization automatically.
 
-We are moving away from a mandatory @Secret annotation.
-Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+We are moving away from a mandatory `@Secret` annotation.
+From this release onwards, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
 
-To migrate your Connector implementations, please do the following:
+To migrate your Connector implementations, complete the following:
 
 1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
 2. If you used the `InboundConnectorContext::getPropertiesAsType` method in you inbound Connector executables, replace it with `InboundConnectorContext::bindProperties`.

--- a/docs/guides/update-guide/connectors/0100-to-0110.md
+++ b/docs/guides/update-guide/connectors/0100-to-0110.md
@@ -24,8 +24,9 @@ We are moving away from a mandatory @Secret annotation.
 Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
 
 To migrate your Connector implementations, please do the following:
+
 1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
 2. If you used the `InboundConnectorContext::getPropertiesAsType` method in you inbound Connector executables, replace it with `InboundConnectorContext::bindProperties`.
 3. Remove calls to `OutboundConnectorContext::replaceSecrets` and `InboundConnectorContext::replaceSecrets` methods. The secrets are now replaced automatically.
 4. Remove calls to `OutboundConnectorContext::validate` and `InboundConnectorContext::validate` methods. The validation is now performed automatically.
-4. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.
+5. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.

--- a/docs/guides/update-guide/connectors/0100-to-0110.md
+++ b/docs/guides/update-guide/connectors/0100-to-0110.md
@@ -1,0 +1,31 @@
+---
+id: 0100-to-0110
+title: Update 0.10 to 0.11
+description: "Review which adjustments must be made to migrate from Connector SDK 0.10.x to 0.11.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--beginner">Beginner</span>
+
+:::note
+Please migrate directly to the version 0.11.2 of the SDK. It contains a fix for several issues in the 0.11.0 release.
+:::
+
+This SDK release is not backwards-compatible.
+We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
+
+In this SDK version, we changed the OutboundConnectorContext and InboundConnectorContext interfaces significantly.
+You can no longer use the `getVariablesAsType` or `getPropertiesAsType` methods in outbound and inbound connectors, respectively.
+Use the new bindVariables method instead: it takes care of secret replacement, payload validation and deserialization automatically.
+
+We are moving away from a mandatory @Secret annotation.
+Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+
+To migrate your Connector implementations, please do the following:
+1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
+2. If you used the `InboundConnectorContext::getPropertiesAsType` method in you inbound Connector executables, replace it with `InboundConnectorContext::bindProperties`.
+3. Remove calls to `OutboundConnectorContext::replaceSecrets` and `InboundConnectorContext::replaceSecrets` methods. The secrets are now replaced automatically.
+4. Remove calls to `OutboundConnectorContext::validate` and `InboundConnectorContext::validate` methods. The validation is now performed automatically.
+4. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.

--- a/docs/guides/update-guide/connectors/introduction.md
+++ b/docs/guides/update-guide/connectors/introduction.md
@@ -9,6 +9,10 @@ Connector runtimes to a newer version of the
 
 There is a dedicated update guide for each version:
 
+### [Connector SDK 0.10.x to 0.11](../0100-to-0110)
+
+Update from 0.10.x to 0.11.2
+
 ### [Connector SDK 0.9 to 0.10](../090-to-0100)
 
 Update from 0.9.x to 0.10.0

--- a/sidebars.js
+++ b/sidebars.js
@@ -53,6 +53,7 @@ module.exports = {
             "guides/update-guide/connectors/070-to-080",
             "guides/update-guide/connectors/080-to-090",
             "guides/update-guide/connectors/090-to-0100",
+            "guides/update-guide/connectors/0100-to-0110",
           ],
         },
         {

--- a/versioned_docs/version-8.0/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.0/components/connectors/custom-built-connectors/connector-sdk.md
@@ -38,7 +38,7 @@ This section outlines how to set up a Connector project, test it, and run it loc
 ### Setup
 
 When developing a new **Connector**, we recommend using one of our custom Connector
-templates for custom [outbound](https://github.com/camunda/connector-template-outbound) connectors.
+templates for custom [outbound](https://github.com/camunda/connector-template-outbound) Connectors.
 These templates are [Maven](https://maven.apache.org/)-based Java projects, and can be used in various
 ways such as:
 

--- a/versioned_docs/version-8.0/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.0/components/connectors/custom-built-connectors/connector-sdk.md
@@ -316,14 +316,14 @@ You can either fetch this data as a raw JSON string using the context's `getVari
 or deserialize the data into your own request object directly with the `bindVariables`
 method shown in **(1)**.
 
-Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string 
+Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string
 containing the input data into Java objects, and perform the input validation.
 This deserialization depends on the Connector runtime environment your Connector function runs in.
 
 Thus, use this deserialization approach with caution.
 While it works reliably for many input data types like string, boolean, integer, and nested
 objects, you might want to consider deserializing your Connector's input data in a custom fashion
-using `getVariables` and a library like [Jackson](https://github.com/FasterXML/jackson)or 
+using `getVariables` and a library like [Jackson](https://github.com/FasterXML/jackson)or
 [Gson](https://github.com/google/gson).
 
 The `bindVariables` method and tools like Jackson or Gson can properly reflect nested data
@@ -353,7 +353,7 @@ public class Authentication {
 
 #### Validation
 
-Validating input data is a common task in a Connector function. The SDK provides 
+Validating input data is a common task in a Connector function. The SDK provides
 an out-of-the-box solution for input validation.
 A default implementation of the SDK's core validation API is provided in a separate,
 optional artifact `connector-validation`. If you want to use validation in your
@@ -677,7 +677,7 @@ public class Authentication {
 }
 ```
 
-In the input model above, the Runtime will attempt to find and replace secrets in all String fields 
+In the input model above, the Runtime will attempt to find and replace secrets in all String fields
 of the `Authentication` and `MyConnectorRequest` classes.
 
 ## Testing

--- a/versioned_docs/version-8.0/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.0/components/connectors/custom-built-connectors/connector-sdk.md
@@ -273,7 +273,6 @@ public class MyConnectorFunction implements OutboundConnectorFunction {
   }
 
   private MyConnectorResult executeConnector(final MyConnectorRequest connectorRequest) {
-    LOGGER.info("Executing my connector with request {}", connectorRequest);
     String message = connectorRequest.getMessage();
     // (3)
     if (message != null && message.toLowerCase().startsWith("fail")) {
@@ -318,7 +317,7 @@ method shown in **(1)**.
 
 Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string
 containing the input data into Java objects, and perform the input validation.
-This deserialization depends on the Connector runtime environment your Connector function runs in.
+The JSON deserialization depends on the Connector runtime environment your Connector function runs in.
 
 Thus, use this deserialization approach with caution.
 While it works reliably for many input data types like string, boolean, integer, and nested

--- a/versioned_docs/version-8.0/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.0/components/connectors/custom-built-connectors/connector-sdk.md
@@ -38,8 +38,8 @@ This section outlines how to set up a Connector project, test it, and run it loc
 ### Setup
 
 When developing a new **Connector**, we recommend using one of our custom Connector
-template for custom [outbound](https://github.com/camunda/connector-template-outbound) connector.
-These template is [Maven](https://maven.apache.org/)-based Java projects, and can be used in various
+templates for custom [outbound](https://github.com/camunda/connector-template-outbound) connectors.
+These templates are [Maven](https://maven.apache.org/)-based Java projects, and can be used in various
 ways such as:
 
 - _Create your own GitHub repository_: Click **Use this template** and follow the prompted steps.
@@ -66,7 +66,7 @@ Ensure you adhere to the project outline detailed in the next section.
 <dependency>
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-core</artifactId>
-  <version>0.8.1</version>
+  <version>0.11.2</version>
 </dependency>
 ```
 
@@ -75,7 +75,7 @@ Ensure you adhere to the project outline detailed in the next section.
 <TabItem value='gradle'>
 
 ```yml
-implementation 'io.camunda.connector:connector-core:0.8.1'
+implementation 'io.camunda.connector:connector-core:0.11.2'
 ```
 
 </TabItem>
@@ -181,7 +181,7 @@ For example, you can create the domain object `authentication` that contains the
 ```
 
 You can deserialize these authentication properties into a domain object using the SDK.
-Visit the [input data](#input-data) section for further details.
+Visit the [input data](#outbound-connector-input-data) section for further details.
 
 Connectors that offer any kind of result from their invocation should allow users to configure
 how to map the result into their processes. Therefore, Connector templates can reuse the two
@@ -267,27 +267,21 @@ public class MyConnectorFunction implements OutboundConnectorFunction {
   @Override
   public Object execute(OutboundConnectorContext context) throws Exception {
     // (1)
-    var connectorRequest = context.getVariablesAsType(MyConnectorRequest.class);
-
+    var connectorRequest = context.bindVariables(MyConnectorRequest.class);
     // (2)
-    context.validate(connectorRequest);
-
-    // (3)
-    context.replaceSecrets(connectorRequest);
-
     return executeConnector(connectorRequest);
   }
 
   private MyConnectorResult executeConnector(final MyConnectorRequest connectorRequest) {
     LOGGER.info("Executing my connector with request {}", connectorRequest);
     String message = connectorRequest.getMessage();
-    // (4)
+    // (3)
     if (message != null && message.toLowerCase().startsWith("fail")) {
       throw new ConnectorException("FAIL", "My property started with 'fail', was: " + message);
     }
     var result = new MyConnectorResult();
 
-    // (5)
+    // (4)
     result.setMyProperty("Message received: " + message);
     return result;
   }
@@ -297,18 +291,17 @@ public class MyConnectorFunction implements OutboundConnectorFunction {
 The `execute` method receives all necessary environment data via the `OutboundConnectorContext` object.
 The Connector runtime environment initializes the context and allows the following to occur:
 
-- Fetch and deserialize the input data as shown in **(1)**. See the [input data](#input-data) section for details.
-- Validate the created request object as shown in **(2)**. See the [validation](#validation) section for details.
-- Replace secrets in the request object as shown in **(3)**. See the [secrets](#secrets) section for details.
+- Fetch and deserialize the input data as shown in **(1)**. See the [input data](#outbound-connector-input-data) section for details.
+- Execute the Connector's business logic as shown in **(2)**.
 
 If the Connector handles exceptional cases, it can use any exception to express technical errors. If a technical
 error should be associated with a specific error code, the Connector can throw a `ConnectorException` and define
-a `code` as shown in **(4)**.
+a `code` as shown in **(3)**.
 We recommend documenting the list of error codes as part of the Connector's API. Users can build on those codes
 by creating [BPMN errors](/components/connectors/use-connectors/index.md#bpmn-errors) in their Connector configurations.
 
 If the Connector has a result to return, it can create a new result data object and set
-its properties as shown in **(5)**.
+its properties as shown in **(4)**.
 
 For best interoperability, Connector functions provide default meta-data via the `@OutboundConnector` annotation.
 Connector runtime environments can use this data to auto-discover provided Connector runtime behavior.
@@ -320,19 +313,20 @@ and expand from there.
 
 The input data of a Connector is provided by the process instance that executes the Connector.
 You can either fetch this data as a raw JSON string using the context's `getVariables` method,
-or deserialize the data into your own request object directly with the `getVariablesAsType`
+or deserialize the data into your own request object directly with the `bindVariables`
 method shown in **(1)**.
 
-Using `getVariablesAsType` will attempt to deserialize the JSON string containing the input
-data into Java objects. This deserialization depends on the Connector runtime environment your
-Connector function runs in.
+Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string 
+containing the input data into Java objects, and perform the input validation.
+This deserialization depends on the Connector runtime environment your Connector function runs in.
 
 Thus, use this deserialization approach with caution.
 While it works reliably for many input data types like string, boolean, integer, and nested
 objects, you might want to consider deserializing your Connector's input data in a custom fashion
-using `getVariables` and a library like [Gson](https://github.com/google/gson).
+using `getVariables` and a library like [Jackson](https://github.com/FasterXML/jackson)or 
+[Gson](https://github.com/google/gson).
 
-The `getVariablesAsType` method and tools like Gson can properly reflect nested data
+The `bindVariables` method and tools like Jackson or Gson can properly reflect nested data
 objects. You can define nested structures by referencing other Java classes as attributes.
 Looking at the `authentication` data input example described in the [Connector template](#outbound-connector-element-template),
 you can create the following input data objects to reflect the structure properly:
@@ -359,9 +353,9 @@ public class Authentication {
 
 #### Validation
 
-Validating input data is a common task in a Connector function. The SDK provides an
-API to help you ensure the data conforms to your Connector's input requirements. A
-default implementation of the SDK's core validation API is provided in a separate,
+Validating input data is a common task in a Connector function. The SDK provides 
+an out-of-the-box solution for input validation.
+A default implementation of the SDK's core validation API is provided in a separate,
 optional artifact `connector-validation`. If you want to use validation in your
 Connector, add the following dependency to your project:
 
@@ -378,7 +372,7 @@ Connector, add the following dependency to your project:
 <dependency>
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-validation</artifactId>
-  <version>0.8.1</version>
+  <version>0.11.2</version>
 </dependency>
 ```
 
@@ -387,33 +381,20 @@ Connector, add the following dependency to your project:
 <TabItem value='gradle'>
 
 ```yml
-implementation 'io.camunda.connector:connector-validation:0.8.1'
+implementation 'io.camunda.connector:connector-validation:0.11.2'
 ```
 
 </TabItem>
 </Tabs>
 
-To initiate the validation from the Connector function, use the `OutboundConnectorContext`
-object's `validate` method as shown in the [runtime logic](#runtime-logic) section:
-
-```java
-...
-  @Override
-  public Object execute(OutboundConnectorContext context) throws Exception {
-    ...
-    // (2)
-    context.validate(connectorRequest);
-    ...
-  }
-...
-```
+Validation is performed automatically if you use the `bindVariables` / `bindProperties` methods.
 
 This instructs the context to prepare a validator that is provided by an implementation
 of the `ValidationProvider` interface. The `connector-validation` artifact brings along
 such an implementation. It uses the [Jakarta Bean Validation API](https://beanvalidation.org/)
 together with [Hibernate Validator](https://hibernate.org/validator/).
 
-To validate your input object `connectorRequest` using the API, you need to annotate the input's
+For your input object `connectorRequest` to be validated, you need to annotate the input's
 attributes to define your requirements:
 
 ```java
@@ -657,7 +638,7 @@ Connectors that require confidential information to connect to external systems 
 to manage those securely. As described in the
 [guide for creating secrets](/components/console/manage-clusters/manage-secrets.md), secrets can be
 controlled in a secure location and referenced in a Connector's properties using a placeholder
-pattern `secrets.*`. To make this mechanism as robust as possible, secret handling comes with
+pattern `{{secrets.*}}`. To make this mechanism as robust as possible, secret handling comes with
 the Connector SDK out of the box. That way, all Connectors can use the same standard way of
 handling secrets in input data.
 
@@ -666,43 +647,21 @@ in the environments that handle Connector invocation. We do not pass secrets int
 Connector function in clear text but only as placeholders that you can replace from
 within the Connector function.
 
-To initiate the secret replacement from the Connector function,
-use the `OutboundConnectorContext` object's `replaceSecrets` method as shown in the
-[runtime logic](#runtime-logic) section:
+Secrets are replaced automatically in the Connector input when you use the variable access methods
+of the `OutboundConnectorContext`. You will always receive inputs with secrets replaced.
 
-```java
-...
-  @Override
-  public Object execute(OutboundConnectorContext context) throws Exception {
-    ...
-    // (3)
-    context.replaceSecrets(connectorRequest);
-    ...
-  }
-...
-```
-
-This will instruct the context to search for and replace secret placeholders in the object passed to it.
-The secret store present in the Connector runtime environment that invokes the Connector function
-takes care of that. Every environment can define its own way of providing such a secret store. Consult
-the [runtime environments](#runtime-environments) section to learn more about them.
-
-To replace secrets in the `connectorRequest` using the API, you need to annotate the object's
-attributes that can hold secrets with `@Secret`. This instructs the SDK to search for and replace
-secrets in the annotated properties. You can use the `@Secret` annotation on String fields
-and container types. Using the annotation on container objects will lead to
-graph traversal until either no further matching annotation is found or the annotated property
-is of type String. Annotating properties that are neither a String nor a container will lead to runtime exceptions.
+The Runtime automatically replaces secrets in String fields or in container types. Using the
+placeholder pattern `{{secrets.*}}` in a String field will replace the placeholder with the secret
+value. Using the placeholder pattern in a container type will replace the placeholder in all
+String fields of the container type.
 
 ```java
 package io.camunda.connector;
 
-import io.camunda.connector.api.annotation.Secret;
-
 public class MyConnectorRequest {
 
   private String message;
-  @Secret private Authentication authentication;
+  private Authentication authentication;
 }
 ```
 
@@ -714,12 +673,12 @@ import io.camunda.connector.api.annotation.Secret;
 public class Authentication {
 
   private String user;
-  @Secret private String token;
+  private String token;
 }
 ```
 
-Using this approach, you can replace secrets in your whole input data structure with one
-initial call from the central Connector function.
+In the input model above, the Runtime will attempt to find and replace secrets in all String fields 
+of the `Authentication` and `MyConnectorRequest` classes.
 
 ## Testing
 
@@ -759,7 +718,7 @@ void shouldReplaceTokenSecretWhenReplaceSecrets() {
     .secret("MY_TOKEN", "token value")
     .build();
   // when
-  context.replaceSecrets(input);
+  var variables = context.bindVariables(MyConnectorType.class);
   // then
   assertThat(input)
     .extracting("authentication")

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/0100-to-0110.md
@@ -23,7 +23,8 @@ We are moving away from a mandatory @Secret annotation.
 Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
 
 To migrate your Connector implementations, please do the following:
+
 1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
 2. Remove calls to the `OutboundConnectorContext::replaceSecrets` method. The secrets are now replaced automatically.
-4. Remove calls to the `OutboundConnectorContext::validate` methods. The validation is now performed automatically.
+3. Remove calls to the `OutboundConnectorContext::validate` methods. The validation is now performed automatically.
 4. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/0100-to-0110.md
@@ -1,0 +1,29 @@
+---
+id: 0100-to-0110
+title: Update 0.10 to 0.11
+description: "Review which adjustments must be made to migrate from Connector SDK 0.10.x to 0.11.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--beginner">Beginner</span>
+
+:::note
+Please migrate directly to the version 0.11.2 of the SDK. It contains a fix for several issues in the 0.11.0 release.
+:::
+
+This SDK release is not backwards-compatible.
+We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
+
+In this SDK version, we changed the OutboundConnectorContext and InboundConnectorContext interfaces significantly. You can no longer use the `getVariablesAsType`.
+Use the new bindVariables method instead: it takes care of secret replacement, payload validation and deserialization automatically.
+
+We are moving away from a mandatory @Secret annotation.
+Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+
+To migrate your Connector implementations, please do the following:
+1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
+2. Remove calls to the `OutboundConnectorContext::replaceSecrets` method. The secrets are now replaced automatically.
+4. Remove calls to the `OutboundConnectorContext::validate` methods. The validation is now performed automatically.
+4. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/0100-to-0110.md
@@ -10,21 +10,20 @@ import TabItem from "@theme/TabItem";
 <span class="badge badge--beginner">Beginner</span>
 
 :::note
-Please migrate directly to the version 0.11.2 of the SDK. It contains a fix for several issues in the 0.11.0 release.
+Migrate directly to version 0.11.2 of the SDK. This contains a fix for several issues in the 0.11.0 release.
 :::
 
-This SDK release is not backwards-compatible.
-We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
+This SDK release is not backwards-compatible. We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
 
-In this SDK version, we changed the OutboundConnectorContext and InboundConnectorContext interfaces significantly. You can no longer use the `getVariablesAsType`.
-Use the new bindVariables method instead: it takes care of secret replacement, payload validation and deserialization automatically.
+In this SDK version, we changed the `OutboundConnectorContext` and `InboundConnectorContext` interfaces significantly. You can no longer use the `getVariablesAsType`.
 
-We are moving away from a mandatory @Secret annotation.
-Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+Use the new `bindVariables` method instead, as it takes care of secret replacement, payload validation, and deserialization automatically.
 
-To migrate your Connector implementations, please do the following:
+We are moving away from a mandatory `@Secret` annotation. From this release onwards, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+
+To migrate your Connector implementations, complete the following:
 
 1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
 2. Remove calls to the `OutboundConnectorContext::replaceSecrets` method. The secrets are now replaced automatically.
 3. Remove calls to the `OutboundConnectorContext::validate` methods. The validation is now performed automatically.
-4. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.
+4. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it as it has no effect.

--- a/versioned_docs/version-8.0/guides/update-guide/connectors/introduction.md
+++ b/versioned_docs/version-8.0/guides/update-guide/connectors/introduction.md
@@ -9,6 +9,10 @@ Connector runtimes to a newer version of the
 
 There is a dedicated update guide for each version:
 
+### [Connector SDK 0.10.x to 0.11](../0100-to-0110)
+
+Update from 0.10.x to 0.11.2
+
 ### [Connector SDK 0.9 to 0.10](../090-to-0100)
 
 Update from 0.9.x to 0.10.0

--- a/versioned_docs/version-8.1/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.1/components/connectors/custom-built-connectors/connector-sdk.md
@@ -274,7 +274,6 @@ public class MyConnectorFunction implements OutboundConnectorFunction {
   }
 
   private MyConnectorResult executeConnector(final MyConnectorRequest connectorRequest) {
-    LOGGER.info("Executing my connector with request {}", connectorRequest);
     String message = connectorRequest.getMessage();
     // (3)
     if (message != null && message.toLowerCase().startsWith("fail")) {
@@ -319,7 +318,7 @@ method shown in **(1)**.
 
 Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string
 containing the input data into Java objects, and perform the input validation.
-This deserialization depends on the Connector runtime environment your Connector function runs in.
+The JSON deserialization depends on the Connector runtime environment your Connector function runs in.
 
 Thus, use this deserialization approach with caution.
 While it works reliably for many input data types like string, boolean, integer, and nested

--- a/versioned_docs/version-8.1/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.1/components/connectors/custom-built-connectors/connector-sdk.md
@@ -67,7 +67,7 @@ Ensure you adhere to the project outline detailed in the next section.
 <dependency>
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-core</artifactId>
-  <version>0.8.1</version>
+  <version>0.11.2</version>
 </dependency>
 ```
 
@@ -76,7 +76,7 @@ Ensure you adhere to the project outline detailed in the next section.
 <TabItem value='gradle'>
 
 ```yml
-implementation 'io.camunda.connector:connector-core:0.8.1'
+implementation 'io.camunda.connector:connector-core:0.11.2'
 ```
 
 </TabItem>
@@ -182,7 +182,7 @@ For example, you can create the domain object `authentication` that contains the
 ```
 
 You can deserialize these authentication properties into a domain object using the SDK.
-Visit the [input data](#input-data) section for further details.
+Visit the [input data](#outbound-connector-input-data) section for further details.
 
 Connectors that offer any kind of result from their invocation should allow users to configure
 how to map the result into their processes. Therefore, Connector templates can reuse the two
@@ -268,27 +268,21 @@ public class MyConnectorFunction implements OutboundConnectorFunction {
   @Override
   public Object execute(OutboundConnectorContext context) throws Exception {
     // (1)
-    var connectorRequest = context.getVariablesAsType(MyConnectorRequest.class);
-
+    var connectorRequest = context.bindVariables(MyConnectorRequest.class);
     // (2)
-    context.validate(connectorRequest);
-
-    // (3)
-    context.replaceSecrets(connectorRequest);
-
     return executeConnector(connectorRequest);
   }
 
   private MyConnectorResult executeConnector(final MyConnectorRequest connectorRequest) {
     LOGGER.info("Executing my connector with request {}", connectorRequest);
     String message = connectorRequest.getMessage();
-    // (4)
+    // (3)
     if (message != null && message.toLowerCase().startsWith("fail")) {
       throw new ConnectorException("FAIL", "My property started with 'fail', was: " + message);
     }
     var result = new MyConnectorResult();
 
-    // (5)
+    // (4)
     result.setMyProperty("Message received: " + message);
     return result;
   }
@@ -298,18 +292,17 @@ public class MyConnectorFunction implements OutboundConnectorFunction {
 The `execute` method receives all necessary environment data via the `OutboundConnectorContext` object.
 The Connector runtime environment initializes the context and allows the following to occur:
 
-- Fetch and deserialize the input data as shown in **(1)**. See the [input data](#input-data) section for details.
-- Validate the created request object as shown in **(2)**. See the [validation](#validation) section for details.
-- Replace secrets in the request object as shown in **(3)**. See the [secrets](#secrets) section for details.
+- Fetch and deserialize the input data as shown in **(1)**. See the [input data](#outbound-connector-input-data) section for details.
+- Execute the Connector's business logic as shown in **(2)**.
 
 If the Connector handles exceptional cases, it can use any exception to express technical errors. If a technical
 error should be associated with a specific error code, the Connector can throw a `ConnectorException` and define
-a `code` as shown in **(4)**.
+a `code` as shown in **(3)**.
 We recommend documenting the list of error codes as part of the Connector's API. Users can build on those codes
 by creating [BPMN errors](/components/connectors/use-connectors/index.md#bpmn-errors) in their Connector configurations.
 
 If the Connector has a result to return, it can create a new result data object and set
-its properties as shown in **(5)**.
+its properties as shown in **(4)**.
 
 For best interoperability, Connector functions provide default meta-data via the `@OutboundConnector` annotation.
 Connector runtime environments can use this data to auto-discover provided Connector runtime behavior.
@@ -321,19 +314,20 @@ and expand from there.
 
 The input data of a Connector is provided by the process instance that executes the Connector.
 You can either fetch this data as a raw JSON string using the context's `getVariables` method,
-or deserialize the data into your own request object directly with the `getVariablesAsType`
+or deserialize the data into your own request object directly with the `bindVariables`
 method shown in **(1)**.
 
-Using `getVariablesAsType` will attempt to deserialize the JSON string containing the input
-data into Java objects. This deserialization depends on the Connector runtime environment your
-Connector function runs in.
+Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string 
+containing the input data into Java objects, and perform the input validation.
+This deserialization depends on the Connector runtime environment your Connector function runs in.
 
 Thus, use this deserialization approach with caution.
 While it works reliably for many input data types like string, boolean, integer, and nested
 objects, you might want to consider deserializing your Connector's input data in a custom fashion
-using `getVariables` and a library like [Gson](https://github.com/google/gson).
+using `getVariables` and a library like [Jackson](https://github.com/FasterXML/jackson)or 
+[Gson](https://github.com/google/gson).
 
-The `getVariablesAsType` method and tools like Gson can properly reflect nested data
+The `bindVariables` method and tools like Jackson or Gson can properly reflect nested data
 objects. You can define nested structures by referencing other Java classes as attributes.
 Looking at the `authentication` data input example described in the [Connector template](#outbound-connector-element-template),
 you can create the following input data objects to reflect the structure properly:
@@ -464,10 +458,7 @@ public class MyConnectorExecutable implements InboundConnectorExecutable {
 
     @Override
     public void activate(InboundConnectorContext connectorContext) {
-        MyConnectorProperties props = connectorContext.getPropertiesAsType(MyConnectorProperties.class);
-
-        connectorContext.replaceSecrets(props);
-        connectorContext.validate(props);
+        MyConnectorProperties props = connectorContext.bindProperties(MyConnectorProperties.class);
 
         this.connectorContext = connectorContext;
 
@@ -497,9 +488,9 @@ The implementation must release all resources used by the subscription.
 
 #### Validation
 
-Validating input data is a common task in a Connector function. The SDK provides an
-API to help you ensure the data conforms to your Connector's input requirements. A
-default implementation of the SDK's core validation API is provided in a separate,
+Validating input data is a common task in a Connector function. The SDK provides 
+an out-of-the-box solution for input validation.
+A default implementation of the SDK's core validation API is provided in a separate,
 optional artifact `connector-validation`. If you want to use validation in your
 Connector, add the following dependency to your project:
 
@@ -516,7 +507,7 @@ Connector, add the following dependency to your project:
 <dependency>
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-validation</artifactId>
-  <version>0.8.1</version>
+  <version>0.11.2</version>
 </dependency>
 ```
 
@@ -525,33 +516,20 @@ Connector, add the following dependency to your project:
 <TabItem value='gradle'>
 
 ```yml
-implementation 'io.camunda.connector:connector-validation:0.8.1'
+implementation 'io.camunda.connector:connector-validation:0.11.2'
 ```
 
 </TabItem>
 </Tabs>
 
-To initiate the validation from the Connector function, use the `OutboundConnectorContext`
-object's `validate` method as shown in the [runtime logic](#runtime-logic) section:
-
-```java
-...
-  @Override
-  public Object execute(OutboundConnectorContext context) throws Exception {
-    ...
-    // (2)
-    context.validate(connectorRequest);
-    ...
-  }
-...
-```
+Validation is performed automatically if you use the `bindVariables` / `bindProperties` methods.
 
 This instructs the context to prepare a validator that is provided by an implementation
 of the `ValidationProvider` interface. The `connector-validation` artifact brings along
 such an implementation. It uses the [Jakarta Bean Validation API](https://beanvalidation.org/)
 together with [Hibernate Validator](https://hibernate.org/validator/).
 
-To validate your input object `connectorRequest` using the API, you need to annotate the input's
+For your input object `connectorRequest` to be validated, you need to annotate the input's
 attributes to define your requirements:
 
 ```java
@@ -795,7 +773,7 @@ Connectors that require confidential information to connect to external systems 
 to manage those securely. As described in the
 [guide for creating secrets](/components/console/manage-clusters/manage-secrets.md), secrets can be
 controlled in a secure location and referenced in a Connector's properties using a placeholder
-pattern `secrets.*`. To make this mechanism as robust as possible, secret handling comes with
+pattern `{{secrets.*}}`. To make this mechanism as robust as possible, secret handling comes with
 the Connector SDK out of the box. That way, all Connectors can use the same standard way of
 handling secrets in input data.
 
@@ -804,43 +782,22 @@ in the environments that handle Connector invocation. We do not pass secrets int
 Connector function in clear text but only as placeholders that you can replace from
 within the Connector function.
 
-To initiate the secret replacement from the Connector function,
-use the `OutboundConnectorContext` object's `replaceSecrets` method as shown in the
-[runtime logic](#runtime-logic) section:
+Secrets are replaced automatically in the Connector input when you use the variable access methods
+of the `OutboundConnectorContext` or properties access methods of the `InboundConnectorContext`.
+You will always receive inputs with secrets replaced.
 
-```java
-...
-  @Override
-  public Object execute(OutboundConnectorContext context) throws Exception {
-    ...
-    // (3)
-    context.replaceSecrets(connectorRequest);
-    ...
-  }
-...
-```
-
-This will instruct the context to search for and replace secret placeholders in the object passed to it.
-The secret store present in the Connector runtime environment that invokes the Connector function
-takes care of that. Every environment can define its own way of providing such a secret store. Consult
-the [runtime environments](#runtime-environments) section to learn more about them.
-
-To replace secrets in the `connectorRequest` using the API, you need to annotate the object's
-attributes that can hold secrets with `@Secret`. This instructs the SDK to search for and replace
-secrets in the annotated properties. You can use the `@Secret` annotation on String fields
-and container types. Using the annotation on container objects will lead to
-graph traversal until either no further matching annotation is found or the annotated property
-is of type String. Annotating properties that are neither a String nor a container will lead to runtime exceptions.
+The Runtime automatically replaces secrets in String fields or in container types. Using the
+placeholder pattern `{{secrets.*}}` in a String field will replace the placeholder with the secret
+value. Using the placeholder pattern in a container type will replace the placeholder in all
+String fields of the container type.
 
 ```java
 package io.camunda.connector;
 
-import io.camunda.connector.api.annotation.Secret;
-
 public class MyConnectorRequest {
 
   private String message;
-  @Secret private Authentication authentication;
+  private Authentication authentication;
 }
 ```
 
@@ -852,12 +809,12 @@ import io.camunda.connector.api.annotation.Secret;
 public class Authentication {
 
   private String user;
-  @Secret private String token;
+  private String token;
 }
 ```
 
-Using this approach, you can replace secrets in your whole input data structure with one
-initial call from the central Connector function.
+In the input model above, the Runtime will attempt to find and replace secrets in all String fields 
+of the `Authentication` and `MyConnectorRequest` classes.
 
 ## Testing
 
@@ -897,7 +854,7 @@ void shouldReplaceTokenSecretWhenReplaceSecrets() {
     .secret("MY_TOKEN", "token value")
     .build();
   // when
-  context.replaceSecrets(input);
+  var variables = context.bindVariables(MyConnectorType.class);
   // then
   assertThat(input)
     .extracting("authentication")

--- a/versioned_docs/version-8.1/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.1/components/connectors/custom-built-connectors/connector-sdk.md
@@ -317,14 +317,14 @@ You can either fetch this data as a raw JSON string using the context's `getVari
 or deserialize the data into your own request object directly with the `bindVariables`
 method shown in **(1)**.
 
-Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string 
+Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string
 containing the input data into Java objects, and perform the input validation.
 This deserialization depends on the Connector runtime environment your Connector function runs in.
 
 Thus, use this deserialization approach with caution.
 While it works reliably for many input data types like string, boolean, integer, and nested
 objects, you might want to consider deserializing your Connector's input data in a custom fashion
-using `getVariables` and a library like [Jackson](https://github.com/FasterXML/jackson)or 
+using `getVariables` and a library like [Jackson](https://github.com/FasterXML/jackson)or
 [Gson](https://github.com/google/gson).
 
 The `bindVariables` method and tools like Jackson or Gson can properly reflect nested data
@@ -488,7 +488,7 @@ The implementation must release all resources used by the subscription.
 
 #### Validation
 
-Validating input data is a common task in a Connector function. The SDK provides 
+Validating input data is a common task in a Connector function. The SDK provides
 an out-of-the-box solution for input validation.
 A default implementation of the SDK's core validation API is provided in a separate,
 optional artifact `connector-validation`. If you want to use validation in your
@@ -813,7 +813,7 @@ public class Authentication {
 }
 ```
 
-In the input model above, the Runtime will attempt to find and replace secrets in all String fields 
+In the input model above, the Runtime will attempt to find and replace secrets in all String fields
 of the `Authentication` and `MyConnectorRequest` classes.
 
 ## Testing

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/0100-to-0110.md
@@ -24,8 +24,9 @@ We are moving away from a mandatory @Secret annotation.
 Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
 
 To migrate your Connector implementations, please do the following:
+
 1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
 2. If you used the `InboundConnectorContext::getPropertiesAsType` method in you inbound Connector executables, replace it with `InboundConnectorContext::bindProperties`.
 3. Remove calls to `OutboundConnectorContext::replaceSecrets` and `InboundConnectorContext::replaceSecrets` methods. The secrets are now replaced automatically.
 4. Remove calls to `OutboundConnectorContext::validate` and `InboundConnectorContext::validate` methods. The validation is now performed automatically.
-4. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.
+5. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/0100-to-0110.md
@@ -10,23 +10,22 @@ import TabItem from "@theme/TabItem";
 <span class="badge badge--beginner">Beginner</span>
 
 :::note
-Please migrate directly to the version 0.11.2 of the SDK. It contains a fix for several issues in the 0.11.0 release.
+Migrate directly to version 0.11.2 of the SDK. This contains a fix for several issues in the 0.11.0 release.
 :::
 
-This SDK release is not backwards-compatible.
-We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
+This SDK release is not backwards-compatible. We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
 
-In this SDK version, we changed the OutboundConnectorContext and InboundConnectorContext interfaces significantly.
-You can no longer use the `getVariablesAsType` or `getPropertiesAsType` methods in outbound and inbound connectors, respectively.
-Use the new bindVariables method instead: it takes care of secret replacement, payload validation and deserialization automatically.
+In this SDK version, we changed the `OutboundConnectorContext` and `InboundConnectorContext` interfaces significantly.
+You can no longer use the `getVariablesAsType` or `getPropertiesAsType` methods in outbound and inbound Connectors, respectively.
 
-We are moving away from a mandatory @Secret annotation.
-Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+Use the new `bindVariables` method instead, as this takes care of secret replacement, payload validation, and deserialization automatically.
 
-To migrate your Connector implementations, please do the following:
+We are moving away from a mandatory `@Secret` annotation. From this release onwards, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+
+To migrate your Connector implementations, complete the following:
 
 1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
 2. If you used the `InboundConnectorContext::getPropertiesAsType` method in you inbound Connector executables, replace it with `InboundConnectorContext::bindProperties`.
 3. Remove calls to `OutboundConnectorContext::replaceSecrets` and `InboundConnectorContext::replaceSecrets` methods. The secrets are now replaced automatically.
 4. Remove calls to `OutboundConnectorContext::validate` and `InboundConnectorContext::validate` methods. The validation is now performed automatically.
-5. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.
+5. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it as it has no effect.

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/0100-to-0110.md
@@ -1,0 +1,31 @@
+---
+id: 0100-to-0110
+title: Update 0.10 to 0.11
+description: "Review which adjustments must be made to migrate from Connector SDK 0.10.x to 0.11.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--beginner">Beginner</span>
+
+:::note
+Please migrate directly to the version 0.11.2 of the SDK. It contains a fix for several issues in the 0.11.0 release.
+:::
+
+This SDK release is not backwards-compatible.
+We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
+
+In this SDK version, we changed the OutboundConnectorContext and InboundConnectorContext interfaces significantly.
+You can no longer use the `getVariablesAsType` or `getPropertiesAsType` methods in outbound and inbound connectors, respectively.
+Use the new bindVariables method instead: it takes care of secret replacement, payload validation and deserialization automatically.
+
+We are moving away from a mandatory @Secret annotation.
+Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+
+To migrate your Connector implementations, please do the following:
+1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
+2. If you used the `InboundConnectorContext::getPropertiesAsType` method in you inbound Connector executables, replace it with `InboundConnectorContext::bindProperties`.
+3. Remove calls to `OutboundConnectorContext::replaceSecrets` and `InboundConnectorContext::replaceSecrets` methods. The secrets are now replaced automatically.
+4. Remove calls to `OutboundConnectorContext::validate` and `InboundConnectorContext::validate` methods. The validation is now performed automatically.
+4. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.

--- a/versioned_docs/version-8.1/guides/update-guide/connectors/introduction.md
+++ b/versioned_docs/version-8.1/guides/update-guide/connectors/introduction.md
@@ -9,6 +9,10 @@ Connector runtimes to a newer version of the
 
 There is a dedicated update guide for each version:
 
+### [Connector SDK 0.10.x to 0.11](../0100-to-0110)
+
+Update from 0.10.x to 0.11.2
+
 ### [Connector SDK 0.9 to 0.10](../090-to-0100)
 
 Update from 0.9.x to 0.10.0

--- a/versioned_docs/version-8.2/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.2/components/connectors/custom-built-connectors/connector-sdk.md
@@ -274,7 +274,6 @@ public class MyConnectorFunction implements OutboundConnectorFunction {
   }
 
   private MyConnectorResult executeConnector(final MyConnectorRequest connectorRequest) {
-    LOGGER.info("Executing my connector with request {}", connectorRequest);
     String message = connectorRequest.getMessage();
     // (3)
     if (message != null && message.toLowerCase().startsWith("fail")) {
@@ -319,7 +318,7 @@ method shown in **(1)**.
 
 Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string
 containing the input data into Java objects, and perform the input validation.
-This deserialization depends on the Connector runtime environment your Connector function runs in.
+The JSON deserialization depends on the Connector runtime environment your Connector function runs in.
 
 Thus, use this deserialization approach with caution.
 While it works reliably for many input data types like string, boolean, integer, and nested

--- a/versioned_docs/version-8.2/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.2/components/connectors/custom-built-connectors/connector-sdk.md
@@ -317,14 +317,14 @@ You can either fetch this data as a raw JSON string using the context's `getVari
 or deserialize the data into your own request object directly with the `bindVariables`
 method shown in **(1)**.
 
-Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string 
+Using `bindVariables` will attempt to replace Connector secrets, deserialize the JSON string
 containing the input data into Java objects, and perform the input validation.
 This deserialization depends on the Connector runtime environment your Connector function runs in.
 
 Thus, use this deserialization approach with caution.
 While it works reliably for many input data types like string, boolean, integer, and nested
 objects, you might want to consider deserializing your Connector's input data in a custom fashion
-using `getVariables` and a library like [Jackson](https://github.com/FasterXML/jackson)or 
+using `getVariables` and a library like [Jackson](https://github.com/FasterXML/jackson)or
 [Gson](https://github.com/google/gson).
 
 The `bindVariables` method and tools like Jackson or Gson can properly reflect nested data
@@ -488,7 +488,7 @@ The implementation must release all resources used by the subscription.
 
 #### Validation
 
-Validating input data is a common task in a Connector function. The SDK provides 
+Validating input data is a common task in a Connector function. The SDK provides
 an out-of-the-box solution for input validation.
 A default implementation of the SDK's core validation API is provided in a separate,
 optional artifact `connector-validation`. If you want to use validation in your
@@ -813,7 +813,7 @@ public class Authentication {
 }
 ```
 
-In the input model above, the Runtime will attempt to find and replace secrets in all String fields 
+In the input model above, the Runtime will attempt to find and replace secrets in all String fields
 of the `Authentication` and `MyConnectorRequest` classes.
 
 ## Testing

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/0100-to-0110.md
@@ -24,8 +24,9 @@ We are moving away from a mandatory @Secret annotation.
 Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
 
 To migrate your Connector implementations, please do the following:
+
 1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
 2. If you used the `InboundConnectorContext::getPropertiesAsType` method in you inbound Connector executables, replace it with `InboundConnectorContext::bindProperties`.
 3. Remove calls to `OutboundConnectorContext::replaceSecrets` and `InboundConnectorContext::replaceSecrets` methods. The secrets are now replaced automatically.
 4. Remove calls to `OutboundConnectorContext::validate` and `InboundConnectorContext::validate` methods. The validation is now performed automatically.
-4. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.
+5. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/0100-to-0110.md
@@ -10,23 +10,22 @@ import TabItem from "@theme/TabItem";
 <span class="badge badge--beginner">Beginner</span>
 
 :::note
-Please migrate directly to the version 0.11.2 of the SDK. It contains a fix for several issues in the 0.11.0 release.
+Migrate directly to version 0.11.2 of the SDK. This contains a fix for several issues in the 0.11.0 release.
 :::
 
-This SDK release is not backwards-compatible.
-We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
+This SDK release is not backwards-compatible. We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
 
-In this SDK version, we changed the OutboundConnectorContext and InboundConnectorContext interfaces significantly.
-You can no longer use the `getVariablesAsType` or `getPropertiesAsType` methods in outbound and inbound connectors, respectively.
-Use the new bindVariables method instead: it takes care of secret replacement, payload validation and deserialization automatically.
+In this SDK version, we changed the `OutboundConnectorContext` and `InboundConnectorContext` interfaces significantly.
+You can no longer use the `getVariablesAsType` or `getPropertiesAsType` methods in outbound and inbound Connectors, respectively.
 
-We are moving away from a mandatory @Secret annotation.
-Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+Use the new `bindVariables` method instead, as this takes care of secret replacement, payload validation, and deserialization automatically.
 
-To migrate your Connector implementations, please do the following:
+We are moving away from a mandatory `@Secret` annotation. From this release onwards, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+
+To migrate your Connector implementations, complete the following:
 
 1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
 2. If you used the `InboundConnectorContext::getPropertiesAsType` method in you inbound Connector executables, replace it with `InboundConnectorContext::bindProperties`.
 3. Remove calls to `OutboundConnectorContext::replaceSecrets` and `InboundConnectorContext::replaceSecrets` methods. The secrets are now replaced automatically.
 4. Remove calls to `OutboundConnectorContext::validate` and `InboundConnectorContext::validate` methods. The validation is now performed automatically.
-5. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.
+5. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it as it has no effect.

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/0100-to-0110.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/0100-to-0110.md
@@ -1,0 +1,31 @@
+---
+id: 0100-to-0110
+title: Update 0.10 to 0.11
+description: "Review which adjustments must be made to migrate from Connector SDK 0.10.x to 0.11.0."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--beginner">Beginner</span>
+
+:::note
+Please migrate directly to the version 0.11.2 of the SDK. It contains a fix for several issues in the 0.11.0 release.
+:::
+
+This SDK release is not backwards-compatible.
+We are moving towards a stable Connectors release and continue to improve the experience of developing custom connectors.
+
+In this SDK version, we changed the OutboundConnectorContext and InboundConnectorContext interfaces significantly.
+You can no longer use the `getVariablesAsType` or `getPropertiesAsType` methods in outbound and inbound connectors, respectively.
+Use the new bindVariables method instead: it takes care of secret replacement, payload validation and deserialization automatically.
+
+We are moving away from a mandatory @Secret annotation.
+Starting from this release, secrets are automatically replaced in all input variables/properties without the need to explicitly declare an annotation.
+
+To migrate your Connector implementations, please do the following:
+1. If you used the `OutboundConnectorContext::getVariablesAsType` method in you outbound Connector functions, replace it with `OutboundConnectorContext::bindVariables`.
+2. If you used the `InboundConnectorContext::getPropertiesAsType` method in you inbound Connector executables, replace it with `InboundConnectorContext::bindProperties`.
+3. Remove calls to `OutboundConnectorContext::replaceSecrets` and `InboundConnectorContext::replaceSecrets` methods. The secrets are now replaced automatically.
+4. Remove calls to `OutboundConnectorContext::validate` and `InboundConnectorContext::validate` methods. The validation is now performed automatically.
+4. If you used the `@Secret` annotation in your Connector implementations, you can safely remove it, as it has no effect.

--- a/versioned_docs/version-8.2/guides/update-guide/connectors/introduction.md
+++ b/versioned_docs/version-8.2/guides/update-guide/connectors/introduction.md
@@ -9,6 +9,10 @@ Connector runtimes to a newer version of the
 
 There is a dedicated update guide for each version:
 
+### [Connector SDK 0.10.x to 0.11](../0100-to-0110)
+
+Update from 0.10.x to 0.11.2
+
 ### [Connector SDK 0.9 to 0.10](../090-to-0100)
 
 Update from 0.9.x to 0.10.0

--- a/versioned_sidebars/version-8.0-sidebars.json
+++ b/versioned_sidebars/version-8.0-sidebars.json
@@ -42,7 +42,8 @@
             "guides/update-guide/connectors/060-to-070",
             "guides/update-guide/connectors/070-to-080",
             "guides/update-guide/connectors/080-to-090",
-            "guides/update-guide/connectors/090-to-0100"
+            "guides/update-guide/connectors/090-to-0100",
+            "guides/update-guide/connectors/0100-to-0110"
           ]
         }
       ]

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -43,7 +43,8 @@
             "guides/update-guide/connectors/060-to-070",
             "guides/update-guide/connectors/070-to-080",
             "guides/update-guide/connectors/080-to-090",
-            "guides/update-guide/connectors/090-to-0100"
+            "guides/update-guide/connectors/090-to-0100",
+            "guides/update-guide/connectors/0100-to-0110"
           ]
         }
       ]

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -44,7 +44,8 @@
             "guides/update-guide/connectors/060-to-070",
             "guides/update-guide/connectors/070-to-080",
             "guides/update-guide/connectors/080-to-090",
-            "guides/update-guide/connectors/090-to-0100"
+            "guides/update-guide/connectors/090-to-0100",
+            "guides/update-guide/connectors/0100-to-0110"
           ]
         },
         {


### PR DESCRIPTION
## Description

This PR updates the Connectors docs to reflect some major changes in the Connector SDK 0.11 release.
What's inside
- Update guide for migrating to SDK 0.11
- Adjustments for code examples of custom connectors

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
