### PR TITLE
add assets to ignorePatterns

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -245,7 +245,7 @@ module.exports = {
           changefreq: "weekly",
           priority: 0.5,
           ignorePatterns: [
-            "/assets/**",
+            "/docs/**/assets/**",
             "/docs/**/tags/**",
             "/docs/next/**",
             "/docs/1.1/**",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -245,6 +245,7 @@ module.exports = {
           changefreq: "weekly",
           priority: 0.5,
           ignorePatterns: [
+            "/assets/**",
             "/docs/**/tags/**",
             "/docs/next/**",
             "/docs/1.1/**",


### PR DESCRIPTION
## Description

Closes #2320 and #2288. 

Unfortunately, the sitemap does not generate on an `npm run start`. So you need to do a `build` and `serve`.

<img width="1791" alt="image" src="https://github.com/camunda/camunda-platform-docs/assets/1051363/8aadcdce-cc53-4fbf-b36d-26e8d75b715c">

Screenshot shows no returns for "assets".

## When should this change go live?

I marked this as a bug but with no urgency because I don't think it's hurting anyone but looks unpolished.

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
