### PR TITLE
docs(self-managed): update openshift supported versions

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -13,6 +13,9 @@ We test against the following OpenShift versions and guarantee compatibility wit
 | OpenShift version | Supported          |
 | ----------------- | ------------------ |
 | 4.10.x            | :white_check_mark: |
+| 4.11.x            | :white_check_mark: |
+| 4.12.x            | :white_check_mark: |
+| 4.13.x            | :white_check_mark: |
 
 Any version not explicitly marked in the table above is not tested, and we cannot guarantee compatibility.
 

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -13,6 +13,9 @@ We test against the following OpenShift versions and guarantee compatibility wit
 | OpenShift version | Supported          |
 | ----------------- | ------------------ |
 | 4.10.x            | :white_check_mark: |
+| 4.11.x            | :white_check_mark: |
+| 4.12.x            | :white_check_mark: |
+| 4.13.x            | :white_check_mark: |
 
 Any version not explicitly marked in the table above is not tested, and we cannot guarantee compatibility.
 


### PR DESCRIPTION
## Description

Update OpenShift-supported versions (mark v4.11, v4.12, and v4.13 as supported).

## When should this change go live?

Any time.

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory.
- [x] I have added changes to the main `/docs` directory (aka `/next/`).
- [x] My changes do not require an Engineering review.
- [x] My changes do not require a technical writer review.
