### PR TITLE
Stadtler best practices 82 hints

### DIFF
--- a/docs/components/best-practices/modeling/building-flexibility-into-bpmn-models.md
+++ b/docs/components/best-practices/modeling/building-flexibility-into-bpmn-models.md
@@ -53,10 +53,6 @@ Sometimes we need to build in flexible activities which are carried out at any p
 
 ### Escalation events
 
-:::caution Camunda Platform 7 Only
-Escalation events are [not yet supported in Camunda Platform 8](/components/modeler/bpmn/bpmn-coverage.md).
-:::
-
 Sometimes we need highly flexible means to cancel scopes or trigger additional activities from within a scope. The BPMN escalation events can be particularly useful to implement such requirements.
 
 <div bpmn="best-practices/building-flexibility-into-bpmn-models-assets/escalation.bpmn" callouts="escalation,boundary,activity,followup" />

--- a/docs/components/best-practices/modeling/creating-readable-process-models.md
+++ b/docs/components/best-practices/modeling/creating-readable-process-models.md
@@ -43,10 +43,6 @@ Try to model symmetrically. Identify related splitting and joining gateways and 
 
 <div bpmn="best-practices/creating-readable-process-models-assets/modeling-symmetrically.bpmn" callouts="inclusive_gateway_splitting,inclusive_gateway_joining,exclusive_gateway_splitting,exclusive_gateway_joining" />
 
-:::caution Camunda Platform 7 Only
-Inclusive Gateways (OR) are [not yet supported in Camunda Platform 8](/components/modeler/bpmn/bpmn-coverage.md)
-:::
-
 <span className="callout">1</span>
 
 The inclusive gateway splits the process flow into two paths which are ...
@@ -95,10 +91,6 @@ _Avoid very long (multi page) sequence flows_, especially when flowing against t
 
 <div bpmn="best-practices/creating-readable-process-models-assets/avoiding-multi-page-sequence-flows.bpmn" callouts="throwing-linkevent-recourse-not-possible,catching-linkevent-recourse-not-possible" />
 
-:::caution Camunda Platform 7 Only
-Link events are [not yet supported in Camunda Platform 8](/components/modeler/bpmn/bpmn-coverage.md)
-:::
-
 <span className="callout">1</span>
 
 You see a throwing link event here, which...
@@ -118,10 +110,6 @@ Make your models easier to understand by modeling _explicitly_, which most often
 Model splitting the process flow by always using _gateway symbols_ like <img src="/img/bpmn-elements/inclusive-gateway.svg" className="inline-image" /> instead of conditional flows <img src="/img/bpmn-elements/conditional-flow.svg" className="inline-image" />.
 
 <div bpmn="best-practices/creating-readable-process-models-assets/explicit-gateways-instead-of-conditional-flows.bpmn" callouts="inclusive_gateway" />
-
-:::caution Camunda Platform 7 Only
-Inclusive Gateways (OR) and Conditional sequence flows are [not yet supported in Camunda Platform 8](/components/modeler/bpmn/bpmn-coverage.md)
-:::
 
 <span className="callout">1</span>
 

--- a/versioned_docs/version-8.2/components/best-practices/modeling/building-flexibility-into-bpmn-models.md
+++ b/versioned_docs/version-8.2/components/best-practices/modeling/building-flexibility-into-bpmn-models.md
@@ -53,10 +53,6 @@ Sometimes we need to build in flexible activities which are carried out at any p
 
 ### Escalation events
 
-:::caution Camunda Platform 7 Only
-Escalation events are [not yet supported in Camunda Platform 8](/components/modeler/bpmn/bpmn-coverage.md).
-:::
-
 Sometimes we need highly flexible means to cancel scopes or trigger additional activities from within a scope. The BPMN escalation events can be particularly useful to implement such requirements.
 
 <div bpmn="best-practices/building-flexibility-into-bpmn-models-assets/escalation.bpmn" callouts="escalation,boundary,activity,followup" />

--- a/versioned_docs/version-8.2/components/best-practices/modeling/creating-readable-process-models.md
+++ b/versioned_docs/version-8.2/components/best-practices/modeling/creating-readable-process-models.md
@@ -43,10 +43,6 @@ Try to model symmetrically. Identify related splitting and joining gateways and 
 
 <div bpmn="best-practices/creating-readable-process-models-assets/modeling-symmetrically.bpmn" callouts="inclusive_gateway_splitting,inclusive_gateway_joining,exclusive_gateway_splitting,exclusive_gateway_joining" />
 
-:::caution Camunda Platform 7 Only
-Inclusive Gateways (OR) are [not yet supported in Camunda Platform 8](/components/modeler/bpmn/bpmn-coverage.md)
-:::
-
 <span className="callout">1</span>
 
 The inclusive gateway splits the process flow into two paths which are ...
@@ -95,10 +91,6 @@ _Avoid very long (multi page) sequence flows_, especially when flowing against t
 
 <div bpmn="best-practices/creating-readable-process-models-assets/avoiding-multi-page-sequence-flows.bpmn" callouts="throwing-linkevent-recourse-not-possible,catching-linkevent-recourse-not-possible" />
 
-:::caution Camunda Platform 7 Only
-Link events are [not yet supported in Camunda Platform 8](/components/modeler/bpmn/bpmn-coverage.md)
-:::
-
 <span className="callout">1</span>
 
 You see a throwing link event here, which...
@@ -118,10 +110,6 @@ Make your models easier to understand by modeling _explicitly_, which most often
 Model splitting the process flow by always using _gateway symbols_ like <img src="/img/bpmn-elements/inclusive-gateway.svg" className="inline-image" /> instead of conditional flows <img src="/img/bpmn-elements/conditional-flow.svg" className="inline-image" />.
 
 <div bpmn="best-practices/creating-readable-process-models-assets/explicit-gateways-instead-of-conditional-flows.bpmn" callouts="inclusive_gateway" />
-
-:::caution Camunda Platform 7 Only
-Inclusive Gateways (OR) and Conditional sequence flows are [not yet supported in Camunda Platform 8](/components/modeler/bpmn/bpmn-coverage.md)
-:::
 
 <span className="callout">1</span>
 


### PR DESCRIPTION
## Description

This PR removes caution hints on Camunda 8 not supporting Escalation Events, Link Events, OR Gateways, and Conditional Events. This is no longer the case as of version 8.2. The changes were done for doc version 8.2 and /docs.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] There is no urgency with this change.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
