### PR TITLE
chore: list child pages as carts

### DIFF
--- a/docs/components/modeler/reference/modeling-guidance/index.md
+++ b/docs/components/modeler/reference/modeling-guidance/index.md
@@ -5,13 +5,11 @@ sidebar_label: About
 description: Learn how to resolve common modeling issues, using assistance baked into Camunda's modeling tools.
 ---
 
+import DocCardList from '@theme/DocCardList';
+import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
+
 Modeler checks your BPMN diagram for problems affecting deployment and execution, and provides guidance on how to fix them. This page lists all the rules used to check your diagram and explains how to fix the problems.
 
 ## Rules
 
-- [Called element](/docs/components/modeler/reference/modeling-guidance/rules/called-element.md)
-- [Element type](/docs/components/modeler/reference/modeling-guidance/rules/element-type.md)
-- [Error reference](/docs/components/modeler/reference/modeling-guidance/rules/error-reference.md)
-- [Escalation reference](/docs/components/modeler/reference/modeling-guidance/rules/escalation-reference.md)
-- [FEEL](/docs/components/modeler/reference/modeling-guidance/rules/feel.md)
-- [Message reference](/docs/components/modeler/reference/modeling-guidance/rules/message-reference.md)
+<DocCardList items={useCurrentSidebarCategory().items}/>


### PR DESCRIPTION
Allows us to add new pages without the need to update the parent.

## Description

Uses DocCardList to link all modeling guidance sub-pages as suggested by @pepopowitz in https://github.com/camunda/camunda-platform-docs/pull/2454#issuecomment-1682670842.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
