### PR TITLE
archive(1.1) fix: update icon URLs based on virtual directory

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -106,7 +106,7 @@ module.exports = {
           title: "Community",
           items: [
             {
-              html: `<a href="https://camunda.com/slack" target="_blank" rel="noreferrer noopener"><img src= "/img/Slack-mark-white-RGB.png" alt="Camunda on Slack" class="footer-logos" /></a> <a href="https://twitter.com/camunda" target="_blank" rel="noreferrer noopener"><img src= "/img/twitter.svg" alt="Camunda on Twitter" class="footer-logos" /></a> <a href="https://github.com/camunda" target="_blank" rel="noreferrer noopener"><img src= "/img/github-mark-white.svg" alt="Camunda on GitHub" class="footer-logos" /></a>`,
+              html: `<a href="https://camunda.com/slack" target="_blank" rel="noreferrer noopener"><img src="/1.1/img/Slack-mark-white-RGB.png" alt="Camunda on Slack" class="footer-logos" /></a> <a href="https://twitter.com/camunda" target="_blank" rel="noreferrer noopener"><img src="/1.1/img/twitter.svg" alt="Camunda on Twitter" class="footer-logos" /></a> <a href="https://github.com/camunda" target="_blank" rel="noreferrer noopener"><img src="/1.1/img/github-mark-white.svg" alt="Camunda on GitHub" class="footer-logos" /></a>`,
             },
             {
               label: "Forum",


### PR DESCRIPTION
Note that this targets the `unsupported/1.1` branch, and will not make it into `main`.

## Description

Part of #2186.

Fixes the footer social icons in the unsupported/1.1 site. 

The path to them is incorrect in these isolated sites, because they sit in a "virtual directory" named according to their version. So this one, for example, lives at `unsupported.docs.camunda.io/1.1/`. The footer icons are in the _root_ in the main site, but here the path needs to be adjusted based on the `/1.1/`. 

I'll update my automation changes from #2422 in a separate PR, so that I don't miss this on the next version archival.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
