### PR TITLE
docs(self-managed): add zeebe secret extraction

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -65,6 +65,7 @@ export TASKLIST_SECRET=$(kubectl get secret "<RELEASE_NAME>-tasklist-identity-se
 export OPTIMIZE_SECRET=$(kubectl get secret "<RELEASE_NAME>-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
 export OPERATE_SECRET=$(kubectl get secret "<RELEASE_NAME>-operate-identity-secret" -o jsonpath="{.data.operate-secret}" | base64 --decode)
 export CONNECTORS_SECRET=$(kubectl get secret "<RELEASE_NAME>-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
+export ZEEBE_SECRET=$(kubectl get secret "<RELEASE_NAME>-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
 export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
 export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
 export POSTGRESQL_SECRET=$(kubectl get secret "<RELEASE_NAME>-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
@@ -78,6 +79,7 @@ helm upgrade <RELEASE_NAME> charts/camunda-platform/ \
   --set global.identity.auth.optimize.existingSecret=$OPTIMIZE_SECRET \
   --set global.identity.auth.operate.existingSecret=$OPERATE_SECRET \
   --set global.identity.auth.connectors.existingSecret=$CONNECTORS_SECRET \
+  --set global.identity.auth.zeebe.existingSecret=$ZEEBE_SECRET \
   --set identity.keycloak.auth.adminPassword=$KEYCLOAK_ADMIN_SECRET \
   --set identity.keycloak.auth.managementPassword=$KEYCLOAK_MANAGEMENT_SECRET \
   --set identity.keycloak.postgresql.auth.password=$POSTGRESQL_SECRET

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -66,6 +66,7 @@ export OPTIMIZE_SECRET=$(kubectl get secret "<RELEASE_NAME>-optimize-identity-se
 export OPERATE_SECRET=$(kubectl get secret "<RELEASE_NAME>-operate-identity-secret" -o jsonpath="{.data.operate-secret}" | base64 --decode)
 export CONNECTORS_SECRET=$(kubectl get secret "<RELEASE_NAME>-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
 export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
+export ZEEBE_SECRET=$(kubectl get secret "<RELEASE_NAME>-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
 export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret "<RELEASE_NAME>-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
 export POSTGRESQL_SECRET=$(kubectl get secret "<RELEASE_NAME>-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
 ```
@@ -78,6 +79,7 @@ helm upgrade <RELEASE_NAME> charts/camunda-platform/ \
   --set global.identity.auth.optimize.existingSecret=$OPTIMIZE_SECRET \
   --set global.identity.auth.operate.existingSecret=$OPERATE_SECRET \
   --set global.identity.auth.connectors.existingSecret=$CONNECTORS_SECRET \
+  --set global.identity.auth.zeebe.existingSecret=$ZEEBE_SECRET \
   --set identity.keycloak.auth.adminPassword=$KEYCLOAK_ADMIN_SECRET \
   --set identity.keycloak.auth.managementPassword=$KEYCLOAK_MANAGEMENT_SECRET \
   --set identity.keycloak.postgresql.auth.password=$POSTGRESQL_SECRET


### PR DESCRIPTION
Related to: #2291

## Description

Add Zeebe secret extraction since now it's authenticated by default.

## When should this change go live?

Any time.

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

- [x] I have added changes to the relevant `/versioned_docs` directory.
- [x] I have added changes to the main `/docs` directory (aka `/next/`).
- [x] My changes do not require an Engineering review.
- [x] My changes do not require a technical writer review.
