### PR TITLE
Zeebe gateway exposes HTTP endpoints to query its health status error

### DIFF
--- a/versioned_docs/version-8.2/self-managed/zeebe-deployment/operations/health.md
+++ b/versioned_docs/version-8.2/self-managed/zeebe-deployment/operations/health.md
@@ -64,7 +64,7 @@ When a broker becomes unhealthy, it's recommended to check the logs to see what 
 
 Zeebe gateway exposes three HTTP endpoints to query its health status:
 
-- Health status - `http://{zeebe-gateway}:9600/health`
+- Health status - `http://{zeebe-gateway}:9600/actuator/health`
 - Startup probe - `http://{zeebe-gateway}:9600/actuator/health/startup`
 - Liveness probe - `http://{zeebe-gateway}:9600/actuator/health/liveness`
 


### PR DESCRIPTION
1. Health status - http://{zeebe-gateway}:9600/health is error
2. Right: http://{zeebe-gateway}:9600/actuator/health
3. Because the gateway has a base path, Health status cannot start with /health. All three endpoints should start the same way
<img width="1290" alt="image" src="https://github.com/camunda/camunda-platform-docs/assets/62740686/6d02e8fd-24fb-42ac-86e4-be8bffa9cb6e">


## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
