### PR TITLE
feat: update automated archival steps (for Optimize & changes to main)

### DIFF
--- a/hacks/isolateVersion/2-reduceVersionManifest.sh
+++ b/hacks/isolateVersion/2-reduceVersionManifest.sh
@@ -1,8 +1,13 @@
-notify "Removing other versions from the manifest..."
+notify "Removing other versions from the manifests..."
 
-# exclude all other versions from version file
+# exclude all other versions from main version file
 echo "[\"$ARCHIVED_VERSION\"]" > versions.json
 
 git add versions.json
 git commit -m "archiving($ARCHIVED_VERSION): exclude all other versions from the main version file"
 
+# exclude all other versions from optimize version file
+echo "[\"$ARCHIVED_OPTIMIZE_VERSION\"]" > optimize_versions.json
+
+git add optimize_versions.json
+git commit -m "archiving($ARCHIVED_VERSION): exclude all other versions from the optimize version file"

--- a/hacks/isolateVersion/2-reduceVersionManifest.sh
+++ b/hacks/isolateVersion/2-reduceVersionManifest.sh
@@ -4,4 +4,5 @@ notify "Removing other versions from the manifest..."
 echo "[\"$ARCHIVED_VERSION\"]" > versions.json
 
 git add versions.json
-git commit -m "archiving: exclude all other versions from the version file"
+git commit -m "archiving($ARCHIVED_VERSION): exclude all other versions from the main version file"
+

--- a/hacks/isolateVersion/3-preventCrawling.sh
+++ b/hacks/isolateVersion/3-preventCrawling.sh
@@ -3,4 +3,4 @@ notify "Preventing unsupported site from being crawled..."
 echo -e 'User-agent: *\nDisallow: /' > static/robots.txt
 
 git add static/robots.txt
-git commit -m "archiving: prevent unsupported site from being crawled"
+git commit -m "archiving($ARCHIVED_VERSION): prevent unsupported site from being crawled"

--- a/hacks/isolateVersion/4-fixDockerfile.sh
+++ b/hacks/isolateVersion/4-fixDockerfile.sh
@@ -4,4 +4,4 @@ sed -i '' -e "s/\(COPY \/build \/usr\/local\/apache2\/htdocs\/\)/\1$ARCHIVED_VER
 sed -i '' -e "s/\(\/usr\/local\/apache2\/htdocs\/\)\(.htaccess\)/\1$ARCHIVED_VERSION\/\2/" Dockerfile
 
 git add Dockerfile
-git commit -m "archiving: fix Dockerfile for local debugging"
+git commit -m "archiving($ARCHIVED_VERSION): fix Dockerfile for local debugging"

--- a/hacks/isolateVersion/5-updateThemeComponents.sh
+++ b/hacks/isolateVersion/5-updateThemeComponents.sh
@@ -5,4 +5,4 @@ mkdir -p src/theme/DocVersionBanner
 cp hacks/isolateVersion/assets/theme/DocVersionBanner/index.js src/theme/DocVersionBanner/index.js
 
 git add src/theme
-git commit -m "archiving: update theme components"
+git commit -m "archiving($ARCHIVED_VERSION): update theme components"

--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -1,12 +1,9 @@
 notify "Updating CI workflows..."
 
-# 1. linkcheck: delete the file.
-rm .github/workflows/linkcheck.yaml
-
-# 2. build-docs: remove everything after the line `NODE_OPTIONS: --max_old_space_size=4096`.
+# 1. build-docs: remove everything after the line `NODE_OPTIONS: --max_old_space_size=4096`.
 sed -i '' '/NODE_OPTIONS: --max_old_space_size=4096/q' .github/workflows/build-docs.yaml
 
-# 3. publish-prod: 
+# 2. publish-prod: 
 
 #   a. remove every line after `tags:` until the first blank line.
 sed -i '' '/tags:/,/^$/ { /tags:/! { /^$/!d; }; }' .github/workflows/publish-prod.yaml
@@ -19,7 +16,7 @@ sed -i '' "/tags:/a\\
 #   c. replace the main docs remote_path with this isolated version's remote_path.
 sed -i '' "s/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
 
-# 4. publish-stage:
+# 3. publish-stage:
 sed -i '' '/Disable Indexing/{N; d;}' .github/workflows/publish-stage.yaml
 
 #   a. replace `branches: - main` with `branches: - unsupported/{version}`

--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -36,4 +36,4 @@ sed -i '' "s/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH }}/remote_path: \$
 
 
 git add .github/workflows
-git commit -m "archiving: update CI workflows"
+git commit -m "archiving($ARCHIVED_VERSION): update CI workflows"

--- a/hacks/isolateVersion/7-updateDocusaurusConfig.sh
+++ b/hacks/isolateVersion/7-updateDocusaurusConfig.sh
@@ -1,8 +1,5 @@
 notify "Updating docusaurus.config.js..."
 
-# Remove unused versionedLinks dependency
-sed -i '' '/const versionedLinks/d' docusaurus.config.js
-
 # Update `url` to include `unsupported`
 sed -i '' "s/docs.camunda.io/unsupported.docs.camunda.io/" docusaurus.config.js
 
@@ -11,14 +8,6 @@ sed -i '' "s/baseUrl: \"\\/\"/baseUrl: \"\/$ARCHIVED_VERSION\/\"/" docusaurus.co
 
 # Update footer social icons based on the new baseUrl
 sed -i '' "s/src= \"\/img\//src=\"\/$ARCHIVED_VERSION\/img\//g" docusaurus.config.js
-
-# Remove optimize docs plugin.
-#   1. Find the block that starts with the plugin declaration, and the closing braces afterward, and delete it.
-sed -i '' '/^      "@docusaurus\/plugin-content-docs"/,/^      },/d' docusaurus.config.js
-#   2. Format the config file, to collapse the empty brackets left behind (e.g. `  [\n  ]` -> `  []`)
-npx prettier --write docusaurus.config.js
-#   3. Remove the empty array
-sed -i '' '/^    \[\],/d' docusaurus.config.js
 
 # Update announcment bar to show a version warning.
 #   Find the announcementBar block and replace it with a new one.
@@ -45,6 +34,7 @@ sed -i '' "/^        docs: {/,/^        },/c\\
         docs: {\\
           lastVersion: \"$ARCHIVED_VERSION\",\\
           includeCurrentVersion: false,\\
+          beforeDefaultRemarkPlugins: [versionedLinks],\\
           versions: {\\
             \"$ARCHIVED_VERSION\": {\\
               label: \"$ARCHIVED_VERSION\",\\

--- a/hacks/isolateVersion/7-updateDocusaurusConfig.sh
+++ b/hacks/isolateVersion/7-updateDocusaurusConfig.sh
@@ -65,4 +65,4 @@ sed -i '' '/^        sitemap: {/,/^        },/c\
 ' docusaurus.config.js
 
 git add docusaurus.config.js
-git commit -m "archiving: update docusaurus config"
+git commit -m "archiving($ARCHIVED_VERSION): update docusaurus config"

--- a/hacks/isolateVersion/7-updateDocusaurusConfig.sh
+++ b/hacks/isolateVersion/7-updateDocusaurusConfig.sh
@@ -20,9 +20,9 @@ npx prettier --write docusaurus.config.js
 #   3. Remove the empty array
 sed -i '' '/^    \[\],/d' docusaurus.config.js
 
-# Add `announcementBar` to `themeConfig`
-#   Find the line containing `themeConfig` and append the new settings to it.
-sed -i '' "/themeConfig/a\\
+# Update announcment bar to show a version warning.
+#   Find the announcementBar block and replace it with a new one.
+sed -i '' "/announcementBar: {/,/    },/c\\
     announcementBar: {\\
       id: \"camunda8\",\\
       content:\\

--- a/hacks/isolateVersion/8-configureOptimizeDocs.sh
+++ b/hacks/isolateVersion/8-configureOptimizeDocs.sh
@@ -1,0 +1,36 @@
+notify "Configuring Optimize docs instance..."
+
+# Edit the optimize docs plugin config to limit to only the isolated optimize version
+sed -i '' "/^        routeBasePath: \"optimize\"/,/^      },/c\\
+        routeBasePath: \"optimize\",\\
+        beforeDefaultRemarkPlugins: [versionedLinks],\\
+        lastVersion: \"$ARCHIVED_OPTIMIZE_VERSION\",\\
+        includeCurrentVersion: false,\\
+        versions: {\\
+          \"$ARCHIVED_OPTIMIZE_VERSION\": {\\
+            label: \"$ARCHIVED_OPTIMIZE_VERSION\",\\
+            path: \"/\",\\
+            noIndex: true,\\
+            banner: \"unmaintained\",\\
+          },\\
+        },\\
+      },\\
+" docusaurus.config.js
+
+# remove other versions from versionedLinks markdown plugin
+#   replace the existing versionMappings array with an array that 
+#   includes only the archived versions.
+sed -i '' "/^const versionMappings = \[$/,/\];/c\\
+const versionMappings = [\\
+  { docsVersion: \"$ARCHIVED_VERSION\", optimizeVersion: \"$ARCHIVED_OPTIMIZE_VERSION\" },\\
+];\\
+" src/mdx/expandVersionedUrl.js
+
+# remove hard-coded versions from main docs sidebar configuration
+sed -i '' "s/optimize\/$ARCHIVED_OPTIMIZE_VERSION\//optimize\//g" versioned_sidebars/version-$ARCHIVED_VERSION-sidebars.json
+
+# remove hard-coded versions from optimize docs sidebar configuration
+sed -i '' "s/docs\/$ARCHIVED_VERSION\//docs\//g" optimize_versioned_sidebars/version-$ARCHIVED_OPTIMIZE_VERSION-sidebars.json
+
+git add docusaurus.config.js src/mdx versioned_sidebars optimize_versioned_sidebars
+git commit -m "archiving($ARCHIVED_VERSION): configure Optimize docs instance"

--- a/hacks/isolateVersion/allSteps.sh
+++ b/hacks/isolateVersion/allSteps.sh
@@ -58,8 +58,12 @@ if [[ "$script_index" == 7 || -z "$script_index" ]]; then
   source $script_directory/7-updateDocusaurusConfig.sh
 fi
 
+if [[ "$script_index" == 8 || -z "$script_index" ]]; then
+  source $script_directory/8-configureOptimizeDocs.sh
+fi
+
 notify "Automated steps are complete! For ease of review, consider PR'ing the deletion commits separate from the rest of the changes."
 notify "Manual steps that remain: 
-8. Fix htaccess rules
-9. Fix links
+9. Fix htaccess rules
+10. Fix links
 "


### PR DESCRIPTION
## Description

This PR makes adjustments to the automated steps for version archival, including: 

* Specifying the archived version in all commit messages (because I like it that way).
* Removing the deletion of link-check.yaml, because that file no longer exists in `main`.
* _Updating_ the announcement bar configuration, instead of _adding_ it, because the announcement bar was added back to `main` recently.
* Accounting for the Optimize docs instance.

I _think_ this is the last set of changes I am making to the automation process for now.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
