### PR TITLE
feat(connectors): outbound connector retry backoff

### DIFF
--- a/docs/components/connectors/use-connectors/outbound.md
+++ b/docs/components/connectors/use-connectors/outbound.md
@@ -22,10 +22,31 @@ Each Connector defines its own set of properties you can fill in. Find the detai
 
 ### Retries
 
-By default, Connector execution is repeated `3` times if execution fails. To change the default retries value, edit the BPMN XML file and set the `retries` attribute at the `zeebe:taskDefinition`. For example:
+By default, Connector execution is repeated `3` times if execution fails. The retries are executed sequentially without delays.
+
+To change the default retries value, edit the BPMN XML file and set the `retries` attribute at the `zeebe:taskDefinition`. For example:
 
 ```xml
 ...
 <zeebe:taskDefinition type="io.camunda:http-json:1" retries="12" />
 ...
 ```
+
+The Connector runtime also supports custom intervals between retries (**retry backoff**). To configure a custom retry interval, you need to add a special property to the Connector element template. The property must bind to the `retryBackoff` task header, and the value must be a valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration.
+
+```json
+{
+  "value": "PT30S",
+  "binding": {
+    "key": "retryBackoff",
+    "type": "zeebe:taskHeader"
+  },
+  "type": "Hidden"
+}
+```
+
+In the example above, the retry attempts will be spaced 30 seconds apart, instead of the default behavior of retrying immediately.
+
+If necessary, the **retry backoff** property can be made visible and editable in the properties panel by changing the property `type` to `String`.
+
+`retryBackoff` is a reserved task header key recognized by the Connector runtime. You don't need to handle this input in your Connector implementation, as the runtime handles it automatically for all outbound Connectors.


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Added an example of configuring the custom retry backoff. The feature is already available in the latest 8.3 alpha.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or <ins>they are not for an **already released version**.<ins>
- [x] <ins>I have added changes to the main `/docs` directory (aka `/next/`)</ins>, or they are not for **future versions**.
- [x] <ins>My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer</ins>, or my changes do not require an Engineering review.
- [x] <ins>My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer</ins>, or my changes do not require a technical writer review.
