### PR TITLE
docs(zeebe): refer to `forcePathStyleAccess` in upgrade guide

### DIFF
--- a/docs/self-managed/operational-guides/update-guide/810-to-820.md
+++ b/docs/self-managed/operational-guides/update-guide/810-to-820.md
@@ -35,7 +35,7 @@ The [gRPC API](/apis-tools/grpc.md) is not affected by this change.
 Zeebe uses an updated version of the AWS S3 client which automatically chooses between [path-style and virtual-hosted-style access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html).
 If your S3 backup store does not support virtual-hosted-style access and the client fails to detect this, Zeebe will not connect to S3 and backups are not usable.
 
-Self-managed deployments that use MinIO as an S3 compatible backup target might need to force path-style access.
+Self-managed deployments that use [MinIO](https://min.io/) as an S3 compatible backup target might need to force path-style access.
 You can use a new configuraton setting to always force path-style access: `ZEEBE_BROKER_DATA_BACKUP_S3_FORCEPATHSTYLEACCESS`.
 
 ## Operate

--- a/docs/self-managed/operational-guides/update-guide/810-to-820.md
+++ b/docs/self-managed/operational-guides/update-guide/810-to-820.md
@@ -30,6 +30,14 @@ This only applies to the Actuator endpoints such as the [Management API](/self-m
 
 The [gRPC API](/apis-tools/grpc.md) is not affected by this change.
 
+### AWS S3 Backup store connectivity
+
+Zeebe uses an updated version of the AWS S3 client which automatically chooses between [path-style and virtual-hosted-style access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html).
+If your S3 backup store does not support virtual-hosted-style access and the client fails to detect this, Zeebe will not connect to S3 and backups are not usable.
+
+Self-managed deployments that use MinIO as an S3 compatible backup target might need to force path-style access.
+You can use a new configuraton setting to always force path-style access: `ZEEBE_BROKER_DATA_BACKUP_S3_FORCEPATHSTYLEACCESS`.
+
 ## Operate
 
 - It is recommended to follow a sequential update path when updating to version 8.2. For example, if running on version 8.0, first update to 8.1, then update to 8.2.

--- a/versioned_docs/version-8.2/guides/update-guide/810-to-820.md
+++ b/versioned_docs/version-8.2/guides/update-guide/810-to-820.md
@@ -30,6 +30,14 @@ This only applies to the Actuator endpoints such as the [Management API](../../s
 
 The [GRPC API](../../apis-tools/grpc.md) is not affected by this change.
 
+### AWS S3 Backup store connectivity
+
+Zeebe uses an updated version of the AWS S3 client which automatically chooses between [path-style and virtual-hosted-style access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html).
+If your S3 backup store does not support virtual-hosted-style access and the client fails to detect this, Zeebe will not connect to S3 and backups are not usable.
+
+Self-managed deployments that use MinIO as an S3 compatible backup target might need to force path-style access.
+You can use a new configuraton setting to always force path-style access: `ZEEBE_BROKER_DATA_BACKUP_S3_FORCEPATHSTYLEACCESS`.
+
 ## Operate
 
 - It is recommended to follow a sequential update path when updating to version 8.2. For example, if running on version 8.0, first update to 8.1, then update to 8.2.

--- a/versioned_docs/version-8.2/guides/update-guide/810-to-820.md
+++ b/versioned_docs/version-8.2/guides/update-guide/810-to-820.md
@@ -35,7 +35,7 @@ The [GRPC API](../../apis-tools/grpc.md) is not affected by this change.
 Zeebe uses an updated version of the AWS S3 client which automatically chooses between [path-style and virtual-hosted-style access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html).
 If your S3 backup store does not support virtual-hosted-style access and the client fails to detect this, Zeebe will not connect to S3 and backups are not usable.
 
-Self-managed deployments that use MinIO as an S3 compatible backup target might need to force path-style access.
+Self-managed deployments that use [MinIO](https://min.io/) as an S3 compatible backup target might need to force path-style access.
 You can use a new configuraton setting to always force path-style access: `ZEEBE_BROKER_DATA_BACKUP_S3_FORCEPATHSTYLEACCESS`.
 
 ## Operate


### PR DESCRIPTION
## Description
This configuration flag was added to help users that rely on path-style access. We've had users who were confused about this so hopefully a mention in our update guide will be helpful.

Closes #1431

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
