### PR TITLE
Update image in docs-on-docs

### DIFF
--- a/howtos/documentation-workflows.MD
+++ b/howtos/documentation-workflows.MD
@@ -27,9 +27,9 @@ If there is no **Edit this page** button available, that particular documentatio
 3. After making your changes, select the **Preview** tab to ensure your changes are formatted correctly.
 4. Once you’ve made your changes and ensured the formatting is correct, you can then scroll to the bottom of the page. You’ll see a bold heading that says either **Commit** or **Propose changes** as shown in the screenshot below, depending on your GitHub repository permissions level for the project. Enter a title and description for your change that matches the formatting outlined in our [commit message guidelines].
 
-![An open pull request with a green 'Commit changes' button in the right hand corner](./../static/img/camunda-workflow-engine-gradient.png)
+![An open pull request with a green 'Commit changes' button in the left hand corner](./../static/img/CommitChanges.png)
 
-5. After your changes have been proposed, you will want to create a pull request (also known as a PR) following the guidelines outlined in our [contributor guide]. If you’ve never submitted a PR before, check out [About Pull Requests] on GitHub to learn more about the pull request process.
-6. Thank you for your contribution! A member of the project’s team will review and merge your pull request once it has been reviewed and approved. Keep in mind that you may get feedback from maintainers requesting changes, so be sure to check your GitHub notifications on a regular basis.
+1. After your changes have been proposed, you will want to create a pull request (also known as a PR) following the guidelines outlined in our [contributor guide]. If you’ve never submitted a PR before, check out [About Pull Requests] on GitHub to learn more about the pull request process.
+2. Thank you for your contribution! A member of the project’s team will review and merge your pull request once it has been reviewed and approved. Keep in mind that you may get feedback from maintainers requesting changes, so be sure to check your GitHub notifications on a regular basis.
 
 [about pull requests]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests


### PR DESCRIPTION
## Description

Closes #2598 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
