### PR TITLE
chore(docs): update documentation for Spring Boot 3 migration

### DIFF
--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -77,8 +77,8 @@ You can also use newer versions of Desktop and Web Modeler with older Zeebe vers
 | Optimize 3.7.x  | Camunda Platform 7.14.x, 7.15.x, 7.16.x    | OpenJDK 11+               | 7.8.0+, 7.9.0+, 7.10.0+, 7.11.0+, 7.12.0+, 7.13.0+, 7.14.0+, 7.15.0+, 7.16.2+ |
 | Optimize 3.8.x  | Camunda Platform 7.15.x, 7.16.x, 7.17.x    | OpenJDK 11+               | 7.10.0+, 7.11.0+, 7.12.0+, 7.13.0+, 7.14.0+, 7.15.0+, 7.16.2+, 7.17.0+        |
 | Optimize 3.9.x  | Camunda Platform 7.16.x, 7.17.x, 7.18.x    | OpenJDK 11+               | 7.13.0+, 7.14.0+, 7.15.0+, 7.16.2+, 7.17.0+                                   |
-| Optimize 3.10.x | Camunda Platform 7.17.x, 7.18.x, 7.19.x    | OpenJDK 11+               | 7.16.2+, 7.17.0+, 8.5.0+, 8.6.0+, 8.7.0+                                      |
-| Optimize 3.11.x | Camunda Platform 7.17.x, 7.18.x, 7.19.x    | OpenJDK 11+               | 8.7.0+                                                                        |
+| Optimize 3.10.x | Camunda Platform 7.17.x, 7.18.x, 7.19.x    | OpenJDK 17+               | 7.16.2+, 7.17.0+, 8.5.0+, 8.6.0+                                              |
+| Optimize 3.11.x | Camunda Platform 7.17.x, 7.18.x, 7.19.x    | OpenJDK 17+               | 8.7.0+, 8.8.0+                                                                |
 
 :::note Elasticsearch support
 [Elastic's Elasticsearch](https://www.elastic.co/elasticsearch/) is the only supported version of Elastic compatible with Optimize.

--- a/optimize/self-managed/optimize-deployment/migration-update/3.10-to-3.11.md
+++ b/optimize/self-managed/optimize-deployment/migration-update/3.10-to-3.11.md
@@ -14,23 +14,43 @@ Here you will find information about:
 - Limitations
 - Known issues
 - Changes in supported environments
-- Any unexpected behavior of Optimize (for example, due to a new feature)
+- Changes in behavior (for example, due to a new feature)
 - Changes in translation resources
 
-## Elasticsearch
+## Changes in supported environments
 
-Optimize now supports Elasticsearch `8.7`.
+### Elasticsearch
+
+Optimize now supports Elasticsearch `8.7` and `8.8`. Elasticsearch `8.5` and `8.6` are no longer supported.
 See the [supported environments]($docs$/reference/supported-environments) section for the full range of supported versions.
 
 If you need to update your Elasticsearch cluster, refer to the general [Elasticsearch update guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html). Usually, the only thing you need to do is perform a [rolling update](https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html).
 
-## Changes in the configuration
+### Java
+
+With this release, the minimum version of Java that Optimize supports is now Java 17. See the [Supported Environments]($docs$/reference/supported-environments) sections for more information on supported versions.
+
+### Plugins
+
+Optimize now runs with Spring Boot 3. As a result, some plugin interfaces have been updated accordingly. More specifically, the [Engine Rest Filter Plugin](./../plugins/engine-rest-filter-plugin.md) and the [Single-Sign-On Plugin](./../plugins/single-sign-on.md) now import jakarta dependencies. If you use these plugins, you will need to adjust your implementation accordingly.
+
+### Logging
+
+With the change to Spring Boot 3, Optimize's logging configuration format has also been updated. Please review the updated `environment-logback.xml` to make sure your configuration is valid.
+
+## Changes in behavior
+
+### Collection Role Cleanup
 
 Prior to Optimize 3.11.0, Optimize has performed collection role cleanup after syncing identities with the engine. From
 Optimize 3.11.0 onwards, this is now disabled by default. It can be reenabled by setting the
 `import.identitySync.collectionRoleCleanupEnabled` property value to `true`
 
-## API changes
+### API behaviour
+
+Before the 3.11.0 release, the Optimize API would accept requests when the URI contained a trailing slash (`/`). This is no longer the case, and requests containing a trailing slash will no longer be matched to the corresponding API path.
+
+### Raw Data Report API
 
 :::caution
 These changes require you to adjust any integrations using the data mentioned below.

--- a/optimize/self-managed/optimize-deployment/migration-update/3.9-to-3.10.md
+++ b/optimize/self-managed/optimize-deployment/migration-update/3.9-to-3.10.md
@@ -14,10 +14,37 @@ Here you will find information about:
 - Limitations
 - Known issues
 - Changes in supported environments
-- Any unexpected behavior of Optimize (for example, due to a new feature)
+- Changes in behavior (for example, due to a new feature)
 - Changes in translation resources
 
-## Changes in the configuration
+## Changes in supported environments
+
+### Elasticsearch
+
+Optimize now supports Elasticsearch `8.5` and `8.6`, but it requires at least Elasticsearch `7.16.2`.
+See the [supported environments]($docs$/reference/supported-environments) section for the full range of supported versions.
+
+If you need to update your Elasticsearch cluster, refer to the general [Elasticsearch update guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html). Usually, the only thing you need to do is perform a [rolling update](https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html).
+
+### Java
+
+From Optimize 3.10.4, the minimum version of Java that Optimize supports is now Java 17. See the [Supported Environments]($docs$/reference/supported-environments) sections for more information on supported versions.
+
+### Plugins
+
+From 3.10.4, Optimize runs with Spring Boot 3. As a result, some plugin interfaces have been updated accordingly. More specifically, the [Engine Rest Filter Plugin](./../plugins/engine-rest-filter-plugin.md) and the [Single-Sign-On Plugin](./../plugins/single-sign-on.md) now import jakarta dependencies. If you use these plugins, you will need to adjust your implementation accordingly.
+
+### Logging
+
+In 3.10.4, Optimize's logging configuration format has also been updated. Please review the updated `environment-logback.xml` to make sure your configuration is valid.
+
+## Changes in behavior
+
+### API behaviour
+
+Before the 3.10.4 release, the Optimize API would accept requests when the URI contained a trailing slash (`/`). This is no longer the case, and requests containing a trailing slash will no longer be matched to the corresponding API path.
+
+### Configuration changes
 
 In the 3.10 version of Optimize, it is no longer possible to apply custom configuration to the UI header. The following
 configuration options have therefore been removed:
@@ -25,13 +52,6 @@ configuration options have therefore been removed:
 - ui.header.textColor
 - ui.header.pathToLogoIcon
 - ui.header.backgroundColor
-
-## Elasticsearch
-
-Optimize now supports Elasticsearch `8.5` and `8.6`, but it requires at least Elasticsearch `7.16.2`.
-See the [supported environments]($docs$/reference/supported-environments) section for the full range of supported versions.
-
-If you need to update your Elasticsearch cluster, refer to the general [Elasticsearch update guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html). Usually, the only thing you need to do is perform a [rolling update](https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html).
 
 ## Changes in translation files
 

--- a/optimize/self-managed/optimize-deployment/plugins/engine-rest-filter-plugin.md
+++ b/optimize/self-managed/optimize-deployment/plugins/engine-rest-filter-plugin.md
@@ -27,7 +27,7 @@ The following example shows a filter that simply adds a custom header to every R
 package com.example.optimize.enginerestplugin;
 
 import java.io.IOException;
-import javax.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestContext;
 
 public class AddCustomTokenFilter implements EngineRestFilter {
 

--- a/optimize/self-managed/optimize-deployment/plugins/single-sign-on.md
+++ b/optimize/self-managed/optimize-deployment/plugins/single-sign-on.md
@@ -31,7 +31,7 @@ package com.example.optimize.security.authentication;
 import org.camunda.optimize.plugin.security.authentication.AuthenticationExtractor;
 import org.camunda.optimize.plugin.security.authentication.AuthenticationResult;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 public class AutomaticallySignInUserFromHeaderPlugin implements AuthenticationExtractor {
 

--- a/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/plugins/engine-rest-filter-plugin.md
+++ b/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/plugins/engine-rest-filter-plugin.md
@@ -27,7 +27,7 @@ The following example shows a filter that simply adds a custom header to every R
 package com.example.optimize.enginerestplugin;
 
 import java.io.IOException;
-import javax.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestContext;
 
 public class AddCustomTokenFilter implements EngineRestFilter {
 

--- a/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/plugins/single-sign-on.md
+++ b/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/plugins/single-sign-on.md
@@ -31,7 +31,7 @@ package com.example.optimize.security.authentication;
 import org.camunda.optimize.plugin.security.authentication.AuthenticationExtractor;
 import org.camunda.optimize.plugin.security.authentication.AuthenticationResult;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 public class AutomaticallySignInUserFromHeaderPlugin implements AuthenticationExtractor {
 

--- a/versioned_docs/version-8.2/reference/supported-environments.md
+++ b/versioned_docs/version-8.2/reference/supported-environments.md
@@ -79,7 +79,7 @@ You can also use newer versions of Desktop and Web Modeler with older Zeebe vers
 | Optimize 3.7.x  | Camunda Platform 7.14.x, 7.15.x, 7.16.x    | OpenJDK 11+               | 7.8.0+, 7.9.0+, 7.10.0+, 7.11.0+, 7.12.0+, 7.13.0+, 7.14.0+, 7.15.0+, 7.16.2+ |
 | Optimize 3.8.x  | Camunda Platform 7.15.x, 7.16.x, 7.17.x    | OpenJDK 11+               | 7.10.0+, 7.11.0+, 7.12.0+, 7.13.0+, 7.14.0+, 7.15.0+, 7.16.2+, 7.17.0+        |
 | Optimize 3.9.x  | Camunda Platform 7.16.x, 7.17.x, 7.18.x    | OpenJDK 11+               | 7.13.0+, 7.14.0+, 7.15.0+, 7.16.2+, 7.17.0+                                   |
-| Optimize 3.10.x | Camunda Platform 7.17.x, 7.18.x, 7.19.x    | OpenJDK 11+               | 7.16.2+, 7.17.0+, 8.5.0+, 8.6.0+                                              |
+| Optimize 3.10.x | Camunda Platform 7.17.x, 7.18.x, 7.19.x    | OpenJDK 17+               | 7.16.2+, 7.17.0+, 8.5.0+, 8.6.0+                                              |
 
 :::note Elasticsearch support
 [Elastic's Elasticsearch](https://www.elastic.co/elasticsearch/) is the only supported version of Elastic compatible with Optimize.


### PR DESCRIPTION
relates to OPT-7160

## Description

Optimize is now using Spring Boot 3 and the docs changes here explain the changes that the customer needs to know about.

Note that we are backporting the change to 3.10 as part of a 3.10.4. Sadly, this is breaking semantic versioning and this creates a bit of confusion with the docs. I have proposed how we can present this information to users, but would be open to any alternative suggestions if there is a better way we can do this (@christinaausley / @akeller)

## When should this change go live?

We are hoping to release 3.10.4 on 23rd August. So releasing the 3.10 docs around then would be ideal. There is a little flexibility if needed. Sorry for creating this PR so late, it was unclear what the changes that needed documenting were until we had completed QA.

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
