### PR TITLE
docs(alerts): alerts are part of collection not report

### DIFF
--- a/docs/guides/improve-processes-with-optimize.md
+++ b/docs/guides/improve-processes-with-optimize.md
@@ -81,12 +81,12 @@ To create a custom report based on a key performance indicator (KPI) you’d lik
 
 You don’t have to log in or view reports and dashboards to be alerted that something may need correction or further analysis in your process.
 
-For this purpose, you can create new alerts within your reports. These alerts watch reports for you among collections, and email you an alert if a set outlier occurs in your process flow.
+For this purpose, you can create new alerts for reports within your collections. These alerts watch reports for you among collections, and email you an alert if a set outlier occurs in your process flow.
 
 To create an alert, take the following steps:
 
 1. Create a report with a number visualization inside a collection for a KPI you want to track.
-2. Inside your report, select the **Alerts** tab.
+2. Inside your collection, select the **Alerts** tab.
 3. Select the type of alert you would like to receive. For example, you can receive an email notification when the backlog on your bottleneck becomes too high.
 
 As you’re notified, you can begin to examine if the process is broken and if additional teams need to be notified.

--- a/versioned_docs/version-1.3/guides/improve-processes-with-optimize.md
+++ b/versioned_docs/version-1.3/guides/improve-processes-with-optimize.md
@@ -79,12 +79,12 @@ To create a custom report based on a key performance indicator (KPI) you’d lik
 
 You don’t have to log in or view reports and dashboards to be alerted that something may need correction or further analysis in your process.
 
-For this purpose, you can create new alerts within your reports. These alerts watch reports for you among collections, and email you an alert if a set outlier occurs in your process flow.
+For this purpose, you can create new alerts for reports within your collections. These alerts watch reports for you among collections, and email you an alert if a set outlier occurs in your process flow.
 
 To create an alert, take the following steps:
 
 1. Create a report with a number visualization inside a collection for a KPI you want to track.
-2. Inside your report, select the **Alerts** tab.
+2. Inside your collection, select the **Alerts** tab.
 3. Select the type of alert you would like to receive. For example, you can receive an email notification when the backlog on your bottleneck becomes too high.
 
 As you’re notified, you can begin to examine if the process is broken and if additional teams need to be notified.

--- a/versioned_docs/version-8.0/guides/improve-processes-with-optimize.md
+++ b/versioned_docs/version-8.0/guides/improve-processes-with-optimize.md
@@ -81,12 +81,12 @@ To create a custom report based on a key performance indicator (KPI) you’d lik
 
 You don’t have to log in or view reports and dashboards to be alerted that something may need correction or further analysis in your process.
 
-For this purpose, you can create new alerts within your reports. These alerts watch reports for you among collections, and email you an alert if a set outlier occurs in your process flow.
+For this purpose, you can create new alerts for reports within your collections. These alerts watch reports for you among collections, and email you an alert if a set outlier occurs in your process flow.
 
 To create an alert, take the following steps:
 
 1. Create a report with a number visualization inside a collection for a KPI you want to track.
-2. Inside your report, select the **Alerts** tab.
+2. Inside your collection, select the **Alerts** tab.
 3. Select the type of alert you would like to receive. For example, you can receive an email notification when the backlog on your bottleneck becomes too high.
 
 As you’re notified, you can begin to examine if the process is broken and if additional teams need to be notified.

--- a/versioned_docs/version-8.1/guides/improve-processes-with-optimize.md
+++ b/versioned_docs/version-8.1/guides/improve-processes-with-optimize.md
@@ -81,12 +81,12 @@ To create a custom report based on a key performance indicator (KPI) you’d lik
 
 You don’t have to log in or view reports and dashboards to be alerted that something may need correction or further analysis in your process.
 
-For this purpose, you can create new alerts within your reports. These alerts watch reports for you among collections, and email you an alert if a set outlier occurs in your process flow.
+For this purpose, you can create new alerts for reports within your collections. These alerts watch reports for you among collections, and email you an alert if a set outlier occurs in your process flow.
 
 To create an alert, take the following steps:
 
 1. Create a report with a number visualization inside a collection for a KPI you want to track.
-2. Inside your report, select the **Alerts** tab.
+2. Inside your collection, select the **Alerts** tab.
 3. Select the type of alert you would like to receive. For example, you can receive an email notification when the backlog on your bottleneck becomes too high.
 
 As you’re notified, you can begin to examine if the process is broken and if additional teams need to be notified.

--- a/versioned_docs/version-8.2/guides/improve-processes-with-optimize.md
+++ b/versioned_docs/version-8.2/guides/improve-processes-with-optimize.md
@@ -81,12 +81,12 @@ To create a custom report based on a key performance indicator (KPI) you’d lik
 
 You don’t have to log in or view reports and dashboards to be alerted that something may need correction or further analysis in your process.
 
-For this purpose, you can create new alerts within your reports. These alerts watch reports for you among collections, and email you an alert if a set outlier occurs in your process flow.
+For this purpose, you can create new alerts for reports within your collections. These alerts watch reports for you among collections, and email you an alert if a set outlier occurs in your process flow.
 
 To create an alert, take the following steps:
 
 1. Create a report with a number visualization inside a collection for a KPI you want to track.
-2. Inside your report, select the **Alerts** tab.
+2. Inside your collection, select the **Alerts** tab.
 3. Select the type of alert you would like to receive. For example, you can receive an email notification when the backlog on your bottleneck becomes too high.
 
 As you’re notified, you can begin to examine if the process is broken and if additional teams need to be notified.


### PR DESCRIPTION
related to OPT-7150

## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
