### PR TITLE
fix(archive): update footer social icons when archiving a version

### DIFF
--- a/hacks/isolateVersion/7-updateDocusaurusConfig.sh
+++ b/hacks/isolateVersion/7-updateDocusaurusConfig.sh
@@ -9,6 +9,9 @@ sed -i '' "s/docs.camunda.io/unsupported.docs.camunda.io/" docusaurus.config.js
 # Update `baseUrl` to specify isolated version
 sed -i '' "s/baseUrl: \"\\/\"/baseUrl: \"\/$ARCHIVED_VERSION\/\"/" docusaurus.config.js
 
+# Update footer social icons based on the new baseUrl
+sed -i '' "s/src= \"\/img\//src=\"\/$ARCHIVED_VERSION\/img\//g" docusaurus.config.js
+
 # Remove optimize docs plugin.
 #   1. Find the block that starts with the plugin declaration, and the closing braces afterward, and delete it.
 sed -i '' '/^      "@docusaurus\/plugin-content-docs"/,/^      },/d' docusaurus.config.js


### PR DESCRIPTION
## Description

In #2428, I corrected the footer social icons for the unsupported/1.1 site, based on the new `1.1/` base path. 

This PR adds this correction to the automated updates of the docusaurus.config.js, so that we don't miss it the next time we're archiving a version.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
