### PR TITLE
chore(ootbc): removed incorrect note

### DIFF
--- a/docs/components/connectors/use-connectors/inbound.md
+++ b/docs/components/connectors/use-connectors/inbound.md
@@ -8,11 +8,6 @@ description: Learn how to use inbound Connectors
 
 ### Creating the BPMN start event
 
-:::note
-Inbound Connectors are currently supported only in [Camunda Platform 8 Self-Managed](/self-managed/about-self-managed.md).
-To use an Inbound Connector, [install](/components/modeler/desktop-modeler/element-templates/configuring-templates.md) a related element template (for example, [generic webhook](https://github.com/camunda/connectors-bundle/tree/main/connectors/webhook-connector/element-templates) or [GitHub webhook](https://github.com/camunda/connectors-bundle/tree/main/connectors/github/element-templates)) first.
-:::
-
 1. Start building your BPMN diagram with a **Start Event** building block.
 2. Change its template to an Inbound Webhook of your choice (e.g., generic webhook or GitHub).
 3. Fill in all required properties.

--- a/versioned_docs/version-8.1/components/connectors/use-connectors/inbound.md
+++ b/versioned_docs/version-8.1/components/connectors/use-connectors/inbound.md
@@ -8,11 +8,6 @@ description: Learn how to use inbound Connectors
 
 ### Creating the BPMN start event
 
-:::note
-Inbound Connectors are currently supported only in [Camunda Platform 8 Self-Managed](/self-managed/about-self-managed.md).
-To use an Inbound Connector, [install](/components/modeler/desktop-modeler/element-templates/configuring-templates.md) a related element template (for example, [generic webhook](https://github.com/camunda/connectors-bundle/tree/main/connectors/webhook-connector/element-templates) or [GitHub webhook](https://github.com/camunda/connectors-bundle/tree/main/connectors/github/element-templates)) first.
-:::
-
 1. Start building your BPMN diagram with a **Start Event** building block.
 2. Change its template to an Inbound Webhook of your choice (e.g., generic webhook or GitHub).
 3. Fill in all required properties.

--- a/versioned_docs/version-8.2/components/connectors/use-connectors/inbound.md
+++ b/versioned_docs/version-8.2/components/connectors/use-connectors/inbound.md
@@ -8,11 +8,6 @@ description: Learn how to use inbound Connectors
 
 ### Creating the BPMN start event
 
-:::note
-Inbound Connectors are currently supported only in [Camunda Platform 8 Self-Managed](/self-managed/about-self-managed.md).
-To use an Inbound Connector, [install](/components/modeler/desktop-modeler/element-templates/configuring-templates.md) a related element template (for example, [generic webhook](https://github.com/camunda/connectors-bundle/tree/main/connectors/webhook-connector/element-templates) or [GitHub webhook](https://github.com/camunda/connectors-bundle/tree/main/connectors/github/element-templates)) first.
-:::
-
 1. Start building your BPMN diagram with a **Start Event** building block.
 2. Change its template to an Inbound Webhook of your choice (e.g., generic webhook or GitHub).
 3. Fill in all required properties.


### PR DESCRIPTION
## Description

chore(ootbc): removed incorrect note

## When should this change go live?

Anytime

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
