### PR TITLE
[unsupported/0.25] chore: remove Search from 0.25 docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -179,12 +179,6 @@ module.exports = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} Camunda`,
     },
-    algolia: {
-      // These keys are for our new standalone algolia instance!
-      apiKey: "d701d38126d1a43866047d3ab97680d1",
-      appId: "6KYF3VMCXZ",
-      indexName: "camunda",
-    },
   },
   presets: [
     [


### PR DESCRIPTION
Note: targets the unsupported/0.25 branch.

## Description

Part of #2475.

Removes the Search experience from the unsupported/0.25 docs, because none of the results lead to an active page.

## Proof that it does what's on the label

<img width="1193" alt="image" src="https://github.com/camunda/camunda-platform-docs/assets/1627089/1d970bc5-e017-4f0a-912c-3bf6b627adba">

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
