### PR TITLE
feat(archival): take into account Optimize when deleting other versions

### DIFF
--- a/hacks/isolateVersion/1-deleteOtherVersions.sh
+++ b/hacks/isolateVersion/1-deleteOtherVersions.sh
@@ -5,7 +5,6 @@ function delete_version() {
 
   rm -rf $folder
   rm $sidebars
-  # This is all of the possible things that could have been deleted.
   git add $folder $sidebars
   git commit -m "archiving($ARCHIVED_VERSION): delete version $version_name"  
 }

--- a/hacks/isolateVersion/1-deleteOtherVersions.sh
+++ b/hacks/isolateVersion/1-deleteOtherVersions.sh
@@ -1,30 +1,13 @@
 function delete_version() {
-  notify "Deleting version $1..."
-  folder=versioned_docs/$VERSION
-  sidebars=versioned_sidebars/$VERSION-sidebars.json
+  local version_name=${1}
+  local folder=${2}
+  local sidebars=${3}
+
   rm -rf $folder
   rm $sidebars
-  git add versioned_docs versioned_sidebars
-  git commit -m "archiving: delete version $VERSION"
-}
-
-function delete_next() {
-  notify "Deleting next version..."
-  folder=docs
-  sidebars=sidebars.js
-  rm -rf $folder
-  rm $sidebars
-  git add docs sidebars.js
-  git commit -m "archiving: delete version 'next'"  
-}
-
-function delete_optimize() {
-  notify "Deleting Optimize docs..."
-  rm -rf ./optimize
-  rm -rf ./optimize_versioned_docs
-  rm -rf ./optimize_versioned_sidebars
-  git add optimize optimize_versioned_docs optimize_versioned_sidebars
-  git commit -m "archiving: delete optimize docs"  
+  # This is all of the possible things that could have been deleted.
+  git add $folder $sidebars
+  git commit -m "archiving($ARCHIVED_VERSION): delete version $version_name"  
 }
 
 # list all versions; search for all that don't match the current version; continue even if there are no matches.
@@ -32,9 +15,20 @@ OTHER_VERSIONS=$(ls versioned_docs | grep -xv "version-$ARCHIVED_VERSION" || tru
 
 for VERSION in ${OTHER_VERSIONS[*]}
   do
-    delete_version $VERSION
+    delete_version "docs/$VERSION" "versioned_docs/$VERSION" "versioned_sidebars/$VERSION-sidebars.json"
   done
 
-delete_next
+# delete docs/next version
+delete_version "docs/next" "docs" "sidebars.js"
 
-delete_optimize
+# list all *optimize* versions; search for all that don't match the current version; continue even if there are no matches.
+OTHER_OPTIMIZE_VERSIONS=$(ls optimize_versioned_docs | grep -xv "version-$ARCHIVED_OPTIMIZE_VERSION" || true) 
+
+for VERSION in ${OTHER_OPTIMIZE_VERSIONS[*]}
+  do
+    delete_version "optimize/$VERSION" "optimize_versioned_docs/$VERSION" "optimize_versioned_sidebars/$VERSION-sidebars.json"
+  done
+
+# delete optimize/next version
+delete_version "optimize/next" "optimize" "optimize_sidebars.js"
+

--- a/hacks/isolateVersion/allSteps.sh
+++ b/hacks/isolateVersion/allSteps.sh
@@ -2,8 +2,8 @@
 set -e # exit at first error
 
 # Before running this script make sure these versions are correct!
-ARCHIVED_VERSION="1.0"
-# ARCHIVED_OPTIMIZE_VERSION="3.7.0"
+ARCHIVED_VERSION="1.3"
+ARCHIVED_OPTIMIZE_VERSION="3.7.0"
 
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'


### PR DESCRIPTION
## Description

Modifies the 1-deleteOtherVersions.sh script to take into account Optimize docs when deleting other versions for archival.

(And also updates the versions in allSteps.sh because it's useful to call out that both should be set from now on.)

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
