### PR TITLE
Typo in Service Task

### DIFF
--- a/docs/components/modeler/bpmn/service-tasks/service-tasks.md
+++ b/docs/components/modeler/bpmn/service-tasks/service-tasks.md
@@ -14,7 +14,7 @@ A [job worker](/components/concepts/job-workers.md) can subscribe to the job typ
 
 ## Task definition
 
-A service task must have a `taskDefiniton`. The `taskDefiniton` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
+A service task must have a `taskDefinition`. The `taskDefinition` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
 
 A `taskDefinition` specifies the following properties:
 

--- a/versioned_docs/version-8.0/components/modeler/bpmn/service-tasks/service-tasks.md
+++ b/versioned_docs/version-8.0/components/modeler/bpmn/service-tasks/service-tasks.md
@@ -14,7 +14,7 @@ A [job worker](/components/concepts/job-workers.md) can subscribe to the job typ
 
 ## Task definition
 
-A service task must have a `taskDefiniton`. The `taskDefiniton` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
+A service task must have a `taskDefinition`. The `taskDefinition` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
 
 A `taskDefinition` specifies the following properties:
 

--- a/versioned_docs/version-8.1/components/modeler/bpmn/service-tasks/service-tasks.md
+++ b/versioned_docs/version-8.1/components/modeler/bpmn/service-tasks/service-tasks.md
@@ -14,7 +14,7 @@ A [job worker](/components/concepts/job-workers.md) can subscribe to the job typ
 
 ## Task definition
 
-A service task must have a `taskDefiniton`. The `taskDefiniton` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
+A service task must have a `taskDefinition`. The `taskDefinition` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
 
 A `taskDefinition` specifies the following properties:
 

--- a/versioned_docs/version-8.2/components/modeler/bpmn/service-tasks/service-tasks.md
+++ b/versioned_docs/version-8.2/components/modeler/bpmn/service-tasks/service-tasks.md
@@ -14,7 +14,7 @@ A [job worker](/components/concepts/job-workers.md) can subscribe to the job typ
 
 ## Task definition
 
-A service task must have a `taskDefiniton`. The `taskDefiniton` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
+A service task must have a `taskDefinition`. The `taskDefinition` is used to specify which [job workers](../../../concepts/job-workers.md) handle the service task work.
 
 A `taskDefinition` specifies the following properties:
 


### PR DESCRIPTION
## Description

taskDefiniton -> taskDefinition

This should be backported to all supported versions.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
