### PR TITLE
fix: remove unnecessary complexity from canonical regular expression

### DIFF
--- a/src/theme/DocItem/Metadata/determineCanonical.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.js
@@ -107,7 +107,7 @@ function determineCanonicalFromDoc(currentDoc, currentPlugin) {
     .find((doc) => doc.id === unversionedId);
 
   if (match) {
-    if (match.path.match(/(optimize|docs)((next|[0-9\.]*)\/)/)) {
+    if (/(optimize|docs)((next|[0-9\.]*)\/)/.test(match.path)) {
       // This finds docs whose matches are non-latest versions.
       //  These docs would probably benefit from adding canonical frontmatter.
       console.log(

--- a/src/theme/DocItem/Metadata/determineCanonical.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.js
@@ -107,7 +107,7 @@ function determineCanonicalFromDoc(currentDoc, currentPlugin) {
     .find((doc) => doc.id === unversionedId);
 
   if (match) {
-    if (match.path.match(/(?<=(optimize|docs)\/)((next|[0-9\.]*)\/)(?=.+)/)) {
+    if (match.path.match(/(optimize|docs)((next|[0-9\.]*)\/)/)) {
       // This finds docs whose matches are non-latest versions.
       //  These docs would probably benefit from adding canonical frontmatter.
       console.log(


### PR DESCRIPTION
## Description

Fixes the docs for Safari versions <= 16.3, which [do not yet support lookbehind in regular expressions](https://caniuse.com/js-regexp-lookbehind).

The regular expression used here was overly complex anyway. We were previously doing something with the resulting `matches`. Now, the expression is only used for a test, and we don't use the match. 

Initially raised in [Slack](https://camunda.slack.com/archives/C026U8GBNSW/p1695712165348429) by @remcowesterhoud (cc @christinaausley).

## Proof that the tests still pass (because we don't run them in CI)

<img width="729" alt="image" src="https://github.com/camunda/camunda-platform-docs/assets/1627089/e0f8658b-4330-45ee-becc-aa3eab917c9c">

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
