### PR TITLE
RBA - Add one-liner for Operate changes

### DIFF
--- a/docs/components/concepts/resource-authorizations.md
+++ b/docs/components/concepts/resource-authorizations.md
@@ -26,6 +26,10 @@ The Camunda ecosystem contains several resource types and many actions that can 
   - Read
   - Delete
 
+:::note
+Operate uses a caching mechanism where resource authorization changes can take 30 seconds to take effect.
+:::
+
 **Tasklist**
 
 - Process definition:

--- a/docs/self-managed/operate-deployment/operate-authentication.md
+++ b/docs/self-managed/operate-deployment/operate-authentication.md
@@ -191,6 +191,10 @@ curl -X POST 'http://localhost:8080/v1/process-definitions/search' -H 'Content-T
 
 ### Resource-based permissions
 
+:::note
+Operate uses a caching mechanism where resource authorization changes can take 30 seconds to take effect.
+:::
+
 By default, when using Operate with Identity, one can assign a user "read" and/or "write" permissions for Operate. "Read" allows read-only access to Operate. "Write" permission allows the user to perform all types of operations modifying data (e.g. update the variables, resolve the incidents or cancel instances).
 
 More detailed permissions may be enabled:


### PR DESCRIPTION
Closes https://github.com/camunda-cloud/identity/issues/2118

## Description

Quick fix! Adds an admonition for changes to RBA w/ Operate taking 30 seconds.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
