### PR TITLE
[WIP] feat: properly identify canonicals for non-latest docs

### DIFF
--- a/optimize/components/what-is-optimize.md
+++ b/optimize/components/what-is-optimize.md
@@ -2,6 +2,8 @@
 id: what-is-optimize
 title: What is Optimize?
 description: "Leverage process data and analyze areas for improvement."
+canonicalUrl: "/optimize/next/components/what-is-optimize"
+canonicalId: "components/what-is-optimize"
 ---
 
 :::note

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@playwright/test": "^1.32.2",
         "@swc/core": "^1.3.49",
+        "@types/jest": "^29.5.4",
         "husky": "^8.0.3",
         "jest": "^29.6.4",
         "lint-staged": "^14.0.1",
@@ -4900,6 +4901,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.4",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.4.tgz",
+      "integrity": "sha512-PhglGmhWeD46FYOVLt3X7TiWjzwuVGW9wG/4qocPevXMjCmrIc5b6db9WjeGE4QYVpUAWMDv3v0IiBwObY289A==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -29421,6 +29432,16 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "29.5.4",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.4.tgz",
+      "integrity": "sha512-PhglGmhWeD46FYOVLt3X7TiWjzwuVGW9wG/4qocPevXMjCmrIc5b6db9WjeGE4QYVpUAWMDv3v0IiBwObY289A==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@playwright/test": "^1.32.2",
     "@swc/core": "^1.3.49",
+    "@types/jest": "^29.5.4",
     "husky": "^8.0.3",
     "jest": "^29.6.4",
     "lint-staged": "^14.0.1",

--- a/src/theme/DocItem/Metadata/determineCanonical.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.js
@@ -17,6 +17,13 @@
  *  * @param {Doc} doc
  */
 function determineCanonical(doc) {
+  // const {
+  //   metadata: {
+  //     unversionedId,
+  //     frontMatter: { canonicalUrl, canonicalId },
+  //   },
+  // } = doc;
+
   if (doc.frontMatter.canonicalUrl) {
     return doc.frontMatter.canonicalUrl;
   }

--- a/src/theme/DocItem/Metadata/determineCanonical.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.js
@@ -1,0 +1,27 @@
+// @ts-check
+// Note: these type definitions are only checked within an editor. We aren't set up
+//   for type-checking in the build (yet!) but having these types defined helped me write this code.
+
+/**
+ * @typedef {object} FrontMatter
+ * @property {string?} canonicalUrl
+ *
+ * @typedef {object} Doc
+ * @property {FrontMatter} frontMatter
+ */
+
+// sjh - this is how to import the original type, if you need it later
+// *  * @param {import("@docusaurus/theme-common/lib/internal").DocContextValue} doc
+
+/**
+ *  * @param {Doc} doc
+ */
+function determineCanonical(doc) {
+  if (doc.frontMatter.canonicalUrl) {
+    return doc.frontMatter.canonicalUrl;
+  }
+
+  return "x";
+}
+
+module.exports = determineCanonical;

--- a/src/theme/DocItem/Metadata/determineCanonical.spec.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.spec.js
@@ -20,5 +20,47 @@ describe("determineCanonical", () => {
 
       expect(result).toEqual("/docs/welcome/");
     });
+
+    describe("when that URL exists in a newer version", () => {
+      // it("returns the value of the canonicalUrl");
+    });
+
+    describe("when that URL does not exist in a newer version", () => {
+      // it("throws an exception");
+    });
+  });
+
+  describe("when the current doc has a canonicalId in its frontmatter", () => {
+    describe("when the current version has a doc with that ID", () => {
+      // it("returns the URL of the matching current version doc");
+    });
+
+    describe("when the current version does not have a doc with that ID", () => {
+      // it("throws an exception");
+    });
+  });
+
+  describe("when the current doc has no canonical frontmatter", () => {
+    describe("when there are newer docs with with the same id", () => {
+      describe("when one version newer has the same id", () => {
+        // it("returns the versioned URL of that one version newer");
+      });
+
+      describe("when all newer versions have the same id", () => {
+        // it("returns the current version's URL");
+      });
+
+      // maybe something about gaps between matching IDs? e.g. in v1, 2, not 3, not 4, back in 5
+    });
+
+    describe("when there are no newer docs with the same id", () => {
+      describe("when the current doc is the latest version", () => {
+        // it("returns the URL for the current doc");
+      });
+
+      describe("when the current doc is a non-latest version", () => {
+        // it("returns the URL with the version removed");
+      });
+    });
   });
 });

--- a/src/theme/DocItem/Metadata/determineCanonical.spec.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.spec.js
@@ -1,0 +1,24 @@
+// @ts-check
+
+/**
+ * @typedef {import("./determineCanonical").Doc} Doc
+ */
+
+const determineCanonical = require("./determineCanonical");
+
+describe("determineCanonical", () => {
+  describe("when the current doc has a canonicalUrl in its frontmatter", () => {
+    it("returns the value of the canonicalUrl", () => {
+      /** @type Doc */
+      const doc = {
+        frontMatter: {
+          canonicalUrl: "/docs/welcome/",
+        },
+      };
+
+      const result = determineCanonical(doc);
+
+      expect(result).toEqual("/docs/welcome/");
+    });
+  });
+});

--- a/src/theme/DocItem/Metadata/determineCanonical.spec.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.spec.js
@@ -7,7 +7,8 @@
 const determineCanonical = require("./determineCanonical");
 
 describe("determineCanonical", () => {
-  describe("when the current doc has a canonicalUrl in its frontmatter", () => {
+  describe("a simple test to prove connectivity", () => {
+    // this test will be deleted in favor of the more specific ones below!
     it("returns the value of the canonicalUrl", () => {
       /** @type Doc */
       const doc = {
@@ -20,23 +21,32 @@ describe("determineCanonical", () => {
 
       expect(result).toEqual("/docs/welcome/");
     });
+  });
 
+  describe("when the current doc has a canonicalUrl in its frontmatter", () => {
     describe("when that URL exists in a newer version", () => {
       // it("returns the value of the canonicalUrl");
+      //   we know it's a valid URL so it's a safe canonical
     });
 
     describe("when that URL does not exist in a newer version", () => {
       // it("throws an exception");
+      //   because it would be a canonical pointing at a 404.
+      //   it probably means you moved a doc, and you should go back
+      //   and point the old ones at the new location.
     });
   });
 
   describe("when the current doc has a canonicalId in its frontmatter", () => {
-    describe("when the current version has a doc with that ID", () => {
-      // it("returns the URL of the matching current version doc");
+    describe("when the latest version has a doc with that ID", () => {
+      // it("returns the URL of the matching latest version doc");
+      //   which is the one without a version number in it
     });
 
-    describe("when the current version does not have a doc with that ID", () => {
+    describe("when the latest version does not have a doc with that ID", () => {
       // it("throws an exception");
+      //   it probably means you moved a doc, and you should go back
+      //   and point the old ones at the new location
     });
   });
 
@@ -44,13 +54,18 @@ describe("determineCanonical", () => {
     describe("when there are newer docs with with the same id", () => {
       describe("when one version newer has the same id", () => {
         // it("returns the versioned URL of that one version newer");
+        //   because it's better for us to group as many canonicals as we can
+        //   instead of pointing them at dead URLs
       });
 
       describe("when all newer versions have the same id", () => {
-        // it("returns the current version's URL");
+        // it("returns the latest version's URL");
+        //   which is the one without a version number in it
       });
 
       // maybe something about gaps between matching IDs? e.g. in v1, 2, not 3, not 4, back in 5
+      //   in that case I'd want to send it to the newest version with the same id
+      //   but that logic is likely covered by the previous test
     });
 
     describe("when there are no newer docs with the same id", () => {
@@ -60,6 +75,9 @@ describe("determineCanonical", () => {
 
       describe("when the current doc is a non-latest version", () => {
         // it("returns the URL with the version removed");
+        //   because we have any way to link it to a known document.
+        //   and we're going to hope that redirects send it to the right place,
+        //    and that google is okay with that.
       });
     });
   });

--- a/src/theme/DocItem/Metadata/index.js
+++ b/src/theme/DocItem/Metadata/index.js
@@ -1,0 +1,19 @@
+import React from "react";
+import Metadata from "@theme-original/DocItem/Metadata";
+import { useDoc, useDocsVersion } from "@docusaurus/theme-common/internal";
+
+export default function MetadataWrapper(props) {
+  const doc = useDoc();
+  const {
+    metadata: { unversionedId },
+  } = doc;
+
+  const docs = useDocsVersion();
+  console.log("sjhsjhsjh", unversionedId, docs.docs[unversionedId]);
+
+  return (
+    <>
+      <Metadata {...props} />
+    </>
+  );
+}

--- a/src/theme/DocItem/Metadata/index.js
+++ b/src/theme/DocItem/Metadata/index.js
@@ -1,19 +1,62 @@
+// Why is this swizzled?
+//   To override the `href` of `link rel=canonical`, so that we are properly
+//   canonicalizing our content for search engines.
+// Swizzled from version 2.4.1.
+
 import React from "react";
 import Metadata from "@theme-original/DocItem/Metadata";
-import { useDoc, useDocsVersion } from "@docusaurus/theme-common/internal";
+import {
+  useDoc,
+  useDocsVersion,
+  useDocsVersionCandidates,
+} from "@docusaurus/theme-common/internal";
+import Head from "@docusaurus/Head";
+import { useAllDocsData } from "@docusaurus/plugin-content-docs/client";
+import determineCanonical from "./determineCanonical";
 
 export default function MetadataWrapper(props) {
+  // Gather some context....
+
+  // 1. Doc
+  //    Context about the current document,
+  //    including metadata/frontMatter/any specified canonical properties on a page
   const doc = useDoc();
-  const {
-    metadata: { unversionedId },
-  } = doc;
 
-  const docs = useDocsVersion();
-  console.log("sjhsjhsjh", unversionedId, docs.docs[unversionedId]);
+  // 2. DocsVersion
+  //    Context about the currently browsed version,
+  //    including the pluginId which is useful for finding all versions
+  //    in this plugin instance
+  const docsVersion = useDocsVersion();
 
+  // 3. AllDocs
+  //    Context about all defined docs versions,
+  //    across both plugin instances,
+  //    including every doc in the system, and its ID, and its path.
+  const allDocsData = useAllDocsData();
+
+  // 4. DocsVersionCandidates
+  //    this gives me the currently browsed version + the latest version
+  //    but I think I probably get more of what I need from allDocs
+  const docsVersionCandidates = useDocsVersionCandidates();
+
+  console.log("sjh", {
+    doc,
+    allDocsForPlugin: allDocsData[docsVersion.pluginId],
+    docsVersion,
+    docsVersionCandidates,
+  });
+
+  // From the context, identify the proper canonical
+  const canonicalPath = determineCanonical(doc, docsVersion, allDocsData);
+  const domain = "https://get-this-from-somewhere-dynamically";
+
+  // Slap the proper canonical into the Head
   return (
     <>
       <Metadata {...props} />
+      <Head>
+        <link rel="canonical" href={domain + canonicalPath} />
+      </Head>
     </>
   );
 }


### PR DESCRIPTION
WIP/Draft -- I'm pushing it up early for feedback on the logic and mechanics of assigning/determining canonicals 

## Description

Part of #1143.

Adds support for proper canonicals on non-latest docs.

## Background

As discovered in our C7 docs, we should specify canonicals for all non-latest docs, and we should always point them at their latest version counterpart. 

Docusaurus applies self-referential canonicals to all pages, which [Google has identified as having no effect on SEO](https://www.youtube.com/watch?v=TepFVYrBVg0&t=968s) when the canonical URL matches the browsed URL exactly. 

Docusaurus _does_ provide the ability to override the canonical via the `<Head>` component, which is utilized in this PR. 

Docusaurus also provides the ability to set custom frontmatter in any markdown document, but it does not currently have any effect on the canonical emitted by a page. This ability to set custom frontmatter properties is also utilized in this PR.

## Proposed architecture for specifying individual canonicals

As seen in this PR: 

1. Individual markdown files can specify canonical information in their frontmatter.
2. A swizzled `Metadata` component determines the proper canonical for each page. 
   1. If canonical information is specified in the frontmatter for a page, that is considered.
   2. If no canonical information is specified, a document in the latest version is potentially identified as canonical.

## Proposed logic for determining canonicals

There is a spec file in this PR that lays out the rules I propose for specifying/identifying canonical URLs. Summarizing here, but see extra contents in the file diff: 

1. when the current doc has a `canonicalUrl` property in its frontmatter
   1. when that URL exists in a newer version
      * it returns the value of the `canonicalUrl` property
   2. when that URL does not exist in a newer version
      * it throws an exception
         because it would be a canonical pointing at a 404. it probably means you moved a doc, and you should go back and point the old ones at the new location.
  2. when the current doc has a `canonicalId` property in its frontmatter
     1. when the latest version has a doc with that ID
        * it returns the URL of the matching latest version doc, which is the one without a version number in it
     2. when the latest version does not have a doc with that ID
        * it throws an exception
           it probably means you moved a doc, and you should go back and point the old ones at the new location
   3. when the current doc has no canonical frontmatter
      1. when there are newer docs with with the same id
         1. when one version newer has the same id
            * it returns the versioned URL of that one version newer
               because it's better for us to group as many canonicals as we can
               (instead of pointing them at dead URLs)
         1. when all newer versions have the same id
            * it returns the latest version's URL
               which is the one without a version number in it
      2. when there are no newer docs with the same id
         1. when the current doc is the latest version
            * it returns the URL for the current doc
         2. when the current doc is a non-latest version 
            * it returns the URL with the version removed
               because we have any way to link it to a known document.
               and we're going to hope that redirects send it to the right place, and that google is okay with that.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
