### PR TITLE
docs(zeebe): document health probe changes

### DIFF
--- a/docs/guides/update-guide/820-to-830.md
+++ b/docs/guides/update-guide/820-to-830.md
@@ -18,7 +18,7 @@ Resources in the **Deployment:CREATED** event are no longer available. Custom Ex
 
 There were some changes to the monitoring endpoints of Zeebe, both for the gateway and the broker. All of these were existing redirects to the new endpoints, so their format is left unchanged; only the redirects have been removed.
 
-You may have to change your Kubernetes health probes or metrics scraping endpoints to accomodate the new ones. Note that if you're deploying with the Helm charts, or are using Camunda Cloud, you do not need to do anything.
+You may have to change your Kubernetes health probes or metrics scraping endpoints to accomodate the new ones. Note that if you're deploying with the Helm charts, or are using Camunda Platform 8 SaaS, you do not need to do anything.
 
 #### Broker
 

--- a/docs/guides/update-guide/820-to-830.md
+++ b/docs/guides/update-guide/820-to-830.md
@@ -13,3 +13,20 @@ The following sections explain which adjustments must be made to migrate from Ca
 ### Resources no longer available in the Deployment:CREATED event
 
 Resources in the **Deployment:CREATED** event are no longer available. Custom Exporters using the resources from this event must be modified to get them from the **Process:CREATED** event for BPMN models and the **DecisionRequirements:CREATED** event for DMN models.
+
+### Change in monitoring endpoints
+
+There were some changes to the monitoring endpoints of Zeebe, both for the gateway and the broker. All of these were existing redirects to the new endpoints, so their format is left unchanged; only the redirects have been removed.
+
+You may have to change your Kubernetes health probes or metrics scraping endpoints to accomodate the new ones. Note that if you're deploying with the Helm charts, or are using Camunda Cloud, you do not need to do anything.
+
+#### Broker
+
+- The `/metrics` endpoint is now `/actuator/prometheus`
+
+#### Gateway
+
+- The `/metrics` endpoint is now `/actuator/prometheus`
+- The `/health` endpoint is now `/actuator/health`
+- The `/startup` endpoint is now `/actuator/health/startup`
+- The `/live` endpoint is now `/actuator/health/liveness`

--- a/docs/self-managed/zeebe-deployment/configuration/gateway-health-probes.md
+++ b/docs/self-managed/zeebe-deployment/configuration/gateway-health-probes.md
@@ -4,7 +4,7 @@ title: "Gateway health probes"
 description: "This section outlines health status, probes, and responsiveness."
 ---
 
-The health status for a standalone gateway is available at `{zeebe-gateway}:8080/actuator/health`.
+The health status for a standalone gateway is available at `{zeebe-gateway}:9600/actuator/health`.
 
 The following health indicators are enabled by default:
 
@@ -19,13 +19,13 @@ Health indicators are set to sensible defaults. For specific use cases, it might
 
 ## Startup probe
 
-The started probe is available at `{zeebe-gateway}:8080/actuator/health/startup`.
+The started probe is available at `{zeebe-gateway}:9600/actuator/health/startup`.
 
 In the default configuration this is merely an alias for the **Gateway Started** health indicator. Other configurations are possible (see below).
 
 ## Liveness probe
 
-The liveness probe is available at `{zeebe-gateway}:8080/actuator/health/liveness`.
+The liveness probe is available at `{zeebe-gateway}:9600/actuator/health/liveness`.
 
 It is based on the health indicators mentioned above.
 

--- a/docs/self-managed/zeebe-deployment/operations/health.md
+++ b/docs/self-managed/zeebe-deployment/operations/health.md
@@ -64,7 +64,7 @@ When a broker becomes unhealthy, it's recommended to check the logs to see what 
 
 Zeebe gateway exposes three HTTP endpoints to query its health status:
 
-- Health status - `http://{zeebe-gateway}:9600/health`
+- Health status - `http://{zeebe-gateway}:9600/actuator/health`
 - Startup probe - `http://{zeebe-gateway}:9600/actuator/health/startup`
 - Liveness probe - `http://{zeebe-gateway}:9600/actuator/health/liveness`
 


### PR DESCRIPTION
## Description

This PR documents the upcoming health probe endpoint changes in Zeebe, starting with 8.3.0. The changes are mostly dropping old routes which were redirects, and using the proper endpoints directly.

## When should this change go live?

At least 8.3, but can be earlier since it's good to have for the next alpha next week.

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
