### PR TITLE
feat(zeebe): message start events clarification

### DIFF
--- a/docs/components/modeler/bpmn/message-events/message-events.md
+++ b/docs/components/modeler/bpmn/message-events/message-events.md
@@ -18,7 +18,7 @@ When the message subscription is created, a message can be correlated to the sta
 
 Messages are **not** correlated if they were published before the process was deployed or if a new version of the process is deployed without a proper start event.
 
-The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. New messages will be queued.
+The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. If the message has a time-to-live (TTL) > 0, it is buffered.
 
 When the active process instance is completed or terminated and a message with the same `correlationKey` and a matching message name is buffered (i.e. TTL > 0), this message is correlated and a new instance of the latest version of the process is created.
 

--- a/docs/components/modeler/bpmn/message-events/message-events.md
+++ b/docs/components/modeler/bpmn/message-events/message-events.md
@@ -18,7 +18,7 @@ When the message subscription is created, a message can be correlated to the sta
 
 Messages are **not** correlated if they were published before the process was deployed or if a new version of the process is deployed without a proper start event.
 
-The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created.
+The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. New messages will be queued.
 
 When the active process instance is completed or terminated and a message with the same `correlationKey` and a matching message name is buffered (i.e. TTL > 0), this message is correlated and a new instance of the latest version of the process is created.
 

--- a/versioned_docs/version-1.3/components/modeler/bpmn/message-events/message-events.md
+++ b/versioned_docs/version-1.3/components/modeler/bpmn/message-events/message-events.md
@@ -18,7 +18,7 @@ When the message subscription is created, a message can be correlated to the sta
 
 Messages are **not** correlated if they were published before the process was deployed or if a new version of the process is deployed without a proper start event.
 
-The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. New messages will be queued.
+The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. If the message has a time-to-live (TTL) > 0, it is buffered.
 
 When the active process instance is completed or terminated and a message with the same `correlationKey` and a matching message name is buffered (i.e. TTL > 0), this message is correlated and a new instance of the latest version of the process is created.
 

--- a/versioned_docs/version-1.3/components/modeler/bpmn/message-events/message-events.md
+++ b/versioned_docs/version-1.3/components/modeler/bpmn/message-events/message-events.md
@@ -18,7 +18,7 @@ When the message subscription is created, a message can be correlated to the sta
 
 Messages are **not** correlated if they were published before the process was deployed or if a new version of the process is deployed without a proper start event.
 
-The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created.
+The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. New messages will be queued.
 
 When the active process instance is completed or terminated and a message with the same `correlationKey` and a matching message name is buffered (i.e. TTL > 0), this message is correlated and a new instance of the latest version of the process is created.
 

--- a/versioned_docs/version-8.0/components/modeler/bpmn/message-events/message-events.md
+++ b/versioned_docs/version-8.0/components/modeler/bpmn/message-events/message-events.md
@@ -18,7 +18,7 @@ When the message subscription is created, a message can be correlated to the sta
 
 Messages are **not** correlated if they were published before the process was deployed or if a new version of the process is deployed without a proper start event.
 
-The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. New messages will be queued.
+The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. If the message has a time-to-live (TTL) > 0, it is buffered.
 
 When the active process instance is completed or terminated and a message with the same `correlationKey` and a matching message name is buffered (i.e. TTL > 0), this message is correlated and a new instance of the latest version of the process is created.
 

--- a/versioned_docs/version-8.0/components/modeler/bpmn/message-events/message-events.md
+++ b/versioned_docs/version-8.0/components/modeler/bpmn/message-events/message-events.md
@@ -18,7 +18,7 @@ When the message subscription is created, a message can be correlated to the sta
 
 Messages are **not** correlated if they were published before the process was deployed or if a new version of the process is deployed without a proper start event.
 
-The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created.
+The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. New messages will be queued.
 
 When the active process instance is completed or terminated and a message with the same `correlationKey` and a matching message name is buffered (i.e. TTL > 0), this message is correlated and a new instance of the latest version of the process is created.
 

--- a/versioned_docs/version-8.1/components/modeler/bpmn/message-events/message-events.md
+++ b/versioned_docs/version-8.1/components/modeler/bpmn/message-events/message-events.md
@@ -18,7 +18,7 @@ When the message subscription is created, a message can be correlated to the sta
 
 Messages are **not** correlated if they were published before the process was deployed or if a new version of the process is deployed without a proper start event.
 
-The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. New messages will be queued.
+The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. If the message has a time-to-live (TTL) > 0, it is buffered.
 
 When the active process instance is completed or terminated and a message with the same `correlationKey` and a matching message name is buffered (i.e. TTL > 0), this message is correlated and a new instance of the latest version of the process is created.
 

--- a/versioned_docs/version-8.1/components/modeler/bpmn/message-events/message-events.md
+++ b/versioned_docs/version-8.1/components/modeler/bpmn/message-events/message-events.md
@@ -18,7 +18,7 @@ When the message subscription is created, a message can be correlated to the sta
 
 Messages are **not** correlated if they were published before the process was deployed or if a new version of the process is deployed without a proper start event.
 
-The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created.
+The `correlationKey` of a published message can be used to control the process instance creation. If an instance of this process is active (independently from its version) and it was triggered by a message with the same `correlationKey`, the message is **not** correlated and no new instance is created. New messages will be queued.
 
 When the active process instance is completed or terminated and a message with the same `correlationKey` and a matching message name is buffered (i.e. TTL > 0), this message is correlated and a new instance of the latest version of the process is created.
 


### PR DESCRIPTION
## Description

feat(zeebe): message start events clarification

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
