### PR TITLE
docs: Update canonical guidance

### DIFF
--- a/howtos/moving-content.md
+++ b/howtos/moving-content.md
@@ -227,9 +227,9 @@ See [the implemented unit tests](/src/theme/DocItem/Metadata/determineCanonical.
 
 3. If there are non-next versions of documents with the same document ID, the system chooses the URL of the newest non-next version of documents with that ID.
 
-4. The system chooses the current page's URL, with the version number/name removed.
+4. The system chooses the current page's URL, as a self-referential canonical.
 
-   This is a last resort. Theoretically, this URL probably does not exist, because the system would have matched it in a previous step. Hopefully there is a redirect rule associated with the URL, though, and hopefully search engines can still link the canonical content correctly.
+   This is a last resort. We have no way of linking this document to one that would more likely be canonical, so we presume it to be unique.
 
 ### Identifying which canonical reference the system chose for a page
 


### PR DESCRIPTION
## Description

Immediately after merging #2577, I re-read the docs that I was about to publicize in Slack, and realized they were out of date. This PR corrects them, based on the last feedback I addressed in #2577.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
