### PR TITLE
feat(archive): automate update of docusaurus.config.js

### DIFF
--- a/hacks/isolateVersion/7-updateDocusaurusConfig.sh
+++ b/hacks/isolateVersion/7-updateDocusaurusConfig.sh
@@ -1,0 +1,65 @@
+notify "Updating docusaurus.config.js..."
+
+# Remove unused versionedLinks dependency
+sed -i '' '/const versionedLinks/d' docusaurus.config.js
+
+# Update `url` to include `unsupported`
+sed -i '' -e "s/docs.camunda.io/unsupported.docs.camunda.io/" docusaurus.config.js
+
+# Update `baseUrl` to specify isolated version
+sed -i '' -e "s/baseUrl: \"\\/\"/baseUrl: \"\/$ARCHIVED_VERSION\/\"/" docusaurus.config.js
+
+# Remove optimize docs plugin.
+#   1. Find the block that starts with the plugin declaration, and the closing braces afterward, and delete it.
+sed -i '' '/^      "@docusaurus\/plugin-content-docs"/,/^      },/d' docusaurus.config.js
+#   2. Format the config file, to collapse the empty brackets left behind (e.g. `  [\n  ]` -> `  []`)
+npx prettier --write docusaurus.config.js
+#   3. Remove the empty array
+sed -i '' '/^    \[\],/d' docusaurus.config.js
+
+# Add `announcementBar` to `themeConfig`
+#   Find the line containing `themeConfig` and append the new settings to it.
+sed -i '' "/themeConfig/a\\
+    announcementBar: {\\
+      id: \"camunda8\",\\
+      content:\\
+        '🚨 This version of Camunda Platform 8 is no longer actively maintained. For up-to-date documentation, see <b><a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://docs.camunda.io\">the latest version</a></b>.',\\
+      backgroundColor: \"#FFC600\",\\
+      textColor: \"#434343\",\\
+      isCloseable: false,\\
+    },\\
+" docusaurus.config.js
+
+# Convert version dropdown in top nav to static version number
+sed -i '' "s/docsVersionDropdown/docsVersion/" docusaurus.config.js
+
+# Remove unused version dropdown configuration
+#   Find the block starting with dropdownItemsAfter, and ending with the correctly-indented closing bracket, and delete the block.
+sed -i '' '/dropdownItemsAfter/,/          ],/d' docusaurus.config.js
+
+# Replace the `docs` block with one that limits to only the isolated version
+sed -i '' "/^        docs: {/,/^        },/c\\
+        docs: {\\
+          lastVersion: \"$ARCHIVED_VERSION\",\\
+          includeCurrentVersion: false,\\
+          versions: {\\
+            \"$ARCHIVED_VERSION\": {\\
+              label: \"$ARCHIVED_VERSION\",\\
+              path: \"/\",\\
+              noIndex: true,\\
+              banner: \"unmaintained\",\\
+            },\\
+          },\\
+        },\\
+" docusaurus.config.js
+
+# Replace the `sitemap`` block with one that only specifies a blanket ignorePattern.
+sed -i '' '/^        sitemap: {/,/^        },/c\
+        sitemap: {\
+          \/\/ exclude everything from sitemap\
+          ignorePatterns: [\"**\"],\
+        },\
+' docusaurus.config.js
+
+# git add docusaurus.config.js
+# git commit -m "archiving: update docusaurus config"

--- a/hacks/isolateVersion/7-updateDocusaurusConfig.sh
+++ b/hacks/isolateVersion/7-updateDocusaurusConfig.sh
@@ -4,10 +4,10 @@ notify "Updating docusaurus.config.js..."
 sed -i '' '/const versionedLinks/d' docusaurus.config.js
 
 # Update `url` to include `unsupported`
-sed -i '' -e "s/docs.camunda.io/unsupported.docs.camunda.io/" docusaurus.config.js
+sed -i '' "s/docs.camunda.io/unsupported.docs.camunda.io/" docusaurus.config.js
 
 # Update `baseUrl` to specify isolated version
-sed -i '' -e "s/baseUrl: \"\\/\"/baseUrl: \"\/$ARCHIVED_VERSION\/\"/" docusaurus.config.js
+sed -i '' "s/baseUrl: \"\\/\"/baseUrl: \"\/$ARCHIVED_VERSION\/\"/" docusaurus.config.js
 
 # Remove optimize docs plugin.
 #   1. Find the block that starts with the plugin declaration, and the closing braces afterward, and delete it.

--- a/hacks/isolateVersion/7-updateDocusaurusConfig.sh
+++ b/hacks/isolateVersion/7-updateDocusaurusConfig.sh
@@ -61,5 +61,5 @@ sed -i '' '/^        sitemap: {/,/^        },/c\
         },\
 ' docusaurus.config.js
 
-# git add docusaurus.config.js
-# git commit -m "archiving: update docusaurus config"
+git add docusaurus.config.js
+git commit -m "archiving: update docusaurus config"

--- a/hacks/isolateVersion/allSteps.sh
+++ b/hacks/isolateVersion/allSteps.sh
@@ -54,9 +54,12 @@ if [[ "$script_index" == 6 || -z "$script_index" ]]; then
   source $script_directory/6-updateCIWorkflows.sh
 fi
 
+if [[ "$script_index" == 7 || -z "$script_index" ]]; then
+  source $script_directory/7-updateDocusaurusConfig.sh
+fi
+
 notify "Automated steps are complete! For ease of review, consider PR'ing the deletion commits separate from the rest of the changes."
 notify "Manual steps that remain: 
-7. Update the docusaurus.config.js
-8. Fix htaccess rules (this might always be manual)
-9. Fix links (this will always be manual)
+8. Fix htaccess rules
+9. Fix links
 "


### PR DESCRIPTION
## Description

Part of #1173.

This PR automates the updates of docusaurus.config.js during a version archival. 

See the changes in #2421, specifically within the `docusaurus.config.js` file, for an example of the changes this step generates.

## Alternatives considered

The file that's being edited is a javascript file, though the large majority of the contents are a single JSON object. I considered two approaches other than the `sed` commands in this PR: 

1. Use [jq](https://jqlang.github.io/jq/) to edit the JSON directly, since it's a tool designed for parsing/editing JSON. The issue here was that the file is _JavaScript_, not JSON, so jq can't parse it. I also couldn't _convert it_ from JavaScript to JSON, because (a) I think docusaurus only supports JavaScript for the config, probably because (b) there are run-time `require` statements in the object.
2. Renaming the existing `docusaurus.config.js` to something like `docusaurus.config.original.js`, creating a second `docusaurus.config.overrides.js` which would contain only properties that would be overridden, and creating a new `docusaurus.config.js` that merged those two sources together at runtime. I decided against this because it seemed like it wouldn't be significantly more maintainable than these `sed` commands, but would probably present tricky edge cases which would make it difficult to build correctly. (Example: some properties need to be replaced, some need to be deleted, some need only one or two child properties changed.)

In the end I chose the `sed` commands and tried to simplify and document them as much as possible, for the inevitable future where something doesn't work and we are pulling our hair out trying to figure out why.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
