### PR TITLE
feat(archive): remove Search experience when archiving an unsupported version

### DIFF
--- a/hacks/isolateVersion/7-updateDocusaurusConfig.sh
+++ b/hacks/isolateVersion/7-updateDocusaurusConfig.sh
@@ -29,6 +29,9 @@ sed -i '' "s/docsVersionDropdown/docsVersion/" docusaurus.config.js
 #   Find the block starting with dropdownItemsAfter, and ending with the correctly-indented closing bracket, and delete the block.
 sed -i '' '/dropdownItemsAfter/,/          ],/d' docusaurus.config.js
 
+# Remove the Search experience, by removing Algolia configuration
+sed -i '' '/algolia: {/,/    },/d' docusaurus.config.js
+
 # Replace the `docs` block with one that limits to only the isolated version
 sed -i '' "/^        docs: {/,/^        },/c\\
         docs: {\\


### PR DESCRIPTION
## Description

Part of #2475.

Adds a command to the `isolateVersion` scripts to remove the Algolia configuration from an archived site, which removes the Search experience.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
