### PR TITLE
feat(docs): update Algolia configuration information

### DIFF
--- a/howtos/configuration.md
+++ b/howtos/configuration.md
@@ -10,9 +10,26 @@ The documentation can be customized by setting parameters in [docusaurus.config.
 
 ## Search by Algolia
 
-- API-Key and Index name is configured in `./docusaurus.config.js`.
+Internal search is handled by an integration with Algolia DocSearch.
 
-[Algolia DocSearch](https://docsearch.algolia.com/) configuration is **NOT** a part of this repository. Config can be found on a dedicated [Docsearch Configurations](https://github.com/algolia/docsearch-configs) repo owned by Algolia but maintained by the individual projects. You must prove you are associated with the project to modify the configuration in the [Camunda config](https://github.com/algolia/docsearch-configs/blob/master/configs/camunda.json).
+### Configuration
+
+Our Algolia API key, app ID, and index name are configured in `./docusaurus.config.js`.
+
+Configuration of Algolia's index and crawler can be edited at https://crawler.algolia.com/.
+
+Currently, the only unique change to our configuration is that we specify multiple `pathsToMatch`, to accommodate our multiple docs instances:
+
+```
+      pathsToMatch: [
+        "https://docs.camunda.io/docs/**",
+        "https://docs.camunda.io/optimize/**",
+      ],
+```
+
+### Troubleshooting
+
+Algolia's index of our documentation can be explored directly at https://dashboard.algolia.com/.
 
 If search experience degrades, check if the Camunda config may need to be updated and submit a PR.
 

--- a/howtos/configuration.md
+++ b/howtos/configuration.md
@@ -10,13 +10,13 @@ The documentation can be customized by setting parameters in [docusaurus.config.
 
 ## Search by Algolia
 
-Internal search is handled by an integration with Algolia DocSearch.
+Internal search is handled by an integration with [Algolia DocSearch](https://docsearch.algolia.com/).
 
 ### Configuration
 
 Our Algolia API key, app ID, and index name are configured in `./docusaurus.config.js`.
 
-Configuration of Algolia's index and crawler can be edited at https://crawler.algolia.com/.
+Configuration of Algolia's index and crawler can be edited with the [Algolia Crawler](https://crawler.algolia.com/).
 
 Currently, the only unique change to our configuration is that we specify multiple `pathsToMatch` to accommodate our multiple docs instances:
 
@@ -29,7 +29,7 @@ Currently, the only unique change to our configuration is that we specify multip
 
 ### Troubleshooting
 
-Algolia's index of our documentation can be explored directly at https://dashboard.algolia.com/.
+Take a closer look at [Algolia's index of our documentation](https://dashboard.algolia.com/).
 
 If search experience degrades, check if the Camunda config may need to be updated and submit a PR.
 

--- a/howtos/configuration.md
+++ b/howtos/configuration.md
@@ -18,7 +18,7 @@ Our Algolia API key, app ID, and index name are configured in `./docusaurus.conf
 
 Configuration of Algolia's index and crawler can be edited at https://crawler.algolia.com/.
 
-Currently, the only unique change to our configuration is that we specify multiple `pathsToMatch`, to accommodate our multiple docs instances:
+Currently, the only unique change to our configuration is that we specify multiple `pathsToMatch` to accommodate our multiple docs instances:
 
 ```
       pathsToMatch: [


### PR DESCRIPTION
## Description

Addresses feedback from #2438.

Updates our documentation on Algolia DocSearch integration.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
